### PR TITLE
Fix of Union master bug with process selection

### DIFF
--- a/mcstas-comps/contrib/union/Union_master.comp
+++ b/mcstas-comps/contrib/union/Union_master.comp
@@ -1642,6 +1642,7 @@ TRACE
             // CPU Only
             //if (0 == Volumes[current_volume]->p_physics->p_scattering_array[selected_process].scattering_function(k_new,k,&p,Volumes[current_volume]->p_physics->p_scattering_array[selected_process].data_transfer,&Volumes[current_volume]->geometry.focus_data_array.elements[0])) {
             // GPU Version with flexible function
+            process = Volumes[current_volume]->p_physics->p_scattering_array[selected_process];
             if (0 == physics_scattering(process->eProcess, k_new, k, &p, process->data_transfer, &Volumes[current_volume]->geometry.focus_data_array.elements[0], _particle)) {
               /*
               // PowderN and Single_crystal requires the option of absorbing the neutron, which is weird. If there is a scattering probability, there should be a new direction.


### PR DESCRIPTION
Found bug in Union master. Process was not selected based on appropriate selection method, but instead just the last one defined was executed every time. For single crystal this was especially problematic, as the scattering call makes no sense in cases where no allowed reflections were found, and thus returning garbage data.