### PR TITLE
Introduction of order=0.5 mode in Single_crystal

### DIFF
--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -19,6 +19,7 @@
 * Modified by: PW, June 2017: Doc updates
 * Modified by: PW, Feb 2018:  GPU edits
 * Modified by: EF, June 2023: can now read CIF files
+* Modified by: MB, November 2024: Order 0.5 optimization with large split numbers
 *
 * Mosaic single crystal with multiple scattering vectors, optimised for speed
 * with large crystals and many reflections.
@@ -36,12 +37,14 @@
 * In order to dramatically improve the simulation efficiency, we recommend to
 * use a SPLIT keyword on this component (or prior to it), as well as to disable
 * the multiple scattering handling by setting order=1. This is especially powerful
-* for large reflection lists such as with macromolecular proteins. When an incoming
-* particle is identical to the preceeding, reciprocal space initialisation is 
-* skipped, and a Monte Carlo choice is done on available reflections from the last
-* repciprocal space calculation! To assist the user in choosing a "relevant" value
-* of the SPLIT, a rolling average of the number of available reflections is
-* calculated and presented in the component output.
+* for large reflection lists such as with macromolecular proteins. With order=1
+* the component still calculates extinction as the ray leaves the crystal, setting
+* order=0.5 removes this step, further increasing the gains with large reflection
+* lists and split.When an incoming particle is identical to the preceeding, 
+* reciprocal space initialisation is skipped, and a Monte Carlo choice is done on 
+* available reflections from the last repciprocal space calculation! To assist the
+* user in choosing a "relevant" value of the SPLIT, a rolling average of the number
+* of available reflections is calculated and presented in the component output.
 *
 * <b>Mosacitiy modes:</b>
 * The component features three independent ways of parametrising mosaicity:
@@ -180,7 +183,7 @@
 * cy: []                                                  c on y axis
 * cz: []                                                  c on z axis
 * reflections: [string]                                   File name containing structure factors of reflections (LAZ LAU CIF, FullProf, ShelX). Use empty ("") or NULL for incoherent scattering only
-* order: [1]                                              Limit multiple scattering up to given order (0: all, 1: first, 2: second, ...)
+* order: [1]                                              Limit multiple scattering up to given order (0: all, 1: first, 2: second, ...) Order 0.5 special case that skips coherent scattering when leaving crystal
 *
 * Optional input parameters
 *
@@ -1169,13 +1172,13 @@ INITIALIZE
     exit(fprintf(stderr,"Single_crystal: %s: powder and PG modes can not be used together!\n"
              "ERROR           Please use EITHER powder or PG mode.\n", NAME_CURRENT_COMP));
 
-  if (powder && !(order==1)) {
+  if (powder && !(order==1 || order==0.5)) {
     fprintf(stderr,"Single_crystal: %s: powder mode means implicit choice of no multiple scattering!\n"
             "WARNING setting order=1\n", NAME_CURRENT_COMP);
     order=1;
   }
 
-  if (PG && !(order==1)) {
+  if (PG && !(order==1 || order==0.5)) {
     fprintf(stderr,"Single_crystal: %s: PG mode means implicit choice of no multiple scattering!\n"
             "WARNING setting order=1\n", NAME_CURRENT_COMP);
     order=1;
@@ -1327,6 +1330,14 @@ TRACE
       }
 
       l_full = t2*v;
+	  
+	  if (order==0.5 && force_transmit) {
+		  // With order 0.5, exit before calculating coherent cross section on exit
+          // Exit due to truncated order, weight with relevant cross-sections to distance l_full
+          p*=exp(-abs_xlen*l_full);
+          intersect=0;
+          break;
+	  }
 
       /* (1). Compute incoming wave vector ki */
       if (powder) { /* orientation of crystallite is random */
@@ -1394,7 +1405,7 @@ TRACE
       } else {
 	T = tau_list;
       }
-      if (order==1 && fabs(kix - hkl_info.kix) < deltak
+      if ((order==1 || order==0.5) && fabs(kix - hkl_info.kix) < deltak
         && fabs(kiy - hkl_info.kiy) < deltak
         && fabs(kiz - hkl_info.kiz) < deltak) {
         hkl_info.nb_reuses++;


### PR DESCRIPTION
The optimization in Single_crystal to reuse calculations for the previous ray when they are identical was supposed to speed up the calculation with a large factor, but in practice it was found to only reach a speed up of about 2 even with large split numbers. This was explored as a tangent in this issue: https://github.com/McStasMcXtrace/McCode/issues/1725

The reason is that the expensive hkl_search is performed both for the ray entering the crystal (which can be reused as the wave vector will be exactly the same as the previous ray when using split), and for when leaving the crystal, hence at most half of the work can be reused.

Here a new mode is introduced, order=0.5, where the attenuation from coherent scattering as the ray leaves the crystal is simply ignored, meaning the number of hkl_search calls can be reduced with a factor equal to the split number.

Here are results for lucine with different values for the order:
![lucine_order_comparison_wide](https://github.com/user-attachments/assets/067a6f4f-d528-4c37-922b-ae7d8d85266b)
![lucine_order_comparison_narrow](https://github.com/user-attachments/assets/06e39a5d-b3f4-42cc-97db-8f0ccfaf6af3)

As well as rubredoxin: 
![output_narrow_rubredoxin](https://github.com/user-attachments/assets/eadf0459-4b33-46f9-93f8-2d8608ac8c12)

The new mode, order=0.5 is stable when changing split value as expected:
![order_half_split_stable](https://github.com/user-attachments/assets/9b90a536-5aec-4912-9988-21b1acc0be71)

The execution time as a function of order and split is shown in the graf below:
![execution_time_orders](https://github.com/user-attachments/assets/2adb29a4-3e43-43d9-84e6-7c78ea81e2e9)
This is for a target ncount after the crystal, so split 100 would be done with a factor 100 less rays than split 1. The fastest run with order=0.5 is barely more than a second, while the slowest runs with higher order is about 100 seconds.

The speedup between the different order settings can be seen below, the limit of 2 for order=1 is clearly seen.
![speedup_orders](https://github.com/user-attachments/assets/307c3e54-b010-4942-8819-acfdb65a5fef)

Here a speedup of almost a factor of 30 is seen. The increase in speed is suspected to grow for higher split numbers, but will saturate as the time spent elsewhere in the simulation starts to become the bottleneck.