### PR TITLE
Update NPI_tof_dhkl_detector.comp

### DIFF
--- a/mcstas-comps/contrib/NPI_tof_dhkl_detector.comp
+++ b/mcstas-comps/contrib/NPI_tof_dhkl_detector.comp
@@ -230,10 +230,7 @@ DECLARE
   int n_dhkl;
   // set to 1 for some debugging info
   int dbg;
-  int dbgn;
-
-}
-  
+  int dbgn; 
 %}
 INITIALIZE
   %{


### PR DESCRIPTION
Remove an unmatched extraneous closing brace in the `DECLARE` block.