### PR TITLE
Allow suppressing conda fancyness

### DIFF
--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -182,7 +182,7 @@ class McStas:
         # conservative we (for now?) only apply this when both CONDA_PREFIX and
         # LDFLAGS/CFLAGS are set (C++/Fortran would use CXXFLAGS/FFLAGS instead
         # of CFLAGS):
-        if configuration['ISCONDAPKG']=='1' and os.environ.get('CONDA_PREFIX'):
+        if mccode_config.configuration['ISCONDAPKG']=='1' and os.environ.get('CONDA_PREFIX'):
             if os.environ.get('LDFLAGS'):
                 cflags += os.environ.get('LDFLAGS') + " "
             if os.environ.get('CFLAGS'):

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -182,7 +182,7 @@ class McStas:
         # conservative we (for now?) only apply this when both CONDA_PREFIX and
         # LDFLAGS/CFLAGS are set (C++/Fortran would use CXXFLAGS/FFLAGS instead
         # of CFLAGS):
-        if os.environ.get('CONDA_PREFIX'):
+        if configuration['ISCONDAPKG']=='1' and os.environ.get('CONDA_PREFIX'):
             if os.environ.get('LDFLAGS'):
                 cflags += os.environ.get('LDFLAGS') + " "
             if os.environ.get('CFLAGS'):


### PR DESCRIPTION
If not build with `-DMCCODE_BUILD_CONDA_PKG=ON`, drop handling CONDA_PREFIX labels internally in mcrun.