### PR TITLE
Disable macos/openmpi in favour of macos/mpich for now

### DIFF
--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -25,9 +25,9 @@ jobs:
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'mpich'   }
           - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'mpich'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'mpich'   }
-          - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
-          - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
-          - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
+          #- { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
+          #- { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
+          #- { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
           #- { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.12", mpi: 'msmpi'   }
 
     name: ${{ matrix.os }}.${{ matrix.CC }}.${{ matrix.mpi }}.python-${{ matrix.python }}

--- a/.github/workflows/mcstas-testsuite.yml
+++ b/.github/workflows/mcstas-testsuite.yml
@@ -20,7 +20,7 @@ jobs:
           - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'openmpi' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'mpich' }
-          - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
+          #- { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
           - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: windows-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'msmpi' }
 

--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -25,9 +25,9 @@ jobs:
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'mpich'   }
           - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'mpich'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'mpich'   }
-          - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
-          - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
-          - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
+          #- { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
+          #- { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
+          #- { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
           #- { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.12", mpi: 'msmpi'   }
 
     name: ${{ matrix.os }}.${{ matrix.CC }}.${{ matrix.mpi }}.python-${{ matrix.python }}

--- a/.github/workflows/mcxtrace-testsuite.yml
+++ b/.github/workflows/mcxtrace-testsuite.yml
@@ -20,7 +20,7 @@ jobs:
           - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'openmpi' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'mpich' }
-          - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
+          #- { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
           - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: windows-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'msmpi' }
 


### PR DESCRIPTION
(We get consistent hangs on the CI, https://github.com/mccode-dev/McCode/issues/1889 is there to remind us.)

It seems the issue is openmpi version dependent, `openmpi=4` e.g. on conda works OK, the CI/brew version is `openmpi=5`.