### PR TITLE
Remove variable length array allocations for #1817

### DIFF
--- a/mcstas-comps/share/polyhedron.c
+++ b/mcstas-comps/share/polyhedron.c
@@ -660,23 +660,23 @@ int line_polyhedron_intersect(double line_t, Coords line_p, Coords line_v,
 
 
 	double *dtime = (double*)malloc(a->nf * sizeof(double));
-  Coords *dpoint = (Coords*)malloc(a->nf * sizeof(Coords));
-  double *time = (double*)malloc(a->nf * sizeof(double));
-  Coords *point = (Coords*)malloc(a->nf * sizeof(Coords));
-  int *plane_number = (int*)malloc(a->nf * sizeof(int));
-  int *type = (int*)malloc(a->nf * sizeof(int));
+	Coords *dpoint = (Coords*)malloc(a->nf * sizeof(Coords));
+	double *time = (double*)malloc(a->nf * sizeof(double));
+	Coords *point = (Coords*)malloc(a->nf * sizeof(Coords));
+	int *plane_number = (int*)malloc(a->nf * sizeof(int));
+	int *type = (int*)malloc(a->nf * sizeof(int));
 
-  if (dtype==NULL || dpoint==NULL || time==NULL || point == NULL || plan_number==null || type == NULL) {
-    // Handle memory allocation failure
-    fprintf(stderr, "Memory allocation failed in line_polyhedron_intersect\n");
-    free(dtime);
-    free(dpoint);
-    free(time);
-    free(point);
-    free(plane_number);
-    return 0;
-  }
-
+	if (dtype == NULL || dpoint == NULL || time == NULL || point == NULL || plan_number == NULL || type == NULL) {
+		// Handle memory allocation failure
+		fprintf(stderr, "Memory allocation failed in line_polyhedron_intersect\n");
+		free(dtime);
+		free(dpoint);
+		free(time);
+		free(point);
+		free(plane_number);
+		free(type);
+		return 0;
+	}
 
 	//first find all the potential intersects that happens immediately or in the future.
 	LinePolyhedronIntersect *lpi = &(a->lpi);
@@ -773,16 +773,14 @@ int line_polyhedron_intersect(double line_t, Coords line_p, Coords line_v,
 	if (n_intersect_found == 0) {
 		//no intersect
 		*num_intersect = 0;
-
-    // Ensure to free the allocated memory after use
-    free(dtime);
-    free(dpoint);
-    free(time);
-    free(point);
-    free(plane_number);
-    free(type);
-
-    return 1;
+		// Ensure to free the allocated memory after use
+		free(dtime);
+		free(dpoint);
+		free(time);
+		free(point);
+		free(plane_number);
+		free(type);
+		return 1;
 	}
 	
 	if (*num_intersect <= 0) {
@@ -836,8 +834,6 @@ int line_polyhedron_intersect(double line_t, Coords line_p, Coords line_v,
   free(point);
   free(plane_number);
   free(type);
-
-
   return 1;
 }
 

--- a/mcstas-comps/share/polyhedron.c
+++ b/mcstas-comps/share/polyhedron.c
@@ -674,7 +674,7 @@ int line_polyhedron_intersect(double line_t, Coords line_p, Coords line_v,
     free(time);
     free(point);
     free(plane_number);
-    exit(EXIT_FAILURE);
+    return 0;
   }
 
 

--- a/mcstas-comps/share/polyhedron.c
+++ b/mcstas-comps/share/polyhedron.c
@@ -657,13 +657,26 @@ int line_polyhedron_intersect(double line_t, Coords line_p, Coords line_v,
 	Coords lp_dp; //intersect dspace
 	double lp_t; //intersect time absolute
 	Coords lp_p; //intersect position absolute
-	
-	double dtime[a->nf];
-	Coords dpoint[a->nf];
-	double time[a->nf];
-	Coords point[a->nf];
-	int plane_number[a->nf];
-	int type[a->nf];
+
+
+	double *dtime = (double*)malloc(a->nf * sizeof(double));
+  Coords *dpoint = (Coords*)malloc(a->nf * sizeof(Coords));
+  double *time = (double*)malloc(a->nf * sizeof(double));
+  Coords *point = (Coords*)malloc(a->nf * sizeof(Coords));
+  int *plane_number = (int*)malloc(a->nf * sizeof(int));
+  int *type = (int*)malloc(a->nf * sizeof(int));
+
+  if (dtype==NULL || dpoint==NULL || time==NULL || point == NULL || plan_number==null || type == NULL) {
+    // Handle memory allocation failure
+    fprintf(stderr, "Memory allocation failed in line_polyhedron_intersect\n");
+    free(dtime);
+    free(dpoint);
+    free(time);
+    free(point);
+    free(plane_number);
+    exit(EXIT_FAILURE);
+  }
+
 
 	//first find all the potential intersects that happens immediately or in the future.
 	LinePolyhedronIntersect *lpi = &(a->lpi);
@@ -760,7 +773,16 @@ int line_polyhedron_intersect(double line_t, Coords line_p, Coords line_v,
 	if (n_intersect_found == 0) {
 		//no intersect
 		*num_intersect = 0;
-		return 1;
+
+    // Ensure to free the allocated memory after use
+    free(dtime);
+    free(dpoint);
+    free(time);
+    free(point);
+    free(plane_number);
+    free(type);
+
+    return 1;
 	}
 	
 	if (*num_intersect <= 0) {
@@ -806,7 +828,17 @@ int line_polyhedron_intersect(double line_t, Coords line_p, Coords line_v,
 	
 	*num_intersect = n_intersect_found;
 
-	return 1;
+
+  // Ensure to free the allocated memory after use
+  free(dtime);
+  free(dpoint);
+  free(time);
+  free(point);
+  free(plane_number);
+  free(type);
+
+
+  return 1;
 }
 
 /*****************************************************/

--- a/mcstas-comps/share/supermirror-lib.c
+++ b/mcstas-comps/share/supermirror-lib.c
@@ -1947,7 +1947,7 @@ calls: 		line_polyhedron_intersect
 	//si->type: 1=x plane, 2=x edge, 3=x vertex, 4=on plane, 5=on edge
 	//SupermirrorIntersect *si = &((sm->proc).si);
 	int skip_plane[] = {0, 1};
-	int n_skip_plane = (int)(sizeof(skip_plane) / sizeof(int));
+	int n_skip_plane = 2;
 	int num_intersect = 1; //only use values of the first intersect
 	line_polyhedron_intersect(state->t, state->p, state->v, &(sm->geo), Maximum_On_Plane_Distance, n_skip_plane, skip_plane,  
 								state->last_time, state->last_point, state->last_plane, 
@@ -2149,7 +2149,7 @@ calls: 		line_polyhedron_intersect
 	//Skip the current plane in finding intersect, neutron should propagate to other planes.
 	//Also, refraction may result in trajectory almost parallel to current plane, can unphysically transmit out due to numerical precision limit. 
 	int skip_plane[] = {state->plane};
-	int n_skip_plane = (int)(sizeof(skip_plane) / sizeof(int)); // 1
+	int n_skip_plane = 1;
 	line_polyhedron_intersect(state->t, state->p, state->v, &(sm->geo), Maximum_On_Plane_Distance, n_skip_plane, skip_plane,  
 								state->last_time, state->last_point, state->last_plane, 
 								&num_intersect, &idt, 0, 0, 0, &iplane, &itype); 
@@ -3139,9 +3139,8 @@ int sm_internal_reflections(SimState *state, Supermirror *sm, double ws_target)
 	//ir.1 Calculate how long it takes to reach one of the edges of the supermirror using surface velocity
 	//Find line-polyhedron intersects
 	//state->itype: 1=x plane, 2=x edge, 3=x vertex, 4=on plane, 5=on edge
-
-	int n_skip_plane = 2; int skip_plane[n_skip_plane];
-	skip_plane[0] = 0; skip_plane[1] = 1; 
+	int skip_plane[] = {0, 1};
+	int n_skip_plane = 2;
 	int num_intersect = 1; //only use values of the first intersect
 	line_polyhedron_intersect(state->t, state->p, state->v, &(sm->geo), Maximum_On_Plane_Distance, n_skip_plane, skip_plane, 
 								state->last_time, state->last_point, state->last_plane, 

--- a/mcstas-comps/share/supermirror-lib.c
+++ b/mcstas-comps/share/supermirror-lib.c
@@ -1946,8 +1946,8 @@ calls: 		line_polyhedron_intersect
 	
 	//si->type: 1=x plane, 2=x edge, 3=x vertex, 4=on plane, 5=on edge
 	//SupermirrorIntersect *si = &((sm->proc).si);
-	int n_skip_plane = 2; int skip_plane[n_skip_plane];
-	skip_plane[0] = 0; skip_plane[1] = 1; 
+	int skip_plane[] = {0, 1};
+	int n_skip_plane = (int)(sizeof(skip_plane) / sizeof(int));
 	int num_intersect = 1; //only use values of the first intersect
 	line_polyhedron_intersect(state->t, state->p, state->v, &(sm->geo), Maximum_On_Plane_Distance, n_skip_plane, skip_plane,  
 								state->last_time, state->last_point, state->last_plane, 
@@ -2148,8 +2148,8 @@ calls: 		line_polyhedron_intersect
 	int num_intersect = 1; //only use values of the first intersect
 	//Skip the current plane in finding intersect, neutron should propagate to other planes.
 	//Also, refraction may result in trajectory almost parallel to current plane, can unphysically transmit out due to numerical precision limit. 
-	int n_skip_plane = 1; int skip_plane[n_skip_plane];
-	skip_plane[0] = state->plane;  
+	int skip_plane[] = {state->plane};
+	int n_skip_plane = (int)(sizeof(skip_plane) / sizeof(int)); // 1
 	line_polyhedron_intersect(state->t, state->p, state->v, &(sm->geo), Maximum_On_Plane_Distance, n_skip_plane, skip_plane,  
 								state->last_time, state->last_point, state->last_plane, 
 								&num_intersect, &idt, 0, 0, 0, &iplane, &itype); 


### PR DESCRIPTION
Replace variable length array allocation with initializer-list allocation.

This is a partial fix for #1817 but does not correct all instances of variable length array allocation.