### PR TITLE
Input flag -y / --yes applies all instrument parameter default values

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -4809,7 +4809,9 @@ mcparseoptions(int argc, char *argv[])
     }
   }
   if (mcusedefaults) {
-    printf("Using all default parameter values\n");
+    MPI_MASTER(
+     printf("Using all default parameter values\n");
+    );
     for(j = 0; j < numipar; j++) {
       int status;
       if(mcinputtable[j].val && strlen(mcinputtable[j].val)){

--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -60,6 +60,7 @@ static   long mcseed                 = 0; /* seed for random generator */
 static   long mcstartdate            = 0; /* start simulation time */
 static   int  mcdisable_output_files = 0; /* --no-output-files */
 mcstatic int  mcgravitation          = 0; /* use gravitation flag, for PROP macros */
+mcstatic int  mcusedefaults          = 0; /* assume default value for all parameters */
 mcstatic int  mcdotrace              = 0; /* flag for --trace and messages for DISPLAY */
 mcstatic int  mcnexus_embed_idf      = 0; /* flag to embed xml-formatted IDF file for Mantid */
 #pragma acc declare create ( mcdotrace )
@@ -4432,6 +4433,7 @@ mchelp(char *pgmname)
 "  -h        --help           Show this help message.\n"
 "  -i        --info           Detailed instrument information.\n"
 "  --list-parameters          Print the instrument parameters to standard out\n"
+"  -y        --yes            Assume default values for all parameters with a default\n"
 "  --meta-list                Print names of components which defined metadata\n"
 "  --meta-defined COMP[:NAME] Print component defined metadata names, or (0,1) if NAME provided\n"
 "  --meta-type COMP:NAME      Print metadata format type specified in definition\n"
@@ -4720,6 +4722,10 @@ mcparseoptions(int argc, char *argv[])
       mcgravitation = 1;
     else if(!strcmp("-g", argv[i]))
       mcgravitation = 1;
+    else if(!strcmp("--yes", argv[i]))
+      mcusedefaults = 1;
+    else if(!strcmp("-y", argv[i]))
+      mcusedefaults = 1;
     else if(!strncmp("--format=", argv[i], 9)) {
       mcformat=&argv[i][9];
     }
@@ -4800,6 +4806,18 @@ mcparseoptions(int argc, char *argv[])
     else {
       fprintf(stderr, "Error: unrecognized argument %s (mcparseoptions). Aborting.\n", argv[i]);
       mcusage(argv[0]);
+    }
+  }
+  if (mcusedefaults) {
+    printf("Using all default parameter values\n");
+    for(j = 0; j < numipar; j++) {
+      int status;
+      if(mcinputtable[j].val && strlen(mcinputtable[j].val)){
+	status = (*mcinputtypes[mcinputtable[j].type].getparm)(mcinputtable[j].val,
+                        mcinputtable[j].par);
+	paramsetarray[j] = 1;
+	paramset = 1;
+      }
     }
   }
   if(!paramset)

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -326,7 +326,7 @@ class McStas:
                 args.extend([f'--{opt}=' + str(val)])
 
         # Handle proxy options without values (flags)
-        proxy_opts_flags = ['no-output-files', 'info', 'list-parameters', 'meta-list']
+        proxy_opts_flags = ['no-output-files', 'info', 'list-parameters', 'meta-list', 'yes']
         if mccode_config.configuration["MCCODE"] == 'mcstas':
             proxy_opts_flags.append('gravitation')
 

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -265,6 +265,10 @@ def add_mcstas_options(parser):
         metavar='trace', type=int, default=0,
         help='Enable trace of %s through instrument' % (mccode_config.configuration["PARTICLE"]))
 
+    add('-y', '--yes',
+        action='store_true', default=False,
+        help='Assume any default parameter value in instrument')
+
     if (mccode_config.configuration["MCCODE"] == 'mcstas'):
         add('-g', '--gravitation', '--gravity',
             action='store_true', default=False,


### PR DESCRIPTION
Feature suggested by @tkittel: 
'Why not have a `-y` flag to apply all default parameter values?'

Example run:
```
mcrun BNL_H8.instr -y
INFO: No output directory specified (--dir)
INFO: Using directory: "BNL_H8_20250330_193022"
INFO: Using existing c-file: ./BNL_H8.c
INFO: Using existing binary: ./BNL_H8.out
INFO: ===
Using all default parameter values
Instrument:     BNL_H8 on localhost.
Monochromator : DM = 3.3539
A1 = 20.60, A2 = 41.20 (deg)
Ki = 2.662 Angs-1 Energy = 14.69 meV
Velocity = 1676 m/s, lambda = 2.36 Angs
[BNL_H8] Initialize
*** TRACE end *** 

Save [BNL_H8]
Detector: D0_Source_I=0.00315452 D0_Source_ERR=1.39164e-05 D0_Source_N=51382 "D0_Source.psd"
Detector: D1_SC1_Out_I=0.0204023 D1_SC1_Out_ERR=3.53787e-05 D1_SC1_Out_N=334459 "D1_SC1_Out.psd"
Detector: D2_A4_I=0.0137362 D2_A4_ERR=2.90321e-05 D2_A4_N=225529 "D2_A4.psd"
Detector: D4_SC2_In_I=0.00154076 D4_SC2_In_ERR=3.07455e-06 D4_SC2_In_N=254958 "D4_SC2_In.psd"
Detector: D5_SC2_Out_I=0.00120478 D5_SC2_Out_ERR=2.71847e-06 D5_SC2_Out_N=200863 "D5_SC2_Out.psd"
Detector: D7_SC3_In_I=1.23664e-07 D7_SC3_In_ERR=2.2403e-10 D7_SC3_In_N=334568 "D7_SC3_In.psd"
Detector: D8_SC3_Out_I=2.37635e-08 D8_SC3_Out_ERR=9.86441e-11 D8_SC3_Out_N=63749 "D8_SC3_Out.psd"
Detector: D10_SC4_In_I=1.23523e-09 D10_SC4_In_ERR=7.13458e-12 D10_SC4_In_N=32931 "D10_SC4_In.psd"
Detector: He3H_I=9.5655e-10 He3H_ERR=6.27794e-12 He3H_N=25482 "He3.psd"

Finally [BNL_H8: BNL_H8_20250330_193022]. Time: 1 [s] 
INFO: Placing instr file copy BNL_H8.instr in dataset BNL_H8_20250330_193022
INFO: Placing generated c-code copy BNL_H8.c in dataset BNL_H8_20250330_193022

```

The only argument against this feature is that some instruments _may_ not have defaults defined for all inputs, which will then currently lead to a runtime error like this:
`Error: Instrument parameter filename left unset (mcparseoptions)`
(The same error occurs if defaults are applied via setting some / leaving the rest in such instruments.)

@g5t, @mads-bertelsen, @farhi, @tweber-ill is this a good idea or not? 
(The standard behaviour of setting one value and assuming default for the rest is still functional.)


