### PR TITLE
NCrystal default branch was renamed from master to main

### DIFF
--- a/cmake/Modules/NCrystal.cmake
+++ b/cmake/Modules/NCrystal.cmake
@@ -43,4 +43,4 @@ endif()
 
 unset( tmp_instprefix )
 
-git_fetch(ncrystal "${NCRYSTAL_MINIMUM_VERSION}" "master" "${NCRYSTAL_REPO}" ${NCRYSTAL_REQUIRE_PREINSTALL} "${ncrystal_fetch_params}")
+git_fetch(ncrystal "${NCRYSTAL_MINIMUM_VERSION}" "main" "${NCRYSTAL_REPO}" ${NCRYSTAL_REQUIRE_PREINSTALL} "${ncrystal_fetch_params}")


### PR DESCRIPTION
Although the cmake fetch ncrystal is a bit obsolete, at least it should refer to the correct branch name :-)