### PR TITLE
Overhaul of the "nightly builds" to include Windows. Does not yet include "metapackage" / miniforge installer

### DIFF
--- a/.github/workflows/mcstas-autobuild.yml
+++ b/.github/workflows/mcstas-autobuild.yml
@@ -16,16 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#         - { os: ubuntu-20.04,  CC: gcc-10,   CXX: g++-10,     python: '3.8'  }
-#         - { os: ubuntu-22.04,  CC: gcc,      CXX: g++,        python: '3.9'  }
         - { os: ubuntu-latest, CC: gcc,      CXX: g++,        python: '3.11' }
-#         - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.11' }
-#         - { os: ubuntu-latest, CC: gcc-12,   CXX: g++-12,     python: '3.11' }
-#         - { os: macos-11,      CC: clang,    CXX: clang++,    python: "3.10" }
-        - { os: macos-12,      CC: clang,    CXX: clang++,    python: "3.11" }
-#         - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11" }
-#         - { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.11" }
-#         - { os: windows-2019,    CC: gcc,    CXX: g++,        python: "3.11" }
+        - { os: macos-latest,      CC: clang,    CXX: clang++,    python: "3.11" }
 
     name: ${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
@@ -51,7 +43,7 @@ jobs:
       id: setup-build-deps
       run: |
            if [ "$RUNNER_OS" == "Linux" ]; then sudo apt-get -y install equivs ; fi
-
+           if [ "$RUNNER_OS" == "Linux" ]; then sudo apt-get -y install mingw-w64 gfortran-mingw-w64 mingw-w64-x86-64-dev libz-mingw-w64-dev dos2unix nsis; fi
     - name: Check versions
       id: version-checks
       run: |
@@ -70,10 +62,24 @@ jobs:
            set -u
            set -x
            cd McCode
-           export REV=`date +%Y-%m-%d`
+           git fetch --tags origin
+           export REV=`git describe --tags --match="mcstas*" | cut -f2 -d\-`
            if [ "$RUNNER_OS" == "macOS" ]; then ./buildscripts/build_macos_mcstas ${REV}; fi
            if [ "$RUNNER_OS" == "Linux" ]; then ./buildscripts/build_debs_mcstas ${REV} meta; fi
            tar cfz dist-${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}.tgz dist/
+
+    - name: Cross-Build McStas for windows
+      id: mcstas-mingw-build
+      run: |
+           set -e
+           set -u
+           set -x
+           cd McCode
+           git fetch --tags origin
+           export REV=`git describe --tags --match="mcstas*" | cut -f2 -d\-`
+           if [ "$RUNNER_OS" == "Linux" ]; then rm -rf dist; fi
+           if [ "$RUNNER_OS" == "Linux" ]; then ./buildscripts/build_windows_mcstas ${REV}; fi
+           if [ "$RUNNER_OS" == "Linux" ]; then tar cfz dist-Windows.mingw64.python-${{ matrix.python }}.tgz dist/; fi
 
     - name: 'Upload Artifact'
       id: tar-upload
@@ -81,7 +87,7 @@ jobs:
       if: always()
       with:
         name: mcstas-artefact-${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}
-        path: "McCode/dist-${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}.tgz"
+        path: "McCode/dist-*.tgz"
 
     - name: Setup tmate session for manual debugging
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/mcxtrace-autobuild.yml
+++ b/.github/workflows/mcxtrace-autobuild.yml
@@ -16,16 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#         - { os: ubuntu-20.04,  CC: gcc-10,   CXX: g++-10,     python: '3.8'  }
-#         - { os: ubuntu-22.04,  CC: gcc,      CXX: g++,        python: '3.9'  }
          - { os: ubuntu-latest, CC: gcc,      CXX: g++,        python: '3.11' }
-#         - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.11' }
-#         - { os: ubuntu-latest, CC: gcc-12,   CXX: g++-12,     python: '3.11' }
-#         - { os: macos-11,      CC: clang,    CXX: clang++,    python: "3.10" }
-         - { os: macos-12,      CC: clang,    CXX: clang++,    python: "3.11" }
-#         - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11" }
-#         - { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.11" }
-#         - { os: windows-2019,    CC: gcc,    CXX: g++,        python: "3.11" }
+        - { os: macos-latest,      CC: clang,    CXX: clang++,    python: "3.11" }
 
     name: ${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
@@ -51,7 +43,7 @@ jobs:
       id: setup-build-deps
       run: |
            if [ "$RUNNER_OS" == "Linux" ]; then sudo apt-get -y install equivs ; fi
-
+           if [ "$RUNNER_OS" == "Linux" ]; then sudo apt-get -y install mingw-w64 gfortran-mingw-w64 mingw-w64-x86-64-dev libz-mingw-w64-dev dos2unix nsis; fi
     - name: Check versions
       id: version-checks
       run: |
@@ -70,10 +62,24 @@ jobs:
            set -u
            set -x
            cd McCode
-           export REV=`date +%Y-%m-%d`
+           git fetch --tags origin
+           export REV=`git describe --tags --match="mcxtrace*" | cut -f2 -d\-`
            if [ "$RUNNER_OS" == "macOS" ]; then ./buildscripts/build_macos_mcxtrace ${REV}; fi
            if [ "$RUNNER_OS" == "Linux" ]; then ./buildscripts/build_debs_mcxtrace ${REV} meta; fi
            tar cfz dist-${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}.tgz dist/
+
+    - name: Cross-Build McXtrace for windows
+      id: mcxtrace-mingw-build
+      run: |
+           set -e
+           set -u
+           set -x
+           cd McCode
+           git fetch --tags origin
+           export REV=`git describe --tags --match="mcxtrace*" | cut -f2 -d\-`
+           if [ "$RUNNER_OS" == "Linux" ]; then rm -rf dist; fi
+           if [ "$RUNNER_OS" == "Linux" ]; then ./buildscripts/build_windows_mcxtrace ${REV}; fi
+           if [ "$RUNNER_OS" == "Linux" ]; then tar cfz dist-Windows.mingw64.python-${{ matrix.python }}.tgz dist/; fi
 
     - name: 'Upload Artifact'
       id: tar-upload
@@ -81,7 +87,7 @@ jobs:
       if: always()
       with:
         name: mcxtrace-artefacts-${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}
-        path: "McCode/dist-${{ matrix.os }}.${{ matrix.CC }}.python-${{ matrix.python }}.tgz"
+        path: "McCode/dist-*.tgz"
 
     - name: Setup tmate session for manual debugging
       uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
* Enable cross-compile for Windows on Ubuntu for both McStas and McXtrace
* Use latest mcstas/mcxtrace 'version tag' ala conda
* General clean-up of the scripts