### PR TITLE
Full adaptation of "spin-component nullification" after "spin up/down measurement"

### DIFF
--- a/mcstas-comps/optics/Monochromator_pol.comp
+++ b/mcstas-comps/optics/Monochromator_pol.comp
@@ -160,6 +160,11 @@ TRACE
     // calculate peak reflection probability
     GetMonoPolRefProb(FN, FM, sy, &R0);
 
+    /* Output of PW discussions with Hal Lee 2024/03/08
+       We have now done our QM "measurement", thus
+       forcing the spin to assume up/down: */
+    sx=0; sz=0;
+
     // calculate reflection probability
     p_reflect = R0*exp(-dlambda2/(2.0*sigmaLambda2));
 

--- a/mcstas-comps/optics/Pol_bender.comp
+++ b/mcstas-comps/optics/Pol_bender.comp
@@ -440,6 +440,10 @@ TRACE
       isPolarising = 1;
       GetMonoPolFNFM(Rup, Rdown, &FN, &FM);
       GetMonoPolRefProb(FN, FM, sy, &weight);
+      /* Output of PW discussions with Hal Lee 2024/03/08
+	 We have now done our QM "measurement", thus
+	 forcing the spin to assume up/down: */
+      sx=0; sz=0;
     } else
       weight = Rup;
 

--- a/mcstas-comps/optics/Pol_guide_mirror.comp
+++ b/mcstas-comps/optics/Pol_guide_mirror.comp
@@ -373,6 +373,10 @@ TRACE
       if (Rdown >  1) Rdown =1 ;
       GetMonoPolFNFM(Rup, Rdown, &FN, &FM);
       GetMonoPolRefProb(FN, FM, sy, &refWeight);
+      /* Output of PW discussions with Hal Lee 2024/03/08
+	 We have now done our QM "measurement", thus
+	 forcing the spin to assume up/down: */
+      sx=0; sz=0;
       // check that refWeight is meaningful
       if (refWeight <  0) ABSORB;
       if (refWeight >  1) refWeight =1 ;

--- a/mcstas-comps/optics/Pol_guide_vmirror.comp
+++ b/mcstas-comps/optics/Pol_guide_vmirror.comp
@@ -531,6 +531,10 @@ TRACE
 
       GetMonoPolFNFM(Rup, Rdown, &FN, &FM);
       GetMonoPolRefProb(FN, FM, sy, &refWeight);
+      /* Output of PW discussions with Hal Lee 2024/03/08
+	 We have now done our QM "measurement", thus
+	 forcing the spin to assume up/down: */
+      sx=0; sz=0;
       // check that refWeight is meaningfull
       if (refWeight <  0) ABSORB;
       if (refWeight >  1) refWeight =1 ;


### PR DESCRIPTION
Logic and procedure from Pol_mirror.comp ported to other polarised components.