### PR TITLE
Doc correction for MCPL install-location in Windows legacy

### DIFF
--- a/INSTALL-McStas/Windows/README.md
+++ b/INSTALL-McStas/Windows/README.md
@@ -2,9 +2,10 @@
 
 * Please install the [McStas 3.5.24 metapackage](https://download.mcstas.org/mcstas-3.5.24/Windows/McStas-Metapackage-3.5.24-win64.exe)
 * To enable use of MCPL with McStas 3.5.24 on Windows, please:
- 1) Locate and run the executable `mcstas-mcpl-NSIS64-3.5.24-mingw64.exe` from the [single-packages folder](https://download.mcstas.org/mcstas-3.5.24/Windows/single-packages)
- 2) During installation, please specify `c:\mcstas-3.5.24` as installation directory
- 3) After installation, place the mcpl-related `.bat` files from the [extras folder](https://download.mcstas.org/mcstas-3.5.24/Windows/extras) folder in `c:\mcstas-3.5.24\bin`
+ 1) Grant yourself write permission to `c:\mcstas-3.5.24\miniconda3`
+ 2) Locate and run the executable `mcstas-mcpl-NSIS64-3.5.24-mingw64.exe` from the [single-packages folder](https://download.mcstas.org/mcstas-3.5.24/Windows/single-packages)
+ 3) During installation, please specify `c:\mcstas-3.5.24\miniconda3` as installation directory
+ 4) After installation, place the mcpl-related `.bat` files from the [extras folder](https://download.mcstas.org/mcstas-3.5.24/Windows/extras) folder in `c:\mcstas-3.5.24\miniconda3\bin`
 
 
 * An alternative to installing this cross-compiled verison is to follow the instructions

--- a/INSTALL-McXtrace/Windows/README.md
+++ b/INSTALL-McXtrace/Windows/README.md
@@ -2,9 +2,10 @@
 
 * Please install the [McXtrace 3.5.24 metapackage](https://download.mcxtrace.org/mcxtrace-3.5.24/Windows/McXtrace-Metapackage-3.5.24-win64.exe)
 * To enable use of MCPL with McXtrace 3.5.24 on Windows, please:
- 1) Locate and run the executable `mcxtrace-mcpl-NSIS64-3.5.24-mingw64.exe` from the [single-packages folder](https://download.mcxtrace.org/mcxtrace-3.5.24/Windows/single-packages)
- 2) During installation, please specify `c:\mcxtrace-3.5.24` as installation directory
- 3) After installation, place the mcpl-related `.bat` files from the [extras folder](https://download.mcxtrace.org/mcxtrace-3.5.24/Windows/extras) folder in `c:\mcxtrace-3.5.24\bin`
+ 1) Grant yourself write permission to `c:\mcxtrace-3.5.24\miniconda3`
+ 2) Locate and run the executable `mcxtrace-mcpl-NSIS64-3.5.24-mingw64.exe` from the [single-packages folder](https://download.mcxtrace.org/mcxtrace-3.5.24/Windows/single-packages)
+ 3) During installation, please specify `c:\mcxtrace-3.5.24\miniconda3` as installation directory
+ 4) After installation, place the mcpl-related `.bat` files from the [extras folder](https://download.mcxtrace.org/mcxtrace-3.5.24/Windows/extras) folder in `c:\mcxtrace-3.5.24\miniconda3\bin`
 
 
 * An alternative to installing this cross-compiled verison is to follow the instructions


### PR DESCRIPTION
Doc correction for MCPL install-location in Windows legacy "cross-compiled" McStas/McXtrace 3.4.25