### PR TITLE
Helmholtz hackathon 2025 limit device2host transfers

### DIFF
--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1496,7 +1496,9 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
     // (first thing to do in "finally")
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
-      coutf("#pragma acc update host(_%s_var)", comp->name);
+      if(!strcmp(comp->def->name,"onitor")) {
+	  coutf("#pragma acc update host(_%s_var)", comp->name);
+      }
     }
     // attach instrument
     cout("#pragma acc update host(_instrument_var)");

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1497,10 +1497,10 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
       if(!strcmp(comp->def->name,"onitor")) {
-	printf("%s looks like a monitor (%s)\n",comp->name, comp->def-name);
+	printf("%s looks like a monitor (%s)\n",comp->name, comp->def->name);
 	coutf("#pragma acc update host(_%s_var)", comp->name);
       } else {
-	printf("%s likely not a monitor (%s)\n",comp->name, comp->def-name);
+	printf("%s likely not a monitor (%s)\n",comp->name, comp->def->name);
       }
     }
     // attach instrument

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1497,7 +1497,10 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
       if(!strcmp(comp->def->name,"onitor")) {
-	  coutf("#pragma acc update host(_%s_var)", comp->name);
+	printf("%s looks like a monitor (%s)\n",comp->name, comp->def-name);
+	coutf("#pragma acc update host(_%s_var)", comp->name);
+      } else {
+	printf("%s likely not a monitor (%s)\n",comp->name, comp->def-name);
       }
     }
     // attach instrument

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1496,7 +1496,7 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
     // (first thing to do in "finally")
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
-      if(!strcmp(comp->def->name,"onitor")) {
+      if(strstr(comp->def->name,"onitor")) {
 	printf("%s looks like a monitor (%s)\n",comp->name, comp->def->name);
 	coutf("#pragma acc update host(_%s_var)", comp->name);
       } else {

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1496,7 +1496,7 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
     // (first thing to do in "finally")
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
-      if(strstr(comp->def->name,"onitor")) {
+      if(strstr(comp->def->name,"onitor")||strstr(comp->def->name,"MCPL_output")) {
 	printf("Adding GPU #pragma acc update device(%s)\n",comp->name, comp->def->name);
 	coutf("#pragma acc update host(_%s_var)", comp->name);
       }

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1501,7 +1501,7 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
       }
     }
     // attach instrument
-    cout("#pragma acc update host(_instrument_var)");
+    //cout("#pragma acc update host(_instrument_var)");
     cout("");
 
     coutf("  siminfo_init(NULL);");

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -1497,10 +1497,8 @@ int cogen_section(struct instr_def *instr, char *section, char *section_lower,
     liter = list_iterate(instr->complist);
     while((comp = list_next(liter)) != NULL) {
       if(strstr(comp->def->name,"onitor")) {
-	printf("%s looks like a monitor (%s)\n",comp->name, comp->def->name);
+	printf("Adding GPU #pragma acc update device(%s)\n",comp->name, comp->def->name);
 	coutf("#pragma acc update host(_%s_var)", comp->name);
-      } else {
-	printf("%s likely not a monitor (%s)\n",comp->name, comp->def->name);
       }
     }
     // attach instrument


### PR DESCRIPTION
The edits here suppress the device->host copy of instrument struct and non-monitor comps.