### PR TITLE
Added order_extra feature for Single_crystal

### DIFF
--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -182,6 +182,7 @@
 * cz: []                                                  c on z axis
 * reflections: [string]                                   File name containing structure factors of reflections (LAZ LAU CIF, FullProf, ShelX). Use empty ("") or NULL for incoherent scattering only
 * order: [1]                                              Limit multiple scattering up to given order (0: all, 1: first, 2: second, ...)
+* extra_order: [1]                                        When using order, allow additional multiple scattering without coherent scattering, sensible with very large unit cells (0: disable, 1: one extra, 2: two extra, ...)
 *
 * Optional input parameters
 *
@@ -289,7 +290,7 @@ ax = 0, ay = 0, az = 0,
 bx = 0, by = 0, bz = 0,
 cx = 0, cy = 0, cz = 0,
 p_transmit = 0.001, sigma_abs = 0, sigma_inc = 0,
-aa=0, bb=0, cc=0, order=0, RX=0, RY=0, powder=0, PG=0,
+aa=0, bb=0, cc=0, order=0, extra_order=0, RX=0, RY=0, powder=0, PG=0,
 deltak=1e-6)
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -1180,6 +1181,10 @@ INITIALIZE
             "WARNING setting order=1\n", NAME_CURRENT_COMP);
     order=1;
   }
+  
+  if (order==0 && extra_order) {
+     fprintf(stderr, "Single_crystal: %s: extra_order used while order=0, then this option has no effect\n", NAME_CURRENT_COMP);
+  }
 
   printf("Direct space lattice orientation:\n");
   printf("  a = [%g %g %g]\n", hkl_info.m_ax, hkl_info.m_ay, hkl_info.m_az);
@@ -1329,8 +1334,9 @@ TRACE
 
       l_full = t2*v;
 	  
-      if (order && event_counter >= order) {
-        /* Exit due to truncated order, weight with relevant cross-sections to distance l_full */
+      if (   (order && !(extra_order) && event_counter >= order)
+  		  || (order && extra_order && event_counter >= order + extra_order)) {
+        // Exit due to truncated order, weight with relevant cross-sections to distance l_full
         p*=exp(-abs_xlen*l_full);
         intersect=0; 
         break;
@@ -1391,11 +1397,13 @@ TRACE
 	  
       double coh_xsect = 0, coh_refl = 0;
 	  
+	  // Condition to skip calculation of coherent cross section when, needed for extra_order feature
+	  if (order==0 || extra_order==0 || event_counter < order) {
 #ifndef OPENACC
       /* in case we use 'SPLIT' then consecutive neutrons can be identical when entering here
          and we may skip the hkl_search call. One tau_list is reserved for data for the initial
-	 ray results so that it potentially can be reused later. */
-	T = tau_list;
+	     ray results so that it potentially can be reused later. */
+  	  T = tau_list;
       if (order==1 && fabs(kix - hkl_info.kix) < deltak
         && fabs(kiy - hkl_info.kiy) < deltak
         && fabs(kiz - hkl_info.kiz) < deltak) {
@@ -1404,7 +1412,7 @@ TRACE
         /* Restore in case of matching event (e.g. SPLIT) */
         coh_refl = hkl_info.coh_refl;
         coh_xsect = hkl_info.coh_xsect;
-	      tau_count = hkl_info.tau_count;
+	    tau_count = hkl_info.tau_count;
       } else {
 #endif
         /* Max possible tau for this ki with 5*sigma delta-d/d cutoff. */
@@ -1446,6 +1454,15 @@ TRACE
         }
       }
 #endif
+      } else {
+	      // When extra_order used, disable coherent scattering after order reached, but continue
+    	  // Set coherent cross section to zero to ignore coherent part
+          coh_refl = 0;
+          coh_xsect = 0;
+          tau_count = 0;
+      }	  
+	  
+	  
       /* (3). Probabilities of the different possible interactions. */
       /* Cross-sections are in barns = 10**-28 m**2, and unit cell volumes are
          in AA**3 = 10**-30 m**2. Hence a factor of 100 is used to convert

--- a/mcxtrace-comps/samples/Single_crystal.comp
+++ b/mcxtrace-comps/samples/Single_crystal.comp
@@ -188,6 +188,7 @@
 * cz:      [AA or AA^-1]   c on z axis
 * reflections:  [string] File name containing structure factors of reflections (LAZ LAU CIF, FullProf, ShelX). Use empty ("") or NULL for incoherent scattering only
 * order:             [1] Limit multiple scattering up to given order (0: all, 1: first, 2: second, ...)
+* extra_order:       [1] When using order, allow additional multiple scattering without coherent scattering, sensible with very large unit cells (0: disable, 1: one extra, 2: two extra, ...)
 *
 * Optional input parameters
 *
@@ -296,7 +297,7 @@ SETTING PARAMETERS(string reflections=0, string geometry=0, vector mosaic_AB={0,
   bx = 0, by = 0, bz = 0,
   cx = 0, cy = 0, cz = 0,
   p_transmit = 0.001, sigma_inc = 0,
-  aa=0, bb=0, cc=0, order=1, RX=0, RY=0, powder=0,
+  aa=0, bb=0, cc=0, order=1, extra_order=0, RX=0, RY=0, powder=0,
   deltak=1e-6, string material_datafile="Si.txt",
   int surf_size=0, vector surf_k=NULL, vector surf_FT2=NULL, vector surf_dir={0,0,0})
 
@@ -1438,10 +1439,6 @@ TRACE
   char   type;      /* type of last event: t=transmit,c=coherent or i=incoherent */
   int    itype;     /* type of last event: t=1,c=2 or i=3 */
 
-  int force_transmit; /* Flag to handle cross-section weighting in case of finite order */
-
-  force_transmit=0;
-
   #ifdef OPENACC
   #ifdef USE_OFF
   off_struct thread_offdata = offdata;
@@ -1537,6 +1534,14 @@ TRACE
       }
 
       l_full = l2;
+	  
+      if (   (order && !(extra_order) && event_counter >= order)
+  		  || (order && extra_order && event_counter >= order + extra_order)) {
+        // Exit due to truncated order, weight with relevant cross-sections to distance l_full
+        p*=exp(-abs_xlen*l_full);
+        intersect=0; 
+        break;
+      }
 
       /* (1). Compute incoming wave vector ki */
       if (powder) { /* orientation of crystallite is random */
@@ -1585,6 +1590,9 @@ TRACE
       /* (2). Intersection of Ewald sphere with reciprocal lattice points */
 
       double coh_xsect = 0, coh_refl = 0;
+	  
+	  // Condition to skip calculation of coherent cross section when, needed for extra_order feature	  
+	  if (order==0 || extra_order==0 || event_counter < order) {	  
       /* in case we use 'SPLIT' then consecutive photons can be identical when entering here
          and we may skip the hkl_search call */
 #ifndef OPENACC
@@ -1628,6 +1636,14 @@ TRACE
 	      }
       }
 #endif
+      } else {
+        // When extra_order used, disable coherent scattering after order reached, but continue
+  	    // Set coherent cross section to zero to ignore coherent part
+        coh_refl = 0;
+        coh_xsect = 0;
+        tau_count = 0;
+      }
+	  
       /* (3). Probabilities of the different possible interactions. */
       /* Cross-sections are in barns = 10**-28 m**2, and unit cell volumes are
          in AA**3 = 10**-30 m**2. Hence a factor of 100 is used to convert
@@ -1640,13 +1656,6 @@ TRACE
 
       if(tot_xlen <= 0){
         ABSORB; // Should we really absorb here? If "nothing" can happen we perhaps ought to "pass" instead? 
-      }
-
-      if (force_transmit) {
-        /* Exit due to truncated order, weight with relevant cross-sections to distance l_full */
-        p*=exp(-abs_xlen*l_full);
-        intersect=0; 
-        break;
       }
       
       /* (5). Transmission */
@@ -1808,8 +1817,6 @@ TRACE
       if (powder) { /* orientation of crystallite is no longer random */
         randderotate(&kx, &ky, &kz, Alpha, Beta, Gamma);
       }
-      /* exit if multiple scattering order has been reached */
-      if (order && event_counter >= order) { force_transmit=1; }
       /* Repeat loop for next scattering event. */
     } while (intersect); /* end do (intersect) (multiple scattering loop) */
   } /* if intersect */


### PR DESCRIPTION
Added extra_order feature to Single_crystal, allowing extra orders of multiple scattering that ignores coherent scattering which is slow for large unit cells.

In a case as below, order=0 does not give satisfactory approximation.

![order_approach_ref](https://github.com/user-attachments/assets/3c1f3c5b-7dd0-4f28-b595-30a9c12dc563)

Using higher orders provides less speedup as a function of split as show below.

![Figure 3](https://github.com/user-attachments/assets/e3f19126-384d-4cce-ba26-6ff1a29e775b)

This update introduces the option to allow a limited number of additional multiple scattering that ignores the coherent part of the cross section which is the computationally expensive part of the algorithm. 

![Figure 199-2](https://github.com/user-attachments/assets/7a2b6054-210e-43b6-a32a-6e151d6514f8)
![Figure 199-3](https://github.com/user-attachments/assets/8df8db6c-edcc-4ee1-9c0f-1abf765a3a74)

Using this feature with order=1 quickly provides a very good approximation with less computation time. Below we see speed ups compared to order=0, all with SPLIT 100. Using extra_order provides a better approximation, but of course does take computation time, though much faster than increasing the normal order parameter.

![Figure 204](https://github.com/user-attachments/assets/3627d45c-d8a0-4028-98a1-da9f4f1c88d4)

It can be a bit complex to choose the right combination of SPLIT, order and extra_order. The plot below shows many runs with speed up relative to a reference simulation and a chi square comparison to the reference run (here extra_order is called order_inc / "oi" in label, order is "o",  SPLIT as "s"). For this system, leucine, using order=1, high split and extra_order somewhere between 3 and 6 would provide a good balance between accuracy and computation time.

![Figure 191](https://github.com/user-attachments/assets/529fe74d-475a-4d72-82c1-f21663f3ad39)

Will update this pull request with equivalent feature for McXtrace.