### PR TITLE
Fix for "interesting" SPLIT + GROUP issue.

### DIFF
--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1760,11 +1760,7 @@ int cogen_raytrace(struct instr_def *instr)
   // we need this override, since "comp" is not defined in raytrace() - see section-wide define
   cout("  #undef ABSORB0");
   cout("  #undef ABSORB");
-  cout("  #ifndef OPENACC");
-  cout("  #define ABSORB0 do { DEBUG_ABSORB(); MAGNET_OFF; ABSORBED++; return(ABSORBED);} while(0)");
-  cout("  #else");
   cout("  #define ABSORB0 do { DEBUG_ABSORB(); MAGNET_OFF; ABSORBED++;} while(0)");
-  cout("  #endif");
   cout("  #define ABSORB ABSORB0");
 
   /* Debugging (initial state). */
@@ -1920,7 +1916,7 @@ int cogen_raytrace(struct instr_def *instr)
         comp->group->last_comp_index, comp->group->last_comp);
       // final_absorb_when_all_not_scattered
       if (comp->index == comp->group->last_comp_index)
-        coutf("      else ABSORB;     // not SCATTERED at end of GROUP: removes left events", comp->group->last_comp);
+        coutf("      else ABSORBED=1;     // not SCATTERED at end of GROUP: removes left events", comp->group->last_comp);
       else // comp_absorb_sends_to_next
         coutf("      else particle_restore(_particle, &_particle_save); // not SCATTERED in GROUP, restore");
     }
@@ -2228,7 +2224,7 @@ int cogen_rt_funnel(struct instr_def *instr)
         comp->group->last_comp_index, comp->group->last_comp);
       // final_absorb_when_all_not_scattered
       if (comp->index == comp->group->last_comp_index)
-        coutf("      else ABSORB;     // not SCATTERED at end of GROUP: removes left events", comp->group->last_comp);
+        coutf("      else ABSORBED=1;     // not SCATTERED at end of GROUP: removes left events", comp->group->last_comp);
       else // comp_absorb_sends_to_next
         coutf("      else ABSORBED=0; // not SCATTERED within GROUP: always tries next");
     }


### PR DESCRIPTION
Found by Torben R. Nielsen: An instrument with SPLIT and a subsequent GROUP of monitors would "lose intensity" and events. After a long analysis with Erik we found that this was due to use of ABSORB; in the final GROUP member (but in the raytrace function) yet still meaning exit().

Hence, non-scattered neutrons (or e.g. n'th pass of the SPLIT) would always exit not only the group, but the full raytrace() fct.