### PR TITLE
Contributed component Source_custom

### DIFF
--- a/mcstas-comps/contrib/Source_custom.comp
+++ b/mcstas-comps/contrib/Source_custom.comp
@@ -5,18 +5,19 @@
 *         DTU Physics, Kongens Lyngby, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Component: Source_pulsed_multi
+* Component: Source_custom
 *
 * %I
-* Written by: Pablo Gila-Herranz, based on component 'Source_pulsed' by K. Lieutenant, 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
+* Written by: Pablo Gila-Herranz, based on 'Source_pulsed' by K. Lieutenant, 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
 * Date: March 31, 2025
 * Version: 2.0
 * Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
 *
-* A flexible pulsed source with customisable parameters. Multiple pulses can be simulated over time.
+* A flexible pulsed or continuous source with customisable parameters. Multiple pulses can be simulated over time.
 *
 * %D
 * Produces a custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
+* To simulate a continuous source, set a pulse length equal or greater than the pulse period (e.g. t_pulse=1.0, freq=1.0).
 *
 * By default, all Maxwellian distributions are assumed to come from anywhere in the moderator.
 * However, a custom radius r_i can be defined such that the central circle of radius r_i is at temperature T1,
@@ -30,9 +31,9 @@
 * Parameters xwidth and yheight must be provided for rectangular moderators, otherwise a circular shape is assumed.
 *
 * Usage example: 
-*   Source_pulsed_multi(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2,
-*                       target_index=1, focus_xw=0.020, focus_yh=0.020, freq=96.0, t_pulse=0.000208,
-*                       T1=325.0, I1=7.6e9, tau1=0.000170, I_um=2.7e8, chi_um=2.5)
+*   Source_custom(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2,
+*                 target_index=1, focus_xw=0.020, focus_yh=0.020, freq=96.0, t_pulse=0.000208,
+*                 T1=325.0, I1=7.6e9, tau1=0.000170, I_um=2.7e8, chi_um=2.5)
 *
 * Parameters for some sources:
 *
@@ -63,8 +64,8 @@
 * Lmax:           [Ang]      Upper edge of the wavelength distribution
 * freq:           [Hz]       Frequency of pulses
 * t_pulse:        [s]        Proton pulse length
-* tmax_multiplier [1]        Defined maximum emission time at moderator (tmax = tmax_multiplier * t_pulse)
-* n_pulses        [1]        Number of pulses to be simulated (minimum 1)
+* tmax_multiplier [1]        Defined maximum emission time at moderator (tmax = tmax_multiplier * t_pulse); 1 for continuous sources
+* n_pulses        [1]        Number of pulses to be simulated (minimum 1); ignored for continuous sources
 * target_index:   [1]        relative index of component to focus at, e.g. next is +1; used to compute 'dist' automatically
 * dist:           [m]        Distance from the source to the target
 * focus_xw:       [m]        Width of the target (focusing rectangle)
@@ -88,7 +89,7 @@
 * %E
 *******************************************************************************/
 
-DEFINE COMPONENT Source_pulsed_multi
+DEFINE COMPONENT Source_custom
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS (xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,
     Lmin, Lmax, freq, t_pulse, tmax_multiplier=3.0, int n_pulses=1,
@@ -175,25 +176,25 @@ INITIALIZE
       ||    n_mod < 0.0 ||      I_um < 0.0 ||           tau_um < 0.0
       ||     n_um < 0.0 ||    chi_um < 0.0 ||           kap_um < 0.0)
   {
-      printf("Source_pulsed_multi: %s: Error: negative input parameter!\n"
+      printf("Source_custom: %s: Error: negative input parameter!\n"
              "ERROR          Exiting\n", NAME_CURRENT_COMP);
       exit(-1);
   }
   if (Lmax <= Lmin)
   {
-      printf("Source_pulsed_multi: %s: Error: wavelengths should be Lmin < Lmax!\n"
+      printf("Source_custom: %s: Error: wavelengths should be Lmin < Lmax!\n"
              "ERROR          Exiting\n", NAME_CURRENT_COMP);
       exit(-1);
   }
   if (T1 == 0.0 && T2 == 0.0 && T3 == 0.0)
   {
-      printf("Source_pulsed_multi: %s: Error: No temperature T1, T2 nor T3 defined!\n"
+      printf("Source_custom: %s: Error: No temperature T1, T2 nor T3 defined!\n"
              "ERROR          Exiting\n", NAME_CURRENT_COMP);
       exit(-1);
   }
   if (I1 == 0.0 && I2 == 0.0 && I3 == 0.0)
   {
-      printf("Source_pulsed_multi: %s: Error: No flux I1, I2 nor I3 defined!\n"
+      printf("Source_custom: %s: Error: No flux I1, I2 nor I3 defined!\n"
              "ERROR          Exiting\n", NAME_CURRENT_COMP);
       exit(-1);
   }
@@ -213,6 +214,17 @@ INITIALIZE
   t_period = 1.0 / freq;
   alpha    = t_pulse / t_period;
 
+  /* The source is assumed to be continuous if the input pulse length is equal or greater than the pulse period.
+  The pulse length is then matched to the pulse period to avoid spurious neutron counts. */
+  if (t_pulse >= t_period)
+  {
+    t_pulse = t_period;
+    if (tmax_multiplier > 1.0)
+      tmax_multiplier = 1.0;
+    if (n_pulses > 1.0)
+      n_pulses = 1.0;
+  }
+
   /* Area for different moderator shapes */
   if (xwidth > 0.0 && yheight > 0.0)
   { 
@@ -224,7 +236,7 @@ INITIALIZE
   }
   else
   {
-    printf("Source_pulsed_multi: %s: Error: The shape of the source is not set! Use xwidth/yheight or radius\n"
+    printf("Source_custom: %s: Error: The shape of the source is not set! Use xwidth/yheight or radius\n"
            "ERROR          Exiting\n", NAME_CURRENT_COMP);
     exit(-1);
   }

--- a/mcstas-comps/contrib/Source_custom.comp
+++ b/mcstas-comps/contrib/Source_custom.comp
@@ -8,7 +8,7 @@
 * Component: Source_custom
 *
 * %I
-* Written by: Pablo Gila-Herranz, based on 'Source_pulsed' by K. Lieutenant, 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
+* Written by: Pablo Gila-Herranz, based on 'Source_pulsed' by K. Lieutenant
 * Date: April 2025
 * Version: 2.0
 * Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
@@ -19,75 +19,87 @@
 * Produces a custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
 *
 * By default, all Maxwellian distributions are assumed to come from anywhere in the moderator.
-* However, a custom radius r_i can be defined such that the central circle of radius r_i is at temperature T1,
+* A custom radius r_i can be defined such that the central circle is at temperature T1,
 * and the surrounding ring is at temperature T2.
 * The third Maxwellian distribution at temperature T3 always comes from anywhere in the moderator.
 *
 * Multiple pulses can be simulated over time with the n_pulses parameter.
-* Note that the intensity spreads over n_pulses, so that the units of neutrons per second are preserved.
-* The input flux is in units of [1/(cm^2 sr s AA)], so to simulate only one pulse the input flux should be divided by the frequency.
+* The input flux is in units of [1/(cm^2 sr s AA)], and the output flux is per second, regardless of the number of pulses.
+* This means that the intensity spreads over n_pulses, so that the units of neutrons per second are preserved.
+* To simulate only the neutron counts of a single pulse, the input flux should be divided by the frequency.
 *
 * To simulate a continuous source, set a pulse length equal to the pulse period (e.g. t_pulse=1.0, freq=1.0).
 * Note that this continuous beam is simulated over time, unlike other continuous sources in McStas which produce a Dirac delta at time 0.
 *
 * Parameters xwidth and yheight must be provided for rectangular moderators, otherwise a circular shape is assumed.
 *
-* Usage example: 
-*   Source_custom(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2,
-*                 target_index=1, focus_xw=0.020, focus_yh=0.020, freq=96.0, t_pulse=0.000208,
-*                 T1=325.0, I1=7.6e9, tau1=0.000170, I_um=2.7e8, chi_um=2.5)
+* The normalised Maxwellian distribution for moderated neutrons is defined by [1]
+*   $M(\lambda)=\frac{2a^2}{T^2\lambda^5}\exp\left(-\frac{a}{T\lambda^{2}}\right)$
+* where
+*   $a=\left(\frac{h^2}{2m_{N}k_{B}}\right)$
+* and the joining function for the under-moderated neutrons is given by [1]
+*   $M(\lambda)_{um}=\frac{1}{\lambda(1+\exp(\lambda\chi-\kappa))}$
+*
+* The normalised time structure of the pulse is defined by [2]
+*   $N_{t<=t_p}=1-\exp\left(-\frac{t}{\tau/n}\right)$
+*   $N_{t>t_p}=\exp\left(-\frac{t-t_p}{\tau}\right)-\exp\left(-\frac{t}{\tau/n}\right)$
+* where tp is the pulse period, tau is the pulse decay time constant, and n is the ratio of decay to ascend time constants.
 *
 * Parameters for some sources:
 *
 *   HBS thermal source:
-*     t_pulse=0.016/freq, freq=96.0 or 24.0, xwidth=0.04, yheight=0.04,
-*     T1=325.0, I1=0.68e+12/freq, tau1=0.000125,
-*     n_mod=10, I_um=2.47e+10/freq, chi_um=2.5
+*     t_pulse=0.016, freq=24.0, xwidth=0.04, yheight=0.04,
+*     T1=325.0, I1=0.68e+12, tau1=0.000125,
+*     I_um=2.47e+10, chi_um=2.5
 *
 *   HBS cold source:
-*     t_pulse=0.016/freq, freq=24.0 or 96.0, radius=0.010,
-*     T1=60.0, I1=1.75e+12/freq, tau1=0.000170,
-*     n_mod=5, I_um=3.82e+10/freq, chi_um=0.9
+*     t_pulse=0.016, freq=24.0, radius=0.010,
+*     T1=60.0, I1=1.75e+12, tau1=0.000170,
+*     I_um=3.82e+10, chi_um=0.9
 *
 *   HBS bi-spectral:
-*     t_pulse=0.016/freq, freq=24.0 or 96.0, radius=0.022, r_i=0.010,
-*     T1= 60.0, I1=1.75e+12/freq, tau1=0.000170,
-*     T2=305.0, I2=0.56e+12/freq, tau2=0.000130,
-*     n_mod=5, I_um=3.82e+10/freq, chi_um=2.5
+*     t_pulse=0.016, freq=24.0, radius=0.022, r_i=0.010,
+*     T1= 60.0, I1=1.75e+12, tau1=0.000170,
+*     T2=305.0, I2=0.56e+12, tau2=0.000130,
+*     I_um=3.82e+10, chi_um=2.5
 *
 *   PSI cold source:
 *     t_pulse=1, freq=1, xwidth=0.1, yheight=0.1,
 *     T1=296.2, I1=8.5e+11, T2=40.68, I2=5.2e+11
 *
+* References:
+*   [1] J. M. Carpenter et al, Nuclear Instruments and Methods in Physics Research Section A, 234, 542–551 (1985).
+*   [2] J. M. Carpenter and W. B. Yelon, Methods in Experimental Physics 23, p. 127, Chapter 2, Neutron Sources (1986).
+*
 * %P
 * Input parameters:
 *
+* target_index:   [1]        Relative index of component to focus at, e.g. next is +1 (used to compute 'dist' automatically)
+* dist:           [m]        Distance from the source to the target
+* focus_xw:       [m]        Width of the target (focusing rectangle)
+* focus_yh:       [m]        Height of the target (focusing rectangle)
 * xwidth:         [m]        Width of the source
 * yheight:        [m]        Height of the source
-* radius:         [m]        Outer radius of the source
+* radius:         [m]        Outer radius of the source (ignored if xwidth and yheight are set)
 * r_i:            [m]        Radius of a central circle at temperature T1, sorrounded by a ring at temperature T2 (ignored by default)
 * Lmin:           [AA]       Lower edge of the wavelength distribution
 * Lmax:           [AA]       Upper edge of the wavelength distribution
 * freq:           [Hz]       Frequency of pulses
 * t_pulse:        [s]        Proton pulse length
 * tmax_multiplier [1]        Defined maximum emission time at moderator (tmax = tmax_multiplier * t_pulse); 1 for continuous sources
-* n_pulses        [1]        Number of pulses to be simulated (minimum 1); ignored for continuous sources
-* target_index:   [1]        relative index of component to focus at, e.g. next is +1; used to compute 'dist' automatically
-* dist:           [m]        Distance from the source to the target
-* focus_xw:       [m]        Width of the target (focusing rectangle)
-* focus_yh:       [m]        Height of the target (focusing rectangle)
+* n_pulses        [1]        Number of pulses to be simulated (ignored for continuous sources)
 * T1:             [K]        Temperature of the 1st Maxwellian distribution; for r_i > 0 it is only used for the central radii r < r_i
 * I1:    [1/(cm^2 sr s AA)]  Flux per solid angle of the 1st Maxwellian distribution (integrated over the whole wavelength range)
-* tau1:           [s]        Pulse decay constant of the 1st Maxwellian distribution
+* tau1:           [s]        Pulse decay time constant of the 1st Maxwellian distribution
 * T2:             [K]        Temperature of the 2nd Maxwellian distribution (0 to disable); for r_i > 0 it is only used for the external ring r > r_i
 * I2:    [1/(cm^2 sr s AA)]  Flux per solid angle of the 2nd Maxwellian distribution
-* tau2:           [s]        Pulse decay constant of the 2nd Maxwellian distribution
+* tau2:           [s]        Pulse decay time constant of the 2nd Maxwellian distribution
 * T3:             [K]        Temperature of the 3rd Maxwellian distribution (0 to disable)
 * I3:    [1/(cm^2 sr s AA)]  Flux per solid angle of the 3rd Maxwellian distribution
-* tau3:           [s]        Pulse decay constant of the 3rd Maxwellian distribution
-* n_mod:          [1]        Ratio of pulse decay constant to pulse ascend constant of moderated neutrons
+* tau3:           [s]        Pulse decay time constant of the 3rd Maxwellian distribution
+* n_mod:          [1]        Ratio of pulse decay constant to pulse ascend constant of moderated neutrons (n = tau_decay / tau_ascend)
 * I_um:  [1/(cm^2 sr s AA)]  Flux per solid angle for the under-moderated neutrons
-* tau_um:         [s]        Pulse decay constant of under-moderated neutrons
+* tau_um:         [s]        Pulse decay time constant of under-moderated neutrons
 * n_um:           [1]        Ratio of pulse decay constant to pulse ascend constant of under-moderated neutrons
 * chi_um:        [1/AA]      Factor for the wavelength dependence of under-moderated neutrons
 * kap_um:         [1]        Scaling factor for the flux of under-moderated neutrons
@@ -97,67 +109,46 @@
 
 DEFINE COMPONENT Source_custom
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS (xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,
-    Lmin, Lmax, freq, t_pulse, tmax_multiplier=3.0, int n_pulses=1,
-    int target_index=1, dist=0.0, focus_xw=0.02, focus_yh=0.02,
-    T1=0.0, I1=0.0, tau1=0.000125, T2=0.0, I2=0.0, tau2=0.000125, T3=0.0, I3=0.0, tau3=0.000125, n_mod=10,
-    I_um=0.0, tau_um=0.000012, n_um=5, chi_um=2.5, kap_um=2.2)
+SETTING PARAMETERS (int target_index=1, dist=0.0, focus_xw=0.02, focus_yh=0.02,
+                    xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,
+                    Lmin, Lmax, freq, t_pulse, tmax_multiplier=3.0, int n_pulses=1,
+                    T1=0.0, I1=0.0, tau1=0.000125, T2=0.0, I2=0.0, tau2=0.000125, T3=0.0, I3=0.0, tau3=0.000125, n_mod=1,
+                    I_um=0.0, tau_um=0.000012, n_um=1, chi_um=2.5, kap_um=2.2)
 OUTPUT PARAMETERS ()
 /* Neutron parameters: (x,y,z, vx,vy,vz, t, sx,sy,sz, p) */
 
 
 SHARE
 %{
-  /* Normalized Maxwellian distribution:
-  $M(\lambda)=\frac{2k_{T h}^{2}}{T^2\lambda^{5}}e^{-\frac{k_{T h}}{T\lambda^{2}}}$
-  */
+  /* Normalized Maxwellian distribution */
   #pragma acc routine
-  double Maxwell(double lmbd, double temperature)
-  {
+  double maxwell(double lmbd, double temperature){
     double a, M=0.0;
-    if (temperature > 0.0 && lmbd > 0.0)
-    { a = 949.29 / temperature;
-      M = 2.0 * a*a * exp(-a / (lmbd*lmbd)) / pow(lmbd, 5);
+    if (temperature > 0.0 && lmbd > 0.0){
+      a = 949.29 / temperature;
+      M = 2.0 * a*a * exp(-a/(lmbd*lmbd)) / pow(lmbd, 5);
     }
     return M;
   }
 
-  /* Distribution of under-moderated neutrons
-  $\frac{1}{\lambda(1+e^{\chi\lambda-\kappa})}$
-  */
+  /* Distribution of under-moderated neutrons */
   #pragma acc routine
-  double Mezei_N_fct(double lmbd, double chi, double kappa)
-  {
+  double joining_function(double lmbd, double chi, double kappa){
     if (lmbd > 0.0)
       return 1.0 / ((1.0 + exp(chi * lmbd - kappa)) * lmbd);
     else
       return 0.0;
   }
 
-  /* Integral of the pulse shape over time
-  $\frac{e^{-\frac{t}{\tau/n}}-ne^{-\frac{t}{\tau}}}{n-1}$
-  */
+  /* Normalised time-dependent pulse structure */
   #pragma acc routine
-  double Mezei_i_fct(double time, double tau, double n)
-  {
-    if (n > 1.0 && tau > 0.0)
-      return (exp(-time / (tau / n)) - n*exp(-time / tau)) / (n - 1);
-    else
-      return 0.0;
-  }
-
-  /* Normalized long pulse function.
-  Models the normalized time-dependent flux of a long pulse,
-  ensuring the total flux integrates to 1 over the pulse duration.*/
-  #pragma acc routine
-  double Mezei_I_fct(double time, double tau, double n, double pulse_length)
-  {
-    if (time <= 0.0  || tau <= 0.0 || n <= 1.0 || pulse_length <= 0.0)
+  double pulse_carpenter(double time, double tau, double n, double pulse_length){
+    if (time <= 0.0  || tau <= 0.0 || n <= 0.0 || pulse_length <= 0.0)
       return 0.0;
     else if (time <= pulse_length)
-      return (Mezei_i_fct(time, tau, n) + 1.0) / pulse_length;
-    else  /* time is greater than the proton pulse */
-      return (Mezei_i_fct(time, tau, n) - Mezei_i_fct(time - pulse_length, tau, n)) / pulse_length;
+      return (1 - exp(-time/(tau/n))) / pulse_length;
+    else
+      return (exp(-(time-pulse_length)/tau) - exp(-time/(tau/n))) / pulse_length;
   }
 %}
 
@@ -182,34 +173,29 @@ INITIALIZE
       ||       T2 < 0.0 ||        I2 < 0.0 ||             tau2 < 0.0
       ||       T3 < 0.0 ||        I3 < 0.0 ||             tau3 < 0.0
       ||    n_mod < 0.0 ||      I_um < 0.0 ||           tau_um < 0.0
-      ||     n_um < 0.0 ||    chi_um < 0.0 ||           kap_um < 0.0)
-  {
-      printf("Source_custom: %s: Error: negative input parameter!\n"
-             "ERROR          Exiting\n", NAME_CURRENT_COMP);
-      exit(-1);
+      ||     n_um < 0.0 ||    chi_um < 0.0 ||           kap_um < 0.0){
+    printf("Source_custom: %s: Error: negative input parameter!\n"
+           "ERROR          Exiting\n", NAME_CURRENT_COMP);
+    exit(-1);
   }
-  if (Lmax <= Lmin)
-  {
-      printf("Source_custom: %s: Error: wavelengths should be Lmin < Lmax!\n"
-             "ERROR          Exiting\n", NAME_CURRENT_COMP);
-      exit(-1);
+  if (Lmax <= Lmin){
+    printf("Source_custom: %s: Error: wavelengths should be Lmin < Lmax!\n"
+           "ERROR          Exiting\n", NAME_CURRENT_COMP);
+    exit(-1);
   }
-  if (T1 == 0.0 && T2 == 0.0 && T3 == 0.0)
-  {
-      printf("Source_custom: %s: Error: No temperature T1, T2 nor T3 defined!\n"
-             "ERROR          Exiting\n", NAME_CURRENT_COMP);
-      exit(-1);
+  if (T1 == 0.0 && T2 == 0.0 && T3 == 0.0){
+    printf("Source_custom: %s: Error: No temperature T1, T2 nor T3 defined!\n"
+           "ERROR          Exiting\n", NAME_CURRENT_COMP);
+    exit(-1);
   }
-  if (I1 == 0.0 && I2 == 0.0 && I3 == 0.0)
-  {
-      printf("Source_custom: %s: Error: No flux I1, I2 nor I3 defined!\n"
-             "ERROR          Exiting\n", NAME_CURRENT_COMP);
-      exit(-1);
+  if (I1 == 0.0 && I2 == 0.0 && I3 == 0.0){
+    printf("Source_custom: %s: Error: No flux I1, I2 nor I3 defined!\n"
+           "ERROR          Exiting\n", NAME_CURRENT_COMP);
+    exit(-1);
   }
 
   /* Automatic distance to the target */
-  if (target_index > 0 && dist == 0.0)
-  {
+  if (target_index > 0 && dist == 0.0){
     Coords ToTarget;
     double tx,ty,tz;
     ToTarget = coords_sub(POS_A_COMP_INDEX(INDEX_CURRENT_COMP + target_index), POS_A_CURRENT_COMP);
@@ -220,30 +206,24 @@ INITIALIZE
 
   /* Pulse parameters */
   t_period = 1.0 / freq;
-  alpha    = t_pulse / t_period;
+  alpha = t_pulse / t_period;
 
   /* The source is assumed to be continuous if the input pulse length is equal or greater than the pulse period.
   The pulse length is then matched to the pulse period to avoid spurious neutron counts. */
-  if (t_pulse >= t_period)
-  {
+  if (t_pulse >= t_period){
     t_pulse = t_period;
-    if (tmax_multiplier > 1.0)
-      tmax_multiplier = 1.0;
-    if (n_pulses > 1.0)
-      n_pulses = 1.0;
+    tmax_multiplier = 1.0;
+    n_pulses = 1.0;
   }
 
   /* Area for different moderator shapes */
-  if (xwidth > 0.0 && yheight > 0.0)
-  { 
+  if (xwidth > 0.0 && yheight > 0.0){
     area  = 10000.0 * xwidth * yheight;
   }
-  else if (radius > 0.0)
-  {
+  else if (radius > 0.0){
     area  = 10000.0 * PI * radius*radius;
   }
-  else
-  {
+  else{
     printf("Source_custom: %s: Error: The shape of the source is not set! Use xwidth/yheight or radius\n"
            "ERROR          Exiting\n", NAME_CURRENT_COMP);
     exit(-1);
@@ -273,13 +253,12 @@ TRACE
 
   /* Choose the starting point on the moderator surface
   with uniform distribution for different moderator shapes */
-  if (xwidth > 0.0 && yheight > 0.0)
-  {
+  if (xwidth > 0.0 && yheight > 0.0){
     x =  xwidth * (rand01() - 0.5);
     y = yheight * (rand01() - 0.5);
   }
-  else
-  { phi = 2 * PI * rand01();
+  else{
+    phi = 2 * PI * rand01();
     r = sqrt(rand01()) * radius;
     x = r * cos(phi);
     y = r * sin(phi);
@@ -312,20 +291,19 @@ TRACE
   vz = v * dist / rf;
 
   /* The input flux variables Ix are in [1/(cm^2 s AA sr)]
-  The flux variable below gets the flux per pulse */
-  flux = I_um * Mezei_N_fct(lambda, chi_um, kap_um) * Mezei_I_fct(t, tau_um, n_um, t_pulse);
+  The flux variable below gets the flux per unit of time (s) */
+  flux = I_um * joining_function(lambda, chi_um, kap_um) * pulse_carpenter(t, tau_um, n_um, t_pulse);
   if (r_i==0.0 || r <= r_i)
-    flux += I1 * Maxwell(lambda, T1) * Mezei_I_fct(t, tau1, n_mod, t_pulse);
+    flux += I1 * maxwell(lambda, T1) * pulse_carpenter(t, tau1, n_mod, t_pulse);
   if (r_i==0.0 || r > r_i)
-    flux += I2 * Maxwell(lambda, T2) * Mezei_I_fct(t, tau2, n_mod, t_pulse); 
-  flux   += I3 * Maxwell(lambda, T3) * Mezei_I_fct(t, tau3, n_mod, t_pulse);
+    flux += I2 * maxwell(lambda, T2) * pulse_carpenter(t, tau2, n_mod, t_pulse);
+  flux   += I3 * maxwell(lambda, T3) * pulse_carpenter(t, tau3, n_mod, t_pulse);
 
   /* Assign this neutron to a random pulse among the specified n_pulses.
   The value of p remains consistent since the intensity now spreads over n_pulses */
-  t += (double)floor((n_pulses)*rand01())/freq;
+  t += (double)floor((n_pulses)*rand01()) * t_period;
   /* The p McStas parameter gets the neutrons per second that reach the target component */
-  p  = flux * area * Omega * p_in;  /*  [1]   neutrons per pulse      */
-  p *= freq;                        /* [1/s]  time averaged intensity */
+  p  = flux * area * Omega * p_in;  /* [1/s] time averaged intensity */
 
   SCATTER;
 %}
@@ -335,18 +313,15 @@ MCDISPLAY
 %{
   double edge;  /* [m] x and y position on the circle */
 
-  if (dist > 0.0)
-  {
-    if (xwidth > 0.0 && yheight > 0.0)
-    {
+  if (dist > 0.0){
+    if (xwidth > 0.0 && yheight > 0.0){
       rectangle("xy", 0,0,0, xwidth,yheight);
       dashed_line(-xwidth/2, -yheight/2, 0, -focus_xw/2, -focus_yh/2, dist, 4);
       dashed_line( xwidth/2, -yheight/2, 0,  focus_xw/2, -focus_yh/2, dist, 4);
       dashed_line( xwidth/2,  yheight/2, 0,  focus_xw/2,  focus_yh/2, dist, 4);
       dashed_line(-xwidth/2,  yheight/2, 0, -focus_xw/2,  focus_yh/2, dist, 4);
     }
-    else
-    {
+    else{
       circle("xy", 0,0,0, radius);
       if (r_i > 0.0)
         circle("xy", 0,0,0, r_i);

--- a/mcstas-comps/contrib/Source_custom.comp
+++ b/mcstas-comps/contrib/Source_custom.comp
@@ -44,14 +44,19 @@
 *
 *   HBS cold source:
 *     t_pulse=0.016/freq, freq=24.0 or 96.0, radius=0.010,
-*     T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,
-*     n_mod= 5, I_um=3.82e+10/freq, chi_um=0.9
+*     T1=60.0, I1=1.75e+12/freq, tau1=0.000170,
+*     n_mod=5, I_um=3.82e+10/freq, chi_um=0.9
 *
 *   HBS bi-spectral:
 *     t_pulse=0.016/freq, freq=24.0 or 96.0, radius=0.022, r_i=0.010,
-*     T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,
-*     T2=305.0, I2=0.56e+12/freq, tau1=0.000130,
-*     n_mod= 5, I_um=3.82e+10/freq, chi_um=2.5
+*     T1= 60.0, I1=1.75e+12/freq, tau1=0.000170,
+*     T2=305.0, I2=0.56e+12/freq, tau2=0.000130,
+*     n_mod=5, I_um=3.82e+10/freq, chi_um=2.5
+*
+*   PSI cold source (continuous):
+*     xwidth=0.1, yheight=0.1, freq=1, t_pulse=1,
+*     T1=296.2, I1=8.5e+11, tau1=???,
+*     T2=40.68, I2=5.2e+11, tau2=???
 *
 * %P
 * Input parameters:
@@ -94,7 +99,7 @@ DEFINITION PARAMETERS ()
 SETTING PARAMETERS (xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,
     Lmin, Lmax, freq, t_pulse, tmax_multiplier=3.0, int n_pulses=1,
     int target_index=1, dist=0.0, focus_xw=0.02, focus_yh=0.02,
-    T1=0.0, I1=0.0, tau1=0.000125, T2=0.0, I2=0.0, tau2=0.0, T3=0.0, I3=0.0, tau3=0.0, n_mod=10,
+    T1=0.0, I1=0.0, tau1=0.000125, T2=0.0, I2=0.0, tau2=0.000125, T3=0.0, I3=0.0, tau3=0.000125, n_mod=10,
     I_um=0.0, tau_um=0.000012, n_um=5, chi_um=2.5, kap_um=2.2)
 OUTPUT PARAMETERS ()
 /* Neutron parameters: (x,y,z, vx,vy,vz, t, sx,sy,sz, p) */
@@ -116,12 +121,14 @@ SHARE
     return M;
   }
 
-  /* Distribution of under-moderated neutrons */
+  /* Distribution of under-moderated neutrons
+  $\frac{1}{(1+e^{\chi\lambda-\kappa})\lambda}$
+  */
   #pragma acc routine
   double Mezei_N_fct(double lmbd, double chi, double kappa)
   {
     if (lmbd > 0.0)
-      return 1.0 / (1.0 + exp(chi * lmbd - kappa)) / lmbd;
+      return 1.0 / ((1.0 + exp(chi * lmbd - kappa)) * lmbd);
     else
       return 0.0;
   }

--- a/mcstas-comps/contrib/Source_custom.comp
+++ b/mcstas-comps/contrib/Source_custom.comp
@@ -53,11 +53,6 @@
 *     T2=305.0, I2=0.56e+12/freq, tau2=0.000130,
 *     n_mod=5, I_um=3.82e+10/freq, chi_um=2.5
 *
-*   PSI cold source (continuous):
-*     xwidth=0.1, yheight=0.1, freq=1, t_pulse=1,
-*     T1=296.2, I1=8.5e+11, tau1=???,
-*     T2=40.68, I2=5.2e+11, tau2=???
-*
 * %P
 * Input parameters:
 *

--- a/mcstas-comps/contrib/Source_custom.comp
+++ b/mcstas-comps/contrib/Source_custom.comp
@@ -9,7 +9,7 @@
 *
 * %I
 * Written by: Pablo Gila-Herranz, based on 'Source_pulsed' by K. Lieutenant, 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
-* Date: March 31, 2025
+* Date: April 2025
 * Version: 2.0
 * Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
 *
@@ -17,16 +17,18 @@
 *
 * %D
 * Produces a custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
-* To simulate a continuous source, set a pulse length equal or greater than the pulse period (e.g. t_pulse=1.0, freq=1.0).
 *
 * By default, all Maxwellian distributions are assumed to come from anywhere in the moderator.
 * However, a custom radius r_i can be defined such that the central circle of radius r_i is at temperature T1,
 * and the surrounding ring is at temperature T2.
 * The third Maxwellian distribution at temperature T3 always comes from anywhere in the moderator.
 *
-* Multiple pulses can be simulated over time with the n_pulses parameter,
-* in contrast to the Source_pulsed component, which only simulates a single pulse.
+* Multiple pulses can be simulated over time with the n_pulses parameter.
 * Note that the intensity spreads over n_pulses, so that the units of neutrons per second are preserved.
+* The input flux is in units of [1/(cm^2 sr s AA)], so to simulate only one pulse the input flux should be divided by the frequency.
+*
+* To simulate a continuous source, set a pulse length equal to the pulse period (e.g. t_pulse=1.0, freq=1.0).
+* Note that this continuous beam is simulated over time, unlike other continuous sources in McStas which produce a Dirac delta at time 0.
 *
 * Parameters xwidth and yheight must be provided for rectangular moderators, otherwise a circular shape is assumed.
 *
@@ -53,6 +55,10 @@
 *     T2=305.0, I2=0.56e+12/freq, tau2=0.000130,
 *     n_mod=5, I_um=3.82e+10/freq, chi_um=2.5
 *
+*   PSI cold source:
+*     t_pulse=1, freq=1, xwidth=0.1, yheight=0.1,
+*     T1=296.2, I1=8.5e+11, T2=40.68, I2=5.2e+11
+*
 * %P
 * Input parameters:
 *
@@ -60,8 +66,8 @@
 * yheight:        [m]        Height of the source
 * radius:         [m]        Outer radius of the source
 * r_i:            [m]        Radius of a central circle at temperature T1, sorrounded by a ring at temperature T2 (ignored by default)
-* Lmin:           [Ang]      Lower edge of the wavelength distribution
-* Lmax:           [Ang]      Upper edge of the wavelength distribution
+* Lmin:           [AA]       Lower edge of the wavelength distribution
+* Lmax:           [AA]       Upper edge of the wavelength distribution
 * freq:           [Hz]       Frequency of pulses
 * t_pulse:        [s]        Proton pulse length
 * tmax_multiplier [1]        Defined maximum emission time at moderator (tmax = tmax_multiplier * t_pulse); 1 for continuous sources
@@ -71,19 +77,19 @@
 * focus_xw:       [m]        Width of the target (focusing rectangle)
 * focus_yh:       [m]        Height of the target (focusing rectangle)
 * T1:             [K]        Temperature of the 1st Maxwellian distribution; for r_i > 0 it is only used for the central radii r < r_i
-* I1:       [1/(cm**2*sr)]   Flux per solid angle of the 1st Maxwellian distribution (integrated over the whole wavelength range)
+* I1:    [1/(cm^2 sr s AA)]  Flux per solid angle of the 1st Maxwellian distribution (integrated over the whole wavelength range)
 * tau1:           [s]        Pulse decay constant of the 1st Maxwellian distribution
 * T2:             [K]        Temperature of the 2nd Maxwellian distribution (0 to disable); for r_i > 0 it is only used for the external ring r > r_i
-* I2:       [1/(cm**2*sr)]   Flux per solid angle of the 2nd Maxwellian distribution
+* I2:    [1/(cm^2 sr s AA)]  Flux per solid angle of the 2nd Maxwellian distribution
 * tau2:           [s]        Pulse decay constant of the 2nd Maxwellian distribution
 * T3:             [K]        Temperature of the 3rd Maxwellian distribution (0 to disable)
-* I3:       [1/(cm**2*sr)]   Flux per solid angle of the 3rd Maxwellian distribution
+* I3:    [1/(cm^2 sr s AA)]  Flux per solid angle of the 3rd Maxwellian distribution
 * tau3:           [s]        Pulse decay constant of the 3rd Maxwellian distribution
 * n_mod:          [1]        Ratio of pulse decay constant to pulse ascend constant of moderated neutrons
-* I_um:     [1/(cm**2*sr)]   Flux per solid angle for the under-moderated neutrons
+* I_um:  [1/(cm^2 sr s AA)]  Flux per solid angle for the under-moderated neutrons
 * tau_um:         [s]        Pulse decay constant of under-moderated neutrons
 * n_um:           [1]        Ratio of pulse decay constant to pulse ascend constant of under-moderated neutrons
-* chi_um:       [1/Ang]      Factor for the wavelength dependence of under-moderated neutrons
+* chi_um:        [1/AA]      Factor for the wavelength dependence of under-moderated neutrons
 * kap_um:         [1]        Scaling factor for the flux of under-moderated neutrons
 *
 * %E
@@ -117,7 +123,7 @@ SHARE
   }
 
   /* Distribution of under-moderated neutrons
-  $\frac{1}{(1+e^{\chi\lambda-\kappa})\lambda}$
+  $\frac{1}{\lambda(1+e^{\chi\lambda-\kappa})}$
   */
   #pragma acc routine
   double Mezei_N_fct(double lmbd, double chi, double kappa)
@@ -305,7 +311,8 @@ TRACE
   vy = v * dy / rf;
   vz = v * dist / rf;
 
-  /* Weight: flux in [1/(cm^2 s Ang sr] */
+  /* The input flux variables Ix are in [1/(cm^2 s AA sr)]
+  The flux variable below gets the flux per pulse */
   flux = I_um * Mezei_N_fct(lambda, chi_um, kap_um) * Mezei_I_fct(t, tau_um, n_um, t_pulse);
   if (r_i==0.0 || r <= r_i)
     flux += I1 * Maxwell(lambda, T1) * Mezei_I_fct(t, tau1, n_mod, t_pulse);
@@ -313,11 +320,12 @@ TRACE
     flux += I2 * Maxwell(lambda, T2) * Mezei_I_fct(t, tau2, n_mod, t_pulse); 
   flux   += I3 * Maxwell(lambda, T3) * Mezei_I_fct(t, tau3, n_mod, t_pulse);
 
-  /* Assign this neutron to a random pulse among the specified n_pulses */
+  /* Assign this neutron to a random pulse among the specified n_pulses.
+  The value of p remains consistent since the intensity now spreads over n_pulses */
   t += (double)floor((n_pulses)*rand01())/freq;
-  /* The value of p remains consistent since the intensity spreads over n_pulses */
-  p  = flux * area* Omega * p_in;  /*  [1]   neutrons per pulse       */
-  p *= freq;                       /* [1/s]  time averaged intensity  */
+  /* The p McStas parameter gets the neutrons per second that reach the target component */
+  p  = flux * area * Omega * p_in;  /*  [1]   neutrons per pulse      */
+  p *= freq;                        /* [1/s]  time averaged intensity */
 
   SCATTER;
 %}

--- a/mcstas-comps/contrib/Source_pulsed_multi.comp
+++ b/mcstas-comps/contrib/Source_pulsed_multi.comp
@@ -8,7 +8,7 @@
 * Component: Source_pulsed_multi
 *
 * %I
-* Written by: Pablo Gila-Herranz, adapted from component 'Source_pulsed' by Klaus Lieutenant, which was based on 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
+* Written by: Pablo Gila-Herranz, based on component 'Source_pulsed' by Klaus Lieutenant, 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
 * Date  : March 31, 2025
 * Version: 1.1
 * Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
@@ -16,27 +16,38 @@
 * A pulsed source for variable proton pulse lengths. Multiple pulses can be simulated over time.
 *
 * %D
-* Produces a custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
+* Custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
 *
 * By default, all Maxwellian distributions are assumed to come from anywhere in the moderator.
 * However, a radious r_i can be defined such that the central circle of radius r_i is at temperature T1,
 * and the surrounding ring is at temperature T2.
 * The third Maxwellian distribution at temperature T3 always comes from anywhere in the moderator.
 *
-* If moderator xwidth and yheight are given, it assumes a rectangular moderator, otherwise it assumes a circular one.
+* Parameters xwidth and yheight must be provided for rectangular moderators, otherwise a circular shape is assumed.
 *
 * Multiple pulses can be simulated over time with the n_pulses parameter,
-* in contrast to the Source_pulsed component, which simulates a single pulse.
+* in contrast to the Source_pulsed component, which only simulates a single pulse.
+* Note that the intensity spreads over n_pulses, so that the units of neutrons per second are preserved.
 *
 * Usage example: 
-*   Source_pulsed_multi(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2, dist=0.700, focus_xw=0.020, focus_yh=0.020,
-*                 freq=96.0, t_pulse=0.000208, T1=325.0, I1=7.6e09, tau1=0.000170, I_um=2.7e08, chi_um=2.5)
+*   Source_pulsed_multi(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2,
+*                       dist=0.700, focus_xw=0.020, focus_yh=0.020, freq=96.0, t_pulse=0.000208,
+*                       T1=325.0, I1=7.6e09, tau1=0.000170, I_um=2.7e08, chi_um=2.5)
 *
 * Parameters for some sources:
-*   HBS thermal source: xwidth=0.04, yheight=0.04, T1=325.0, I1=0.68e+12/freq, tau1=0.000125, n_mod=10, I_um=2.47e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=96.0 or 24.0  
-*   HBS cold source   : radius=0.010,              T1= 60.0, I1=1.75e+12/freq, tau2=0.000170, n_mod= 5, I_um=3.82e+10/freq, chi_um=0.9, t_pulse=0.016/freq, freq=24.0 or 96.0
-*   HBS bi-spectral   : radius=0.022, r_i=0.010,   T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,                                 
-*                                                  T2=305.0, I2=0.56e+12/freq, tau1=0.000130, n_mod= 5, I_um=3.82e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=24.0 or 96.0
+*
+*   HBS thermal source:
+*     xwidth=0.04, yheight=0.04, T1=325.0, I1=0.68e+12/freq, tau1=0.000125,
+*     n_mod=10, I_um=2.47e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=96.0 or 24.0
+*
+*   HBS cold source:
+*     radius=0.010,              T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,
+*     n_mod= 5, I_um=3.82e+10/freq, chi_um=0.9, t_pulse=0.016/freq, freq=24.0 or 96.0
+*
+*   HBS bi-spectral:
+*     radius=0.022, r_i=0.010,   T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,                                 
+*     T2=305.0, I2=0.56e+12/freq, tau1=0.000130,
+*     n_mod= 5, I_um=3.82e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=24.0 or 96.0
 *
 * %P
 * Input parameters:
@@ -47,8 +58,8 @@
 * r_i:            [m]        Radius of a central circle at temperature T1, sorrounded by a ring at temperature T2; ignored by default
 * Lmin:           [Ang]      Lower edge of the wavelength distribution
 * Lmax:           [Ang]      Upper edge of the wavelength distribution
-* t_pulse:        [s]        Proton pulse length
 * freq:           [Hz]       Frequency of pulses
+* t_pulse:        [s]        Proton pulse length
 * tmax_multiplier [1]        Defined maximum emission time at moderator, tmax = tmax_multiplier * t_pulse
 * n_pulses        [1]        Number of pulses to be simulated (minimum 1)
 * target_index:   [1]        relative index of component to focus at, e.g. next is +1; this is used to compute 'dist' automatically
@@ -77,9 +88,9 @@
 DEFINE COMPONENT Source_pulsed_multi
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS (xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,  
-    Lmin, Lmax, t_pulse, freq, tmax_multiplier=3.0, n_pulses=1, 
+    Lmin, Lmax, freq, t_pulse, tmax_multiplier=3.0, int n_pulses=1, 
     int target_index=1, dist=0.0, focus_xw=0.02, focus_yh=0.02,
-    T1, I1, tau1=0.000125,  T2=0.0, I2=0.0, tau2=0.0,  T3=0.0, I3=0.0, tau3=0.0,  n_mod=10,
+    T1=0.0, I1=0.0, tau1=0.000125,  T2=0.0, I2=0.0, tau2=0.0,  T3=0.0, I3=0.0, tau3=0.0,  n_mod=10,
     I_um=0.0, tau_um=0.000012, n_um=5, chi_um=2.5, kap_um=2.2)
 OUTPUT PARAMETERS ()
 /* Neutron parameters: (x,y,z, vx,vy,vz, t, sx,sy,sz, p) */
@@ -143,16 +154,16 @@ SHARE
 
 DECLARE
 %{
-  double area;      /*   [cm^2]  moderator surface area    */
-  double t_period;  /*    [s]    period of the pulse cycle */
-  double alpha;     /*    [1]    duty cycle                */
-  double p_in;      /* [1/Ang/s] flux normalisation factor */
+  double area;      /*   [cm^2]   Moderator surface area    */
+  double t_period;  /*    [s]     Period of the pulse cycle */
+  double alpha;     /*    [1]     Duty cycle                */
+  double p_in;      /* [1/Ang/s]  Flux normalisation factor */
 %}
 
 
 INITIALIZE
 %{
-  /* check of the input parameters */
+  /* Initial check of the input parameters */
   if (   xwidth < 0.0 ||  yheight  < 0.0 ||   radius < 0.0 ||    r_i < 0.0 ||   Lmin < 0.0  ||  Lmax < 0.0
       ||  dist  < 0.0 || focus_xw  < 0.0 || focus_yh < 0.0 ||   freq < 0.0 || t_pulse < 0.0 ||  tmax_multiplier < 0.0
       ||     T1 < 0.0 ||        I1 < 0.0 ||     tau1 < 0.0 ||     T2 < 0.0 ||      I2 < 0.0
@@ -160,17 +171,29 @@ INITIALIZE
       ||   I_um < 0.0 ||    tau_um < 0.0 ||     n_um < 0.0 || chi_um < 0.0 ||  kap_um < 0.0)
   {
       printf("Source_pulsed_multi: %s: Error: negative input parameter!\n"
-             "ERROR          Exiting\n",           NAME_CURRENT_COMP);
+             "ERROR          Exiting\n", NAME_CURRENT_COMP);
       exit(-1);
   }
-  if (Lmax <= Lmin )
+  if (Lmax <= Lmin)
   {
       printf("Source_pulsed_multi: %s: Error: wavelengths should be Lmin < Lmax!\n"
              "ERROR          Exiting\n", NAME_CURRENT_COMP);
       exit(-1);
   }
+  if (T1 == 0.0 && T2 == 0.0 && T3 == 0.0)
+  {
+      printf("Source_pulsed_multi: %s: Error: No temperature T1, T2 nor T3 defined!\n"
+             "ERROR          Exiting\n", NAME_CURRENT_COMP);
+      exit(-1);
+  }
+  if (I1 == 0.0 && I2 == 0.0 && I3 == 0.0)
+  {
+      printf("Source_pulsed_multi: %s: Error: No flux I1, I2 nor I3 defined!\n"
+             "ERROR          Exiting\n", NAME_CURRENT_COMP);
+      exit(-1);
+  }
 
-  /* automatic distance */
+  /* Automatic distance */
   if (target_index > 0 && dist==0.0)
   {
     Coords ToTarget;
@@ -181,11 +204,11 @@ INITIALIZE
     dist=sqrt(tx*tx+ty*ty+tz*tz);
   }
 
-  /* pulse parameters */
+  /* Pulse parameters */
   t_period = 1.0/freq;
   alpha    = t_pulse / t_period;
 
-  /* area for different moderator shapes */
+  /* Area for different moderator shapes */
   if (xwidth > 0.0 && yheight > 0.0)
   { 
     area  = 10000.0 * xwidth * yheight;
@@ -210,18 +233,18 @@ INITIALIZE
 
 TRACE
 %{
-  double phi,    /* [rad]  orientation of the starting point for a spherical moderator */
-         r,      /*  [m]   distance of the starting point from moderator center */
-         v,      /* [m/s]  speed of the neutron      */
-         time,   /*  [s]   */
-         lambda, /* [Ang]  wavelength of the neutron */
-         xf,     /*  [m]   horizontal position on the target */
-         yf,     /*  [m]   vertical position on the target   */
-         rf,     /*  [m]   distance between point on moderator and point on target   */
-         dx,     /*  [m]   horizontal shift from moderator to target */
-         dy,     /*  [m]   vertical shift from moderator to target   */
-         Omega,  /* [sr]   solid angle of the target                 */
-         flux;   /* [1/(cm^2 s Ang sr]  flux(lambda,time)               */
+  double phi,    /* [rad]  Orientation of the starting point for a spherical moderator */
+         r,      /*  [m]   Distance of the starting point from moderator center        */
+         v,      /* [m/s]  Speed of the neutron                                        */
+         time,   /*  [s]   Time                                                        */
+         lambda, /* [Ang]  Wavelength of the neutron                                   */
+         xf,     /*  [m]   Horizontal position on the target                           */
+         yf,     /*  [m]   Vertical position on the target                             */
+         rf,     /*  [m]   Distance between point on moderator and point on target     */
+         dx,     /*  [m]   Horizontal shift from moderator to target                   */
+         dy,     /*  [m]   Vertical shift from moderator to target                     */
+         Omega,  /* [sr]   Solid angle of the target                                   */
+         flux;   /* [1/(cm^2 s Ang sr]  Flux(lambda,time)                              */
 
   /* Choose the starting point on the moderator surface with uniform distribution for different moderator shapes */
   if (xwidth > 0.0 && yheight > 0.0)
@@ -254,7 +277,7 @@ TRACE
   dy = yf - y;
   rf = sqrt(dx*dx + dy*dy + dist*dist);
 
-  /* speed of the neutron */
+  /* Speed of the neutron */
   v  = 3956.0346 / lambda;
   vx = v*dx/rf;
   vy = v*dy/rf;
@@ -271,8 +294,8 @@ TRACE
   /* Assign this neutron to a random pulse */
   t += (double)floor((n_pulses)*rand01())/freq;
   /* The value of p remains consistent since the intensity spreads over n_pulses */
-  p  = flux * area* Omega * p_in;   /*  [1]   neutrons per pulse       */
-  p *= freq;                        /* [1/s]  time averaged intensity  */
+  p  = flux * area* Omega * p_in;  /*  [1]   neutrons per pulse       */
+  p *= freq;                       /* [1/s]  time averaged intensity  */
 
   SCATTER;
 %}
@@ -280,7 +303,7 @@ TRACE
 
 MCDISPLAY
 %{
-  double edge;    /* [m]  x and y position on the circle */
+  double edge;  /* [m]  x and y position on the circle */
 
   if (dist > 0.0) 
   {

--- a/mcstas-comps/contrib/Source_pulsed_multi.comp
+++ b/mcstas-comps/contrib/Source_pulsed_multi.comp
@@ -1,0 +1,309 @@
+/*******************************************************************************
+*
+* Mcstas, neutron ray-tracing package
+*         Copyright (C) 1997-2020, All rights reserved
+*         DTU Physics, Kongens Lyngby, Denmark
+*         Institut Laue Langevin, Grenoble, France
+*
+* Component: Source_pulsed_multi
+*
+* %I
+* Written by: Pablo Gila-Herranz, adapted from component 'Source_pulsed' by Klaus Lieutenant, which was based on 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
+* Date  : March 31, 2025
+* Version: 1.1
+* Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
+*
+* A pulsed source for variable proton pulse lengths. Multiple pulses can be simulated over time.
+*
+* %D
+* Produces a custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
+*
+* By default, all Maxwellian distributions are assumed to come from anywhere in the moderator.
+* However, a radious r_i can be defined such that the central circle of radius r_i is at temperature T1,
+* and the surrounding ring is at temperature T2.
+* The third Maxwellian distribution at temperature T3 always comes from anywhere in the moderator.
+*
+* If moderator xwidth and yheight are given, it assumes a rectangular moderator, otherwise it assumes a circular one.
+*
+* Multiple pulses can be simulated over time with the n_pulses parameter,
+* in contrast to the Source_pulsed component, which simulates a single pulse.
+*
+* Usage example: 
+*   Source_pulsed_multi(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2, dist=0.700, focus_xw=0.020, focus_yh=0.020,
+*                 freq=96.0, t_pulse=0.000208, T1=325.0, I1=7.6e09, tau1=0.000170, I_um=2.7e08, chi_um=2.5)
+*
+* Parameters for some sources:
+*   HBS thermal source: xwidth=0.04, yheight=0.04, T1=325.0, I1=0.68e+12/freq, tau1=0.000125, n_mod=10, I_um=2.47e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=96.0 or 24.0  
+*   HBS cold source   : radius=0.010,              T1= 60.0, I1=1.75e+12/freq, tau2=0.000170, n_mod= 5, I_um=3.82e+10/freq, chi_um=0.9, t_pulse=0.016/freq, freq=24.0 or 96.0
+*   HBS bi-spectral   : radius=0.022, r_i=0.010,   T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,                                 
+*                                                  T2=305.0, I2=0.56e+12/freq, tau1=0.000130, n_mod= 5, I_um=3.82e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=24.0 or 96.0
+*
+* %P
+* Input parameters:
+*
+* xwidth:         [m]        Width of the source
+* yheight:        [m]        Height of the source
+* radius:         [m]        Outer radius of the source
+* r_i:            [m]        Radius of a central circle at temperature T1, sorrounded by a ring at temperature T2; ignored by default
+* Lmin:           [Ang]      Lower edge of the wavelength distribution
+* Lmax:           [Ang]      Upper edge of the wavelength distribution
+* t_pulse:        [s]        Proton pulse length
+* freq:           [Hz]       Frequency of pulses
+* tmax_multiplier [1]        Defined maximum emission time at moderator, tmax = tmax_multiplier * t_pulse
+* n_pulses        [1]        Number of pulses to be simulated (minimum 1)
+* target_index:   [1]        relative index of component to focus at, e.g. next is +1; this is used to compute 'dist' automatically
+* dist:           [m]        Distance from the source to the target
+* focus_xw:       [m]        Width  of the target (= focusing rectangle)
+* focus_yh:       [m]        Height of the target (= focusing rectangle)
+* T1:             [K]        Temperature of the 1st Maxwellian distribution; for r_i > 0 it is only used for the central radii r < r_i
+* I1:       [1/(cm**2*sr)]   Flux per solid angle of the 1st Maxwellian distribution (integrated over the whole wavelength range)
+* tau1:           [s]        Pulse decay constant of the 1st Maxwellian distribution
+* T2:             [K]        Temperature of the 2nd Maxwellian distribution, 0=none; for r_i > 0 it is only used for the external ring r > r_i
+* I2:       [1/(cm**2*sr)]   Flux per solid angle of the 2nd Maxwellian distribution
+* tau2:           [s]        Pulse decay constant of the 2nd Maxwellian distribution
+* T3:             [K]        Temperature of the 3rd Maxwellian distribution, 0=none
+* I3:       [1/(cm**2*sr)]   Flux per solid angle of the 3rd Maxwellian distribution
+* tau3:           [s]        Pulse decay constant of the 3rd Maxwellian distribution
+* n_mod:          [1]        Ratio of pulse decay constant to pulse ascend constant of moderated neutrons
+* I_um:     [1/(cm**2*sr)]   Flux per solid angle for the under-moderated neutrons
+* tau_um:         [s]        Pulse decay constant of under-moderated neutrons
+* n_um:           [1]        Ratio of pulse decay constant to pulse ascend constant of under-moderated neutrons
+* chi_um:       [1/Ang]      Factor for the wavelength dependence of under-moderated neutrons
+* kap_um:         [1]        Scaling factor for the flux of under-moderated neutrons
+*
+* %E
+*******************************************************************************/
+
+DEFINE COMPONENT Source_pulsed_multi
+DEFINITION PARAMETERS ()
+SETTING PARAMETERS (xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,  
+    Lmin, Lmax, t_pulse, freq, tmax_multiplier=3.0, n_pulses=1, 
+    int target_index=1, dist=0.0, focus_xw=0.02, focus_yh=0.02,
+    T1, I1, tau1=0.000125,  T2=0.0, I2=0.0, tau2=0.0,  T3=0.0, I3=0.0, tau3=0.0,  n_mod=10,
+    I_um=0.0, tau_um=0.000012, n_um=5, chi_um=2.5, kap_um=2.2)
+OUTPUT PARAMETERS ()
+/* Neutron parameters: (x,y,z, vx,vy,vz, t, sx,sy,sz, p) */
+
+
+SHARE
+%{
+  /* Normalized Maxwellian distribution:
+  $M(\lambda)=\frac{2k_{T h}^{2}}{T^2\lambda^{5}}e^{-\frac{k_{T h}}{T\lambda^{2}}}$
+  */
+  #pragma acc routine
+  double Maxwell(double lmbd, double temp)
+  {
+    double a, M=0.0;
+
+    if (temp > 0.0 && lmbd > 0.0)
+    { a = 949.29/temp;
+      M = 2.0*a*a*exp(-a/(lmbd*lmbd))/pow(lmbd,5);
+    }
+    return M;
+  }
+
+  /* Distribution of under-moderated neutrons */
+  #pragma acc routine
+  double Mezei_N_fct(double lmbd, double chi, double kappa)
+  {
+    if (lmbd > 0.0)
+      return 1.0 / (1.0 + exp(chi*lmbd-kappa)) / lmbd;
+    else 
+      return 0.0;
+  }
+
+  /* Integral of the pulse shape over time
+  $\frac{e^{-\frac{t}{\tau/n}}-ne^{-\frac{t}{\tau}}}{n-1}$
+  */
+  #pragma acc routine
+  double Mezei_i_fct(double time, double tau, double n)
+  {
+    if (n > 1.0 && tau > 0.0)
+      return (exp(-time/(tau/n)) - n*exp(-time/tau)) / (n-1);
+    else
+      return 0.0;
+  }
+
+  /* Normalized long pulse function.
+  Models the normalized time-dependent flux of a long pulse,
+  ensuring the total flux integrates to 1 over the pulse duration.*/
+  #pragma acc routine
+  double Mezei_I_fct(double time, double tau, double n, double length)
+  {
+    if (time <= 0.0  || tau <= 0.0 || n <= 1.0 || length <= 0.0)
+      return 0.0;
+    else if (time <= length)
+      return (Mezei_i_fct(time, tau, n)+1.0) / length;
+    else  /* time is greater than the proton pulse */
+      return (  Mezei_i_fct(time,        tau, n)
+              - Mezei_i_fct(time-length, tau, n)) / length;
+  }
+%}
+
+
+DECLARE
+%{
+  double area;      /*   [cm^2]  moderator surface area    */
+  double t_period;  /*    [s]    period of the pulse cycle */
+  double alpha;     /*    [1]    duty cycle                */
+  double p_in;      /* [1/Ang/s] flux normalisation factor */
+%}
+
+
+INITIALIZE
+%{
+  /* check of the input parameters */
+  if (   xwidth < 0.0 ||  yheight  < 0.0 ||   radius < 0.0 ||    r_i < 0.0 ||   Lmin < 0.0  ||  Lmax < 0.0
+      ||  dist  < 0.0 || focus_xw  < 0.0 || focus_yh < 0.0 ||   freq < 0.0 || t_pulse < 0.0 ||  tmax_multiplier < 0.0
+      ||     T1 < 0.0 ||        I1 < 0.0 ||     tau1 < 0.0 ||     T2 < 0.0 ||      I2 < 0.0
+      ||   tau2 < 0.0 ||        T3 < 0.0 ||       I3 < 0.0 ||   tau3 < 0.0 ||   n_mod < 0.0
+      ||   I_um < 0.0 ||    tau_um < 0.0 ||     n_um < 0.0 || chi_um < 0.0 ||  kap_um < 0.0)
+  {
+      printf("Source_pulsed_multi: %s: Error: negative input parameter!\n"
+             "ERROR          Exiting\n",           NAME_CURRENT_COMP);
+      exit(-1);
+  }
+  if (Lmax <= Lmin )
+  {
+      printf("Source_pulsed_multi: %s: Error: wavelengths should be Lmin < Lmax!\n"
+             "ERROR          Exiting\n", NAME_CURRENT_COMP);
+      exit(-1);
+  }
+
+  /* automatic distance */
+  if (target_index > 0 && dist==0.0)
+  {
+    Coords ToTarget;
+    double tx,ty,tz;
+    ToTarget = coords_sub(POS_A_COMP_INDEX(INDEX_CURRENT_COMP+target_index),POS_A_CURRENT_COMP);
+    ToTarget = rot_apply(ROT_A_CURRENT_COMP, ToTarget);
+    coords_get(ToTarget, &tx, &ty, &tz);
+    dist=sqrt(tx*tx+ty*ty+tz*tz);
+  }
+
+  /* pulse parameters */
+  t_period = 1.0/freq;
+  alpha    = t_pulse / t_period;
+
+  /* area for different moderator shapes */
+  if (xwidth > 0.0 && yheight > 0.0)
+  { 
+    area  = 10000.0 * xwidth * yheight;
+  }
+  else if (radius > 0.0)
+  {
+    area  = 10000.0 * PI*radius*radius;
+  }
+  else
+  {
+    printf("Source_pulsed_multi: %s: Error: The shape of the source is not set! Use xwidth/yheight or radius. \n"
+           "ERROR          Exiting\n", NAME_CURRENT_COMP);
+    exit(-1);
+  }
+  p_in = (Lmax - Lmin) * (t_pulse * tmax_multiplier) / mcget_ncount();
+
+  /* Set the number of pulses to an integer */
+  n_pulses=(double)floor(n_pulses);
+  if (n_pulses < 1) n_pulses=1;
+%}
+
+
+TRACE
+%{
+  double phi,    /* [rad]  orientation of the starting point for a spherical moderator */
+         r,      /*  [m]   distance of the starting point from moderator center */
+         v,      /* [m/s]  speed of the neutron      */
+         time,   /*  [s]   */
+         lambda, /* [Ang]  wavelength of the neutron */
+         xf,     /*  [m]   horizontal position on the target */
+         yf,     /*  [m]   vertical position on the target   */
+         rf,     /*  [m]   distance between point on moderator and point on target   */
+         dx,     /*  [m]   horizontal shift from moderator to target */
+         dy,     /*  [m]   vertical shift from moderator to target   */
+         Omega,  /* [sr]   solid angle of the target                 */
+         flux;   /* [1/(cm^2 s Ang sr]  flux(lambda,time)               */
+
+  /* Choose the starting point on the moderator surface with uniform distribution for different moderator shapes */
+  if (xwidth > 0.0 && yheight > 0.0)
+  { 
+    x = xwidth* (rand01() - 0.5);
+    y = yheight*(rand01() - 0.5);
+  }
+  else
+  { phi = 2*PI*rand01();          
+    r = sqrt(rand01())*radius; 
+    x = r*cos(phi);
+    y = r*sin(phi);
+  }
+  z = 0.0;
+
+  /* Set zero polarization, choose wavelength and starting time */
+  sx = 0.0;
+  sy = 0.0;
+  sz = 0.0;
+
+  lambda = Lmin  + (Lmax  - Lmin)  * rand01();     
+  t      = t_pulse * tmax_multiplier * rand01(); 
+  
+  /* Propagate to target */
+  randvec_target_rect_real(&xf, &yf, &rf, &Omega,
+                           0, 0, dist, focus_xw, focus_yh, ROT_A_CURRENT_COMP, x, y, z, 2);
+
+  /* Length of the flight path */
+  dx = xf - x;
+  dy = yf - y;
+  rf = sqrt(dx*dx + dy*dy + dist*dist);
+
+  /* speed of the neutron */
+  v  = 3956.0346 / lambda;
+  vx = v*dx/rf;
+  vy = v*dy/rf;
+  vz = v*dist/rf;
+
+  /* Weight: flux in [1/(cm^2 s Ang sr] */
+  flux = I_um * Mezei_N_fct(lambda, chi_um, kap_um) * Mezei_I_fct(t, tau_um, n_um,  t_pulse);
+  if (r_i==0.0 || r <= r_i)
+    flux += I1 * Maxwell(lambda, T1) * Mezei_I_fct(t, tau1,   n_mod, t_pulse); 
+  if (r_i==0.0 || r > r_i)
+    flux += I2 * Maxwell(lambda, T2) * Mezei_I_fct(t, tau2,   n_mod, t_pulse); 
+  flux  +=  I3 * Maxwell(lambda, T3) * Mezei_I_fct(t, tau3,   n_mod, t_pulse);
+
+  /* Assign this neutron to a random pulse */
+  t += (double)floor((n_pulses)*rand01())/freq;
+  /* The value of p remains consistent since the intensity spreads over n_pulses */
+  p  = flux * area* Omega * p_in;   /*  [1]   neutrons per pulse       */
+  p *= freq;                        /* [1/s]  time averaged intensity  */
+
+  SCATTER;
+%}
+
+
+MCDISPLAY
+%{
+  double edge;    /* [m]  x and y position on the circle */
+
+  if (dist > 0.0) 
+  {
+    if (xwidth > 0.0 && yheight > 0.0) 
+    {
+      rectangle("xy", 0,0,0, xwidth,yheight);
+      dashed_line(-xwidth/2, -yheight/2, 0, -focus_xw/2,-focus_yh/2, dist, 4);
+      dashed_line( xwidth/2, -yheight/2, 0,  focus_xw/2,-focus_yh/2, dist, 4);
+      dashed_line( xwidth/2,  yheight/2, 0,  focus_xw/2, focus_yh/2, dist, 4);
+      dashed_line(-xwidth/2,  yheight/2, 0, -focus_xw/2, focus_yh/2, dist, 4);
+    }
+    else
+    {
+      circle("xy", 0,0,0, radius);
+      if (r_i > 0.0)
+        circle("xy", 0,0,0, r_i);
+      edge = radius/sqrt(2.0);
+      dashed_line(-edge, -edge, 0, -focus_xw/2,-focus_yh/2, dist, 4);
+      dashed_line( edge, -edge, 0,  focus_xw/2,-focus_yh/2, dist, 4);
+      dashed_line( edge,  edge, 0,  focus_xw/2, focus_yh/2, dist, 4);
+      dashed_line(-edge,  edge, 0, -focus_xw/2, focus_yh/2, dist, 4);
+    }
+  }
+%}
+
+END

--- a/mcstas-comps/contrib/Source_pulsed_multi.comp
+++ b/mcstas-comps/contrib/Source_pulsed_multi.comp
@@ -8,18 +8,18 @@
 * Component: Source_pulsed_multi
 *
 * %I
-* Written by: Pablo Gila-Herranz, based on component 'Source_pulsed' by Klaus Lieutenant, 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
-* Date  : March 31, 2025
-* Version: 1.1
+* Written by: Pablo Gila-Herranz, based on component 'Source_pulsed' by K. Lieutenant, 'Moderator' by K. Nielsen, M. Hagen and 'ESS_moderator_long_2001' by K. Lefmann
+* Date: March 31, 2025
+* Version: 2.0
 * Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
 *
-* A pulsed source for variable proton pulse lengths. Multiple pulses can be simulated over time.
+* A flexible pulsed source with customisable parameters. Multiple pulses can be simulated over time.
 *
 * %D
-* Custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
+* Produces a custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
 *
 * By default, all Maxwellian distributions are assumed to come from anywhere in the moderator.
-* However, a radious r_i can be defined such that the central circle of radius r_i is at temperature T1,
+* However, a custom radius r_i can be defined such that the central circle of radius r_i is at temperature T1,
 * and the surrounding ring is at temperature T2.
 * The third Maxwellian distribution at temperature T3 always comes from anywhere in the moderator.
 *
@@ -31,23 +31,26 @@
 *
 * Usage example: 
 *   Source_pulsed_multi(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2,
-*                       dist=0.700, focus_xw=0.020, focus_yh=0.020, freq=96.0, t_pulse=0.000208,
+*                       target_index=1, focus_xw=0.020, focus_yh=0.020, freq=96.0, t_pulse=0.000208,
 *                       T1=325.0, I1=7.6e9, tau1=0.000170, I_um=2.7e8, chi_um=2.5)
 *
 * Parameters for some sources:
 *
 *   HBS thermal source:
-*     xwidth=0.04, yheight=0.04, T1=325.0, I1=0.68e+12/freq, tau1=0.000125,
-*     n_mod=10, I_um=2.47e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=96.0 or 24.0
+*     t_pulse=0.016/freq, freq=96.0 or 24.0, xwidth=0.04, yheight=0.04,
+*     T1=325.0, I1=0.68e+12/freq, tau1=0.000125,
+*     n_mod=10, I_um=2.47e+10/freq, chi_um=2.5
 *
 *   HBS cold source:
-*     radius=0.010,              T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,
-*     n_mod= 5, I_um=3.82e+10/freq, chi_um=0.9, t_pulse=0.016/freq, freq=24.0 or 96.0
+*     t_pulse=0.016/freq, freq=24.0 or 96.0, radius=0.010,
+*     T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,
+*     n_mod= 5, I_um=3.82e+10/freq, chi_um=0.9
 *
 *   HBS bi-spectral:
-*     radius=0.022, r_i=0.010,   T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,                                 
+*     t_pulse=0.016/freq, freq=24.0 or 96.0, radius=0.022, r_i=0.010,
+*     T1= 60.0, I1=1.75e+12/freq, tau2=0.000170,
 *     T2=305.0, I2=0.56e+12/freq, tau1=0.000130,
-*     n_mod= 5, I_um=3.82e+10/freq, chi_um=2.5, t_pulse=0.016/freq, freq=24.0 or 96.0
+*     n_mod= 5, I_um=3.82e+10/freq, chi_um=2.5
 *
 * %P
 * Input parameters:
@@ -55,24 +58,24 @@
 * xwidth:         [m]        Width of the source
 * yheight:        [m]        Height of the source
 * radius:         [m]        Outer radius of the source
-* r_i:            [m]        Radius of a central circle at temperature T1, sorrounded by a ring at temperature T2; ignored by default
+* r_i:            [m]        Radius of a central circle at temperature T1, sorrounded by a ring at temperature T2 (ignored by default)
 * Lmin:           [Ang]      Lower edge of the wavelength distribution
 * Lmax:           [Ang]      Upper edge of the wavelength distribution
 * freq:           [Hz]       Frequency of pulses
 * t_pulse:        [s]        Proton pulse length
-* tmax_multiplier [1]        Defined maximum emission time at moderator, tmax = tmax_multiplier * t_pulse
+* tmax_multiplier [1]        Defined maximum emission time at moderator (tmax = tmax_multiplier * t_pulse)
 * n_pulses        [1]        Number of pulses to be simulated (minimum 1)
-* target_index:   [1]        relative index of component to focus at, e.g. next is +1; this is used to compute 'dist' automatically
+* target_index:   [1]        relative index of component to focus at, e.g. next is +1; used to compute 'dist' automatically
 * dist:           [m]        Distance from the source to the target
-* focus_xw:       [m]        Width  of the target (= focusing rectangle)
-* focus_yh:       [m]        Height of the target (= focusing rectangle)
+* focus_xw:       [m]        Width of the target (focusing rectangle)
+* focus_yh:       [m]        Height of the target (focusing rectangle)
 * T1:             [K]        Temperature of the 1st Maxwellian distribution; for r_i > 0 it is only used for the central radii r < r_i
 * I1:       [1/(cm**2*sr)]   Flux per solid angle of the 1st Maxwellian distribution (integrated over the whole wavelength range)
 * tau1:           [s]        Pulse decay constant of the 1st Maxwellian distribution
-* T2:             [K]        Temperature of the 2nd Maxwellian distribution, 0=none; for r_i > 0 it is only used for the external ring r > r_i
+* T2:             [K]        Temperature of the 2nd Maxwellian distribution (0 to disable); for r_i > 0 it is only used for the external ring r > r_i
 * I2:       [1/(cm**2*sr)]   Flux per solid angle of the 2nd Maxwellian distribution
 * tau2:           [s]        Pulse decay constant of the 2nd Maxwellian distribution
-* T3:             [K]        Temperature of the 3rd Maxwellian distribution, 0=none
+* T3:             [K]        Temperature of the 3rd Maxwellian distribution (0 to disable)
 * I3:       [1/(cm**2*sr)]   Flux per solid angle of the 3rd Maxwellian distribution
 * tau3:           [s]        Pulse decay constant of the 3rd Maxwellian distribution
 * n_mod:          [1]        Ratio of pulse decay constant to pulse ascend constant of moderated neutrons
@@ -87,10 +90,10 @@
 
 DEFINE COMPONENT Source_pulsed_multi
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS (xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,  
-    Lmin, Lmax, freq, t_pulse, tmax_multiplier=3.0, int n_pulses=1, 
+SETTING PARAMETERS (xwidth=0.0, yheight=0.0, radius=0.010, r_i=0.0,
+    Lmin, Lmax, freq, t_pulse, tmax_multiplier=3.0, int n_pulses=1,
     int target_index=1, dist=0.0, focus_xw=0.02, focus_yh=0.02,
-    T1=0.0, I1=0.0, tau1=0.000125,  T2=0.0, I2=0.0, tau2=0.0,  T3=0.0, I3=0.0, tau3=0.0,  n_mod=10,
+    T1=0.0, I1=0.0, tau1=0.000125, T2=0.0, I2=0.0, tau2=0.0, T3=0.0, I3=0.0, tau3=0.0, n_mod=10,
     I_um=0.0, tau_um=0.000012, n_um=5, chi_um=2.5, kap_um=2.2)
 OUTPUT PARAMETERS ()
 /* Neutron parameters: (x,y,z, vx,vy,vz, t, sx,sy,sz, p) */
@@ -102,13 +105,12 @@ SHARE
   $M(\lambda)=\frac{2k_{T h}^{2}}{T^2\lambda^{5}}e^{-\frac{k_{T h}}{T\lambda^{2}}}$
   */
   #pragma acc routine
-  double Maxwell(double lmbd, double temp)
+  double Maxwell(double lmbd, double temperature)
   {
     double a, M=0.0;
-
-    if (temp > 0.0 && lmbd > 0.0)
-    { a = 949.29/temp;
-      M = 2.0*a*a*exp(-a/(lmbd*lmbd))/pow(lmbd,5);
+    if (temperature > 0.0 && lmbd > 0.0)
+    { a = 949.29 / temperature;
+      M = 2.0 * a*a * exp(-a / (lmbd*lmbd)) / pow(lmbd, 5);
     }
     return M;
   }
@@ -118,8 +120,8 @@ SHARE
   double Mezei_N_fct(double lmbd, double chi, double kappa)
   {
     if (lmbd > 0.0)
-      return 1.0 / (1.0 + exp(chi*lmbd-kappa)) / lmbd;
-    else 
+      return 1.0 / (1.0 + exp(chi * lmbd - kappa)) / lmbd;
+    else
       return 0.0;
   }
 
@@ -130,7 +132,7 @@ SHARE
   double Mezei_i_fct(double time, double tau, double n)
   {
     if (n > 1.0 && tau > 0.0)
-      return (exp(-time/(tau/n)) - n*exp(-time/tau)) / (n-1);
+      return (exp(-time / (tau / n)) - n*exp(-time / tau)) / (n - 1);
     else
       return 0.0;
   }
@@ -139,15 +141,14 @@ SHARE
   Models the normalized time-dependent flux of a long pulse,
   ensuring the total flux integrates to 1 over the pulse duration.*/
   #pragma acc routine
-  double Mezei_I_fct(double time, double tau, double n, double length)
+  double Mezei_I_fct(double time, double tau, double n, double pulse_length)
   {
-    if (time <= 0.0  || tau <= 0.0 || n <= 1.0 || length <= 0.0)
+    if (time <= 0.0  || tau <= 0.0 || n <= 1.0 || pulse_length <= 0.0)
       return 0.0;
-    else if (time <= length)
-      return (Mezei_i_fct(time, tau, n)+1.0) / length;
+    else if (time <= pulse_length)
+      return (Mezei_i_fct(time, tau, n) + 1.0) / pulse_length;
     else  /* time is greater than the proton pulse */
-      return (  Mezei_i_fct(time,        tau, n)
-              - Mezei_i_fct(time-length, tau, n)) / length;
+      return (Mezei_i_fct(time, tau, n) - Mezei_i_fct(time - pulse_length, tau, n)) / pulse_length;
   }
 %}
 
@@ -164,11 +165,15 @@ DECLARE
 INITIALIZE
 %{
   /* Initial check of the input parameters */
-  if (   xwidth < 0.0 ||  yheight  < 0.0 ||   radius < 0.0 ||    r_i < 0.0 ||   Lmin < 0.0  ||  Lmax < 0.0
-      ||  dist  < 0.0 || focus_xw  < 0.0 || focus_yh < 0.0 ||   freq < 0.0 || t_pulse < 0.0 ||  tmax_multiplier < 0.0
-      ||     T1 < 0.0 ||        I1 < 0.0 ||     tau1 < 0.0 ||     T2 < 0.0 ||      I2 < 0.0
-      ||   tau2 < 0.0 ||        T3 < 0.0 ||       I3 < 0.0 ||   tau3 < 0.0 ||   n_mod < 0.0
-      ||   I_um < 0.0 ||    tau_um < 0.0 ||     n_um < 0.0 || chi_um < 0.0 ||  kap_um < 0.0)
+  if (     xwidth < 0.0 ||  yheight  < 0.0 ||           radius < 0.0
+      ||      r_i < 0.0 ||      Lmin < 0.0 ||             Lmax < 0.0
+      ||    dist  < 0.0 || focus_xw  < 0.0 ||         focus_yh < 0.0
+      ||     freq < 0.0 ||   t_pulse < 0.0 ||  tmax_multiplier < 0.0
+      ||       T1 < 0.0 ||        I1 < 0.0 ||             tau1 < 0.0
+      ||       T2 < 0.0 ||        I2 < 0.0 ||             tau2 < 0.0
+      ||       T3 < 0.0 ||        I3 < 0.0 ||             tau3 < 0.0
+      ||    n_mod < 0.0 ||      I_um < 0.0 ||           tau_um < 0.0
+      ||     n_um < 0.0 ||    chi_um < 0.0 ||           kap_um < 0.0)
   {
       printf("Source_pulsed_multi: %s: Error: negative input parameter!\n"
              "ERROR          Exiting\n", NAME_CURRENT_COMP);
@@ -193,19 +198,19 @@ INITIALIZE
       exit(-1);
   }
 
-  /* Automatic distance */
-  if (target_index > 0 && dist==0.0)
+  /* Automatic distance to the target */
+  if (target_index > 0 && dist == 0.0)
   {
     Coords ToTarget;
     double tx,ty,tz;
-    ToTarget = coords_sub(POS_A_COMP_INDEX(INDEX_CURRENT_COMP+target_index),POS_A_CURRENT_COMP);
+    ToTarget = coords_sub(POS_A_COMP_INDEX(INDEX_CURRENT_COMP + target_index), POS_A_CURRENT_COMP);
     ToTarget = rot_apply(ROT_A_CURRENT_COMP, ToTarget);
     coords_get(ToTarget, &tx, &ty, &tz);
-    dist=sqrt(tx*tx+ty*ty+tz*tz);
+    dist=sqrt(tx*tx + ty*ty + tz*tz);
   }
 
   /* Pulse parameters */
-  t_period = 1.0/freq;
+  t_period = 1.0 / freq;
   alpha    = t_pulse / t_period;
 
   /* Area for different moderator shapes */
@@ -215,19 +220,19 @@ INITIALIZE
   }
   else if (radius > 0.0)
   {
-    area  = 10000.0 * PI*radius*radius;
+    area  = 10000.0 * PI * radius*radius;
   }
   else
   {
-    printf("Source_pulsed_multi: %s: Error: The shape of the source is not set! Use xwidth/yheight or radius. \n"
+    printf("Source_pulsed_multi: %s: Error: The shape of the source is not set! Use xwidth/yheight or radius\n"
            "ERROR          Exiting\n", NAME_CURRENT_COMP);
     exit(-1);
   }
   p_in = (Lmax - Lmin) * (t_pulse * tmax_multiplier) / mcget_ncount();
 
-  /* Set the number of pulses to an integer */
-  n_pulses=(double)floor(n_pulses);
-  if (n_pulses < 1) n_pulses=1;
+  /* Set the number of desired pulses to an integer */
+  n_pulses = (double)floor(n_pulses);
+  if (n_pulses < 1) n_pulses = 1;
 %}
 
 
@@ -246,31 +251,34 @@ TRACE
          Omega,  /* [sr]   Solid angle of the target                                   */
          flux;   /* [1/(cm^2 s Ang sr]  Flux(lambda,time)                              */
 
-  /* Choose the starting point on the moderator surface with uniform distribution for different moderator shapes */
+  /* Choose the starting point on the moderator surface
+  with uniform distribution for different moderator shapes */
   if (xwidth > 0.0 && yheight > 0.0)
-  { 
-    x = xwidth* (rand01() - 0.5);
-    y = yheight*(rand01() - 0.5);
+  {
+    x =  xwidth * (rand01() - 0.5);
+    y = yheight * (rand01() - 0.5);
   }
   else
-  { phi = 2*PI*rand01();          
-    r = sqrt(rand01())*radius; 
-    x = r*cos(phi);
-    y = r*sin(phi);
+  { phi = 2 * PI * rand01();
+    r = sqrt(rand01()) * radius;
+    x = r * cos(phi);
+    y = r * sin(phi);
   }
   z = 0.0;
 
-  /* Set zero polarization, choose wavelength and starting time */
+  /* Set the starting polarization to zero */
   sx = 0.0;
   sy = 0.0;
   sz = 0.0;
 
-  lambda = Lmin  + (Lmax  - Lmin)  * rand01();     
-  t      = t_pulse * tmax_multiplier * rand01(); 
-  
-  /* Propagate to target */
+  /* Choose random wavelength and starting time */
+  lambda = Lmin + (Lmax - Lmin) * rand01();
+  t = t_pulse * tmax_multiplier * rand01();
+
+  /* Propagate to the target */
   randvec_target_rect_real(&xf, &yf, &rf, &Omega,
-                           0, 0, dist, focus_xw, focus_yh, ROT_A_CURRENT_COMP, x, y, z, 2);
+                           0, 0, dist, focus_xw, focus_yh,
+                           ROT_A_CURRENT_COMP, x, y, z, 2);
 
   /* Length of the flight path */
   dx = xf - x;
@@ -279,19 +287,19 @@ TRACE
 
   /* Speed of the neutron */
   v  = 3956.0346 / lambda;
-  vx = v*dx/rf;
-  vy = v*dy/rf;
-  vz = v*dist/rf;
+  vx = v * dx / rf;
+  vy = v * dy / rf;
+  vz = v * dist / rf;
 
   /* Weight: flux in [1/(cm^2 s Ang sr] */
-  flux = I_um * Mezei_N_fct(lambda, chi_um, kap_um) * Mezei_I_fct(t, tau_um, n_um,  t_pulse);
+  flux = I_um * Mezei_N_fct(lambda, chi_um, kap_um) * Mezei_I_fct(t, tau_um, n_um, t_pulse);
   if (r_i==0.0 || r <= r_i)
-    flux += I1 * Maxwell(lambda, T1) * Mezei_I_fct(t, tau1,   n_mod, t_pulse); 
+    flux += I1 * Maxwell(lambda, T1) * Mezei_I_fct(t, tau1, n_mod, t_pulse);
   if (r_i==0.0 || r > r_i)
-    flux += I2 * Maxwell(lambda, T2) * Mezei_I_fct(t, tau2,   n_mod, t_pulse); 
-  flux  +=  I3 * Maxwell(lambda, T3) * Mezei_I_fct(t, tau3,   n_mod, t_pulse);
+    flux += I2 * Maxwell(lambda, T2) * Mezei_I_fct(t, tau2, n_mod, t_pulse); 
+  flux   += I3 * Maxwell(lambda, T3) * Mezei_I_fct(t, tau3, n_mod, t_pulse);
 
-  /* Assign this neutron to a random pulse */
+  /* Assign this neutron to a random pulse among the specified n_pulses */
   t += (double)floor((n_pulses)*rand01())/freq;
   /* The value of p remains consistent since the intensity spreads over n_pulses */
   p  = flux * area* Omega * p_in;  /*  [1]   neutrons per pulse       */
@@ -303,17 +311,17 @@ TRACE
 
 MCDISPLAY
 %{
-  double edge;  /* [m]  x and y position on the circle */
+  double edge;  /* [m] x and y position on the circle */
 
-  if (dist > 0.0) 
+  if (dist > 0.0)
   {
-    if (xwidth > 0.0 && yheight > 0.0) 
+    if (xwidth > 0.0 && yheight > 0.0)
     {
       rectangle("xy", 0,0,0, xwidth,yheight);
-      dashed_line(-xwidth/2, -yheight/2, 0, -focus_xw/2,-focus_yh/2, dist, 4);
-      dashed_line( xwidth/2, -yheight/2, 0,  focus_xw/2,-focus_yh/2, dist, 4);
-      dashed_line( xwidth/2,  yheight/2, 0,  focus_xw/2, focus_yh/2, dist, 4);
-      dashed_line(-xwidth/2,  yheight/2, 0, -focus_xw/2, focus_yh/2, dist, 4);
+      dashed_line(-xwidth/2, -yheight/2, 0, -focus_xw/2, -focus_yh/2, dist, 4);
+      dashed_line( xwidth/2, -yheight/2, 0,  focus_xw/2, -focus_yh/2, dist, 4);
+      dashed_line( xwidth/2,  yheight/2, 0,  focus_xw/2,  focus_yh/2, dist, 4);
+      dashed_line(-xwidth/2,  yheight/2, 0, -focus_xw/2,  focus_yh/2, dist, 4);
     }
     else
     {
@@ -321,10 +329,10 @@ MCDISPLAY
       if (r_i > 0.0)
         circle("xy", 0,0,0, r_i);
       edge = radius/sqrt(2.0);
-      dashed_line(-edge, -edge, 0, -focus_xw/2,-focus_yh/2, dist, 4);
-      dashed_line( edge, -edge, 0,  focus_xw/2,-focus_yh/2, dist, 4);
-      dashed_line( edge,  edge, 0,  focus_xw/2, focus_yh/2, dist, 4);
-      dashed_line(-edge,  edge, 0, -focus_xw/2, focus_yh/2, dist, 4);
+      dashed_line(-edge, -edge, 0, -focus_xw/2, -focus_yh/2, dist, 4);
+      dashed_line( edge, -edge, 0,  focus_xw/2, -focus_yh/2, dist, 4);
+      dashed_line( edge,  edge, 0,  focus_xw/2,  focus_yh/2, dist, 4);
+      dashed_line(-edge,  edge, 0, -focus_xw/2,  focus_yh/2, dist, 4);
     }
   }
 %}

--- a/mcstas-comps/contrib/Source_pulsed_multi.comp
+++ b/mcstas-comps/contrib/Source_pulsed_multi.comp
@@ -23,16 +23,16 @@
 * and the surrounding ring is at temperature T2.
 * The third Maxwellian distribution at temperature T3 always comes from anywhere in the moderator.
 *
-* Parameters xwidth and yheight must be provided for rectangular moderators, otherwise a circular shape is assumed.
-*
 * Multiple pulses can be simulated over time with the n_pulses parameter,
 * in contrast to the Source_pulsed component, which only simulates a single pulse.
 * Note that the intensity spreads over n_pulses, so that the units of neutrons per second are preserved.
 *
+* Parameters xwidth and yheight must be provided for rectangular moderators, otherwise a circular shape is assumed.
+*
 * Usage example: 
 *   Source_pulsed_multi(xwidth=0.04, yheight=0.04, Lmin=1.0, Lmax=3.0, n_pulses=2,
 *                       dist=0.700, focus_xw=0.020, focus_yh=0.020, freq=96.0, t_pulse=0.000208,
-*                       T1=325.0, I1=7.6e09, tau1=0.000170, I_um=2.7e08, chi_um=2.5)
+*                       T1=325.0, I1=7.6e9, tau1=0.000170, I_um=2.7e8, chi_um=2.5)
 *
 * Parameters for some sources:
 *

--- a/mcstas-comps/examples/Tests_sources/Test_Source_custom/test_Source_custom.instr
+++ b/mcstas-comps/examples/Tests_sources/Test_Source_custom/test_Source_custom.instr
@@ -20,7 +20,7 @@
 * Written by: Pablo Gila-Herranz
 * Date: 15:36:54 on April 04, 2025
 * Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
-* %INSTRUMENT_SITE: Generated_instruments
+* %INSTRUMENT_SITE: Tests_sources
 * 
 * 
 * %Parameters

--- a/mcstas-comps/examples/Tests_sources/Test_Source_custom/test_Source_custom.instr
+++ b/mcstas-comps/examples/Tests_sources/Test_Source_custom/test_Source_custom.instr
@@ -1,0 +1,72 @@
+/********************************************************************************
+* 
+* McStas, neutron ray-tracing package
+*         Copyright (C) 1997-2008, All rights reserved
+*         Risoe National Laboratory, Roskilde, Denmark
+*         Institut Laue Langevin, Grenoble, France
+* 
+* This file was written by McStasScript, which is a 
+* python based McStas instrument generator written by 
+* Mads Bertelsen in 2019 while employed at the 
+* European Spallation Source Data Management and 
+* Software Centre
+*
+* This is a test file for the Source_custom component
+* Using the parameters for the HBS bi-spectral source
+* 
+* Instrument test_HBS_bispectral_Source_custom
+* 
+* %Identification
+* Written by: Pablo Gila-Herranz
+* Date: 15:36:54 on April 04, 2025
+* Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
+* %INSTRUMENT_SITE: Generated_instruments
+* 
+* 
+* %Parameters
+* 
+* %End 
+********************************************************************************/
+
+DEFINE INSTRUMENT test_HBS_bispectral_Source_custom (
+)
+
+DECLARE 
+%{
+%}
+
+INITIALIZE 
+%{
+%}
+
+TRACE 
+COMPONENT source = Source_custom(
+ target_index = 1, focus_xw = 0.04,
+ focus_yh = 0.04, radius = 0.022,
+ r_i = 0.01, Lmin = 0.2,
+ Lmax = 10, freq = 24,
+ t_pulse = 0.016, tmax_multiplier = 3,
+ n_pulses = 2, T1 = 60,
+ I1 = 1.75E+12, tau1 = 0.00017,
+ T2 = 305, I2 = 5.6E+11,
+ tau2 = 0.00013, n_mod = 1,
+ I_um = 3.82E+10, chi_um = 2.5)
+AT (0,0,0) ABSOLUTE
+
+COMPONENT TOF_monitor = TOF_monitor(
+ nt = 100, xwidth = 0.04,
+ yheight = 0.04, tmin = 0,
+ tmax = 80000, restore_neutron = 1)
+AT (0,0,10) ABSOLUTE
+
+COMPONENT L_monitor = L_monitor(
+ nL = 100, xwidth = 0.04,
+ yheight = 0.04, Lmin = 0.2,
+ Lmax = 10, restore_neutron = 1)
+AT (0,0,10) ABSOLUTE
+
+FINALLY 
+%{
+%}
+
+END


### PR DESCRIPTION
Hi there!

I noticed that the contributed component Source_pulsed, while very customisable, only simulates the very first pulse of the beam. This may be the desired behaviour for some use cases, but others may need to simulate more pulses.

I have created a new contributed component, ~Source_pulsed_multi~ Source_custom, which simulates all expected pulses in the specified time interval. It is a modification of the previously mentioned Source_pulsed. All component parameters remain the same and the component documentation is up to date.

Attached is a simple test instrument to demonstrate the proper behavior of the proposed component:
[Source_pulsed_multi.zip](https://github.com/user-attachments/files/19509589/Source_pulsed_multi.zip)

The output signal from the test instrument with the previous Source_pulsed component:
![Source_pulsed](https://github.com/user-attachments/assets/f7fc3f5b-b874-4516-88a9-88e65db7477a)

And the output signal with the new Source_pulsed_multi component:
![Source_pulsed_multi](https://github.com/user-attachments/assets/9a080377-a0b8-4435-9d68-516269c3164d)

