### PR TITLE
Update MCPL_input.comp

### DIFF
--- a/mcstas-comps/misc/MCPL_input.comp
+++ b/mcstas-comps/misc/MCPL_input.comp
@@ -137,7 +137,7 @@ INITIALIZE
 #endif
 
     MPI_MASTER(
-      printf(stdout, "%s",tmpstr);
+      fprintf(stdout, "%s",tmpstr);
     );
     read_neutrons=0;
     used_neutrons=0;


### PR DESCRIPTION
One of the two possible fixes for #1923 -- `fprintf` chosen in case `stdout` can somehow be replaced by a normal file somewhere else, and this output would be expected there.