### PR TITLE
DONT MERGE YET: PowderN: remove a static variable declare from SHARE section

### DIFF
--- a/CHANGES_McStas
+++ b/CHANGES_McStas
@@ -3468,7 +3468,7 @@ Changes in McStas v1.6-ill (alpha), October 29th, 2001.
       -USR2: finish simulation and save results
       -QUIT: end simulation immediately
  - The 2D detectors now also output the errors/counts on signal as 1D detectors.
-   Set p2=NULL in DETECTOR_OUT_2D to unactivate error saving in components.
+   Set p2=NULL in DETECTOR_OUT_2D to inactivate error saving in components.
  - We tried to lower the number of components by merging similar ones.
  - There are now new MACROS for the component programmer.
      * mccompcurindex is the number (index) of the current component

--- a/common/lib/share/interoff-lib.c
+++ b/common/lib/share/interoff-lib.c
@@ -633,7 +633,7 @@ int off_cleanInOut(intersection* t, int* t_size)
 *        'xwidth,yheight,zdepth' if given as non-zero, apply bounding box.
 *           Specifying only one of these will also use the same ratio on all axes
 *        'notcenter' center the object to the (0,0,0) position in local frame when set to zero
-* RETURN: number of polyhedra and 'data' OFF structure
+* RETURN: number of polyhedral and 'data' OFF structure
 *******************************************************************************/
 long off_init(  char *offfile, double xwidth, double yheight, double zdepth,
                 int notcenter, off_struct* data)
@@ -1018,7 +1018,7 @@ int quadraticSolve(double* eq, double* x1, double* x2)
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         ax, ay, az are the local acceleration vector
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 *         data is the full OFF structure, including a list intersection type
@@ -1136,7 +1136,7 @@ int off_intersect_all(double* t0, double* t3,
 * ACTION: computes intersection of neutron trajectory with an object.
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 *******************************************************************************/
@@ -1159,7 +1159,7 @@ int off_intersect(double* t0, double* t3,
 * ACTION: computes intersection of an xray trajectory with an object.
 * INPUT:  x,y,z and kx,ky,kz, are spatial coordinates and wavevector of the x-ray
 *         respectively. data points to the OFF data structure.
-* RETURN: the number of polyhedra the trajectory intersects
+* RETURN: the number of polyhedral the trajectory intersects
 *         l0 and l3 are the smallest incoming and outgoing intersection lengths
 *         n0 and n3 are the corresponding normal vectors to the surface
 *******************************************************************************/

--- a/common/lib/share/interoff-lib.h
+++ b/common/lib/share/interoff-lib.h
@@ -93,7 +93,7 @@ typedef struct off_struct {
 *        'xwidth,yheight,zdepth' if given as non-zero, apply bounding box.
 *           Specifying only one of these will also use the same ratio on all axes
 *        'notcenter' center the object to the (0,0,0) position in local frame when set to zero
-* RETURN: number of polyhedra and 'data' OFF structure
+* RETURN: number of polyhedral and 'data' OFF structure
 *******************************************************************************/
 long off_init(  char *offfile, double xwidth, double yheight, double zdepth,
                 int notcenter, off_struct* data);
@@ -109,7 +109,7 @@ long off_init(  char *offfile, double xwidth, double yheight, double zdepth,
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         ax, ay, az are the local acceleration vector
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 *         data is the full OFF structure, including a list intersection type
@@ -133,7 +133,7 @@ int off_intersect_all(double* t0, double* t3,
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         ax, ay, az are the local acceleration vector
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 *******************************************************************************/
@@ -154,7 +154,7 @@ int off_intersect(double* t0, double* t3,
 * ACTION: computes intersection of an xray trajectory with an object.
 * INPUT:  x,y,z and kx,ky,kz, are spatial coordinates and wavevector of the x-ray
 *         respectively. data points to the OFF data structure.
-* RETURN: the number of polyhedra the trajectory intersects
+* RETURN: the number of polyhedral the trajectory intersects
 *         l0 and l3 are the smallest incoming and outgoing intersection lengths
 *         n0 and n3 are the corresponding normal vectors to the surface
 *******************************************************************************/

--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -1838,7 +1838,7 @@ static void mccomp_param_nexus(NXhandle nxhandle, char* component, char* paramet
     if (NXopengroup(nxhandle, "instrument", "NXinstrument") == NX_OK) {
       if (NXopengroup(nxhandle, "components", "NXdata") == NX_OK) {
 	if (NXopengroup(nxhandle, component, "NXdata") == NX_OK) {
-	  NXMDisableErrorReporting(); /* unactivate NeXus error messages, as creation may fail */
+	  NXMDisableErrorReporting(); /* inactivate NeXus error messages, as creation may fail */
 	  NXmakegroup(nxhandle, "parameters", "NXdata");
 	  NXMEnableErrorReporting();  /* re-enable NeXus error messages */
 	  if (NXopengroup(nxhandle, "parameters", "NXdata") == NX_OK) {
@@ -1892,7 +1892,7 @@ mcdatainfo_out_nexus(NXhandle f, MCDETECTOR detector)
   /* the NXdetector group has been created in mcinfo_out_nexus (siminfo_init) */
   if (NXopengroup(f, "instrument", "NXinstrument") == NX_OK) {
     if (NXopengroup(f, "components", "NXdata") == NX_OK) {
-      NXMDisableErrorReporting(); /* unactivate NeXus error messages, as creation may fail */
+      NXMDisableErrorReporting(); /* inactivate NeXus error messages, as creation may fail */
       NXmakegroup(f, detector.nexuscomp, "NXdata");
       if (NXopengroup(f, detector.nexuscomp, "NXdata") == NX_OK) {
 	NXmakegroup(f, "output", "NXdetector");
@@ -2014,7 +2014,7 @@ int mcdetector_out_array_nexus(NXhandle f, char *part, double *data, MCDETECTOR 
   if (strcasestr(detector.format, "list")) fulldims[0] = NX_UNLIMITED;
 
   /* create the data set in NXdata group */
-  NXMDisableErrorReporting(); /* unactivate NeXus error messages, as creation may fail */
+  NXMDisableErrorReporting(); /* inactivate NeXus error messages, as creation may fail */
   ret = NXcompmakedata64(f, part, NX_FLOAT64, detector.rank, fulldims, NX_COMPRESSION, dims);
   if (ret != NX_OK) {
     /* failed: data set already exists */

--- a/common/lib/share/r-interoff-lib.c
+++ b/common/lib/share/r-interoff-lib.c
@@ -632,7 +632,7 @@ int r_off_cleanInOut(r_intersection* t, int* t_size)
 *        'xwidth,yheight,zdepth' if given as non-zero, apply bounding box.
 *           Specifying only one of these will also use the same ratio on all axes
 *        'notcenter' center the object to the (0,0,0) position in local frame when set to zero
-* RETURN: number of polyhedra and 'data' OFF structure
+* RETURN: number of polyhedral and 'data' OFF structure
 *******************************************************************************/
 long r_off_init(  char *offfile, double xwidth, double yheight, double zdepth,
                 int notcenter, r_off_struct* data)
@@ -1045,7 +1045,7 @@ int r_quadraticSolve(double* eq, double* x1, double* x2)
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         ax, ay, az are the local acceleration vector
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 * PL:     faceindex0 and faceindex3 are the corresponding indices of the face
@@ -1178,7 +1178,7 @@ int r_off_intersect_all(double* t0, double* t3,
 * ACTION: computes intersection of neutron trajectory with an object.
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 * PL:     faceindex0 and faceindex3 are the corresponding indices of the face
@@ -1204,7 +1204,7 @@ int r_off_intersect(double* t0, double* t3,
 * ACTION: computes intersection of an xray trajectory with an object.
 * INPUT:  x,y,z and kx,ky,kz, are spatial coordinates and wavevector of the x-ray
 *         respectively. data points to the OFF data structure.
-* RETURN: the number of polyhedra the trajectory intersects
+* RETURN: the number of polyhedral the trajectory intersects
 *         l0 and l3 are the smallest incoming and outgoing intersection lengths
 *         n0 and n3 are the corresponding normal vectors to the surface
 * PL:     faceindex0 and faceindex3 are the corresponding indices of the face

--- a/common/lib/share/r-interoff-lib.h
+++ b/common/lib/share/r-interoff-lib.h
@@ -100,7 +100,7 @@ typedef struct r_off_struct {
 *        'xwidth,yheight,zdepth' if given as non-zero, apply bounding box. 
 *           Specifying only one of these will also use the same ratio on all axes
 *        'notcenter' center the object to the (0,0,0) position in local frame when set to zero
-* RETURN: number of polyhedra and 'data' OFF structure 
+* RETURN: number of polyhedral and 'data' OFF structure
 *******************************************************************************/
 long r_off_init(  char *offfile, double xwidth, double yheight, double zdepth, 
                 int notcenter, r_off_struct* data);
@@ -117,7 +117,7 @@ long r_off_init(  char *offfile, double xwidth, double yheight, double zdepth,
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         ax, ay, az are the local acceleration vector
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 *         data is the full OFF structure, including a list intersection type
@@ -143,7 +143,7 @@ int r_off_intersect_all(double* t0, double* t3,
 * INPUT:  x,y,z and vx,vy,vz are the position and velocity of the neutron
 *         ax, ay, az are the local acceleration vector
 *         data points to the OFF data structure
-* RETURN: the number of polyhedra which trajectory intersects
+* RETURN: the number of polyhedral which trajectory intersects
 *         t0 and t3 are the smallest incoming and outgoing intersection times
 *         n0 and n3 are the corresponding normal vectors to the surface
 *******************************************************************************/
@@ -166,7 +166,7 @@ int r_off_intersect(double* t0, double* t3,
 * ACTION: computes intersection of an xray trajectory with an object.
 * INPUT:  x,y,z and kx,ky,kz, are spatial coordinates and wavevector of the x-ray
 *         respectively. data points to the OFF data structure.
-* RETURN: the number of polyhedra the trajectory intersects
+* RETURN: the number of polyhedral the trajectory intersects
 *         l0 and l3 are the smallest incoming and outgoing intersection lengths
 *         n0 and n3 are the corresponding normal vectors to the surface
 *******************************************************************************/

--- a/doc/manuals/mcstas/monitors/Monitor_nD.tex
+++ b/doc/manuals/mcstas/monitors/Monitor_nD.tex
@@ -136,7 +136,7 @@ extension will then be added if the name does not contain a dot (.).
 Finally, the $filename$ parameter may also be used.
 
 The output files format are standard 1D or 2D McStas detector files.
-The \textit{no file} option will \textit{unactivate} monitor, and make it a
+The \textit{no file} option will \textit{inactivate} monitor, and make it a
 single 0D monitor detecting integrated flux and counts.
 The \textit{verbose} option will display the nature of the monitor, and the
 names of the generated files.
@@ -188,7 +188,7 @@ EPSD\_monitor       & \textit{options}="energy bins=$n_E$ limits=[$E_{min} E_{ma
 Hdiv\_monitor       & \textit{options}="dx bins=$nh$ limits=[$-h_{max}/2 h_{max}/2$]" \textit{filename}=$file$ \\
 L\_monitor          & \textit{options}="lambda bins=$nh$ limits=[$-\lambda_{max}/2 \lambda_{max}/2$]" \textit{filename}=$file$ \\
 Monitor\_4PI        & \textit{options}="sphere" \\
-Monitor            & \textit{options}="unactivate" \\
+Monitor            & \textit{options}="inactivate" \\
 PSDcyl\_monitor     & \textit{options}="theta bins=$nr$,y bins=$ny$, cylinder"
 \textit{filename}=$file$ \textit{yheight}=$height$ \textit{xwidth}=2*radius\\
 PSDlin\_monitor     & \textit{options}="x bins=$nx$" \textit{xmin}=$x_{min}$ \textit{xmax}=$x_{max}$ \textit{ymin}=$y_{min}$ \textit{ymax}=$y_{max}$ \textit{filename}=$file$\\

--- a/doc/manuals/mcstas/sources/Source_Optimizer.tex
+++ b/doc/manuals/mcstas/sources/Source_Optimizer.tex
@@ -133,7 +133,7 @@ The keyword modifiers \textit{no} or \textit{not} revert the next option.
 Other options not shown here are:
 \begin{lstlisting}
 verbose         displays optimization process (debug purpose).
-unactivate      to unactivate the Optimizer.
+inactivate      to inactivate the Optimizer.
 file=[name]     Filename where to save optimized source distributions
 \end{lstlisting}
 The \textit{file} option will save the source distributions at the end of

--- a/doc/manuals/mcxtrace/monitors/Monitor_nD.tex
+++ b/doc/manuals/mcxtrace/monitors/Monitor_nD.tex
@@ -138,7 +138,7 @@ extension will then be added if the name does not contain a dot (.).
 Finally, the $filename$ parameter may also be used.
 
 The output files format are standard 1D or 2D McXtrace detector files.
-The \textit{no file} option will \textit{unactivate} monitor, and make it a
+The \textit{no file} option will \textit{inactivate} monitor, and make it a
 single 0D monitor detecting integrated flux and counts.
 The \textit{verbose} option will display the nature of the monitor, and the
 names of the generated files.
@@ -190,7 +190,7 @@ In the following table \ref{t:monitor-nd-equiv}, we show how the Monitor\_nD may
         %Hdiv\_monitor       & \textit{options}="dx bins=$nh$ limits=[$-h_{max}/2 h_{max}/2$]" \textit{filename}=$file$ \\
         L\_monitor          & \textit{options}="lambda bins=$nh$ limits=[$-\lambda_{max}/2 \lambda_{max}/2$]" \textit{filename}=$file$ \\
         %Monitor\_4PI        & \textit{options}="sphere" \\
-        Monitor            & \textit{options}="unactivate" \\
+        Monitor            & \textit{options}="inactivate" \\
         %PSDcyl\_monitor     & \textit{options}="theta bins=$nr$,y bins=$ny$, cylinder"
         %\textit{filename}=$file$ \textit{yheight}=$height$ \textit{xwidth}=2*radius\\
         %PSDlin\_monitor     & \textit{options}="x bins=$nx$" \textit{xmin}=$x_{min}$ \textit{xmax}=$x_{max}$ \textit{ymin}=$y_{min}$ \textit{ymax}=$y_{max}$ \textit{filename}=$file$\\

--- a/mcstas-comps/contrib/Guide_anyshape_r.comp
+++ b/mcstas-comps/contrib/Guide_anyshape_r.comp
@@ -32,7 +32,7 @@
 * In case at least one among m, alpha and W is not null, then Guide_anyshape_g will use these
 * values as input (common for all the faces), ignoring those specified in the OFF file
 *
-* The complex OFF/PLY geometry option handles any closed non-convex polyhedra.
+* The complex OFF/PLY geometry option handles any closed non-convex polyhedral.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).
 *   Standard .OFF files may be generated from XYZ data using:
 *     qhull < coordinates.xyz Qx Qv Tv o > geomview.off

--- a/mcstas-comps/contrib/Lens.comp
+++ b/mcstas-comps/contrib/Lens.comp
@@ -23,7 +23,7 @@
 *   parabolic (use focus1 and focus2 as optical focal length).
 *
 * Optionally, you can specify the 'geometry' parameter as a OFF/PLY file name.
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the PLY, OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/contrib/Source_gen4.comp
+++ b/mcstas-comps/contrib/Source_gen4.comp
@@ -105,7 +105,7 @@
 * xdiv_file: [str]            Name of the x-horiz. divergence distribution file, given as a free format text matrix, preceeded with a line '# xylimits: xmin xmax xdiv_min xdiv_max'
 * ydiv_file: [str]            Name of the y-vert. divergence distribution file, given as a free format text matrix, preceeded with a line '# xylimits: ymin ymax ydiv_min ydiv_max'
 * gaussian: [0/1]             Use gaussian divergence beam, normal distributions
-* verbose: [0/1]              display info about the source. -1 unactivate source.
+* verbose: [0/1]              display info about the source. -1 inactivate source.
 *
 * %L
 * <a href="http://www.ill.fr/Yellowbook">The ILL Yellow book</a>
@@ -451,7 +451,7 @@ INITIALIZE
   }
   else
     if (verbose == -1)
-      printf("Source_gen: component %s unactivated", NAME_CURRENT_COMP);
+      printf("Source_gen: component %s inactivated", NAME_CURRENT_COMP);
 %}
 
 TRACE

--- a/mcstas-comps/examples/ILL/ILL_H22_D1B/ILL_H22_D1B.instr
+++ b/mcstas-comps/examples/ILL/ILL_H22_D1B/ILL_H22_D1B.instr
@@ -50,7 +50,7 @@
 * R_h: [m]         Height of the collimator
 * R_ttmin: [deg]   Lower scattering angle limit
 * R_ttmax: [deg]   Higher scattering angle limit
-* R_present: [1]   Presence flag for the radial collimator. 0: unactivate component.
+* R_present: [1]   Presence flag for the radial collimator. 0: inactivate component.
 * Inc_Cryo: [1]    Cryostat incoherent fraction
 * Trans_Cryo: [1]  Cryostat event transmission
 * Trans_Spl: [1]   Sample event transmission

--- a/mcstas-comps/examples/ILL/ILL_H22_D1B_noenv/ILL_H22_D1B_noenv.instr
+++ b/mcstas-comps/examples/ILL/ILL_H22_D1B_noenv/ILL_H22_D1B_noenv.instr
@@ -50,7 +50,7 @@
 * R_h: [m]         Height of the collimator
 * R_ttmin: [deg]   Lower scattering angle limit
 * R_ttmax: [deg]   Higher scattering angle limit
-* R_present: [1]   Presence flag for the radial collimator. 0: unactivate component.
+* R_present: [1]   Presence flag for the radial collimator. 0: inactivate component.
 * Inc_Cryo: [1]    Cryostat incoherent fraction
 * Trans_Cryo: [1]  Cryostat event transmission
 * Trans_Spl: [1]   Sample event transmission

--- a/mcstas-comps/misc/Annulus.comp
+++ b/mcstas-comps/misc/Annulus.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/misc/Circle.comp
+++ b/mcstas-comps/misc/Circle.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/misc/Cone.comp
+++ b/mcstas-comps/misc/Cone.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/misc/Disc.comp
+++ b/mcstas-comps/misc/Disc.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/misc/Legacy_circle.comp
+++ b/mcstas-comps/misc/Legacy_circle.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/misc/Shape.comp
+++ b/mcstas-comps/misc/Shape.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/misc/Shape_simple.comp
+++ b/mcstas-comps/misc/Shape_simple.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/monitors/Monitor_nD.comp
+++ b/mcstas-comps/monitors/Monitor_nD.comp
@@ -125,7 +125,7 @@
 *     signal=[var]              Will monitor [var] instead of usual intensity
 *     slit or absorb            Absorb neutrons that are out detector
 *     source                    The monitor will save neutron states
-*     unactivate                To unactivate detector (0D detector)
+*     inactivate                To inactivate detector (0D detector)
 *     verbose                   To display additional informations
 *     3He_pressure=[3 in bars]  The 3He gas pressure in detector. 3He_pressure=0 is perfect detector (default)
 *

--- a/mcstas-comps/monitors/Monitor_nD_noacc.comp
+++ b/mcstas-comps/monitors/Monitor_nD_noacc.comp
@@ -125,7 +125,7 @@
 *     signal=[var]              Will monitor [var] instead of usual intensity
 *     slit or absorb            Absorb neutrons that are out detector
 *     source                    The monitor will save neutron states
-*     unactivate                To unactivate detector (0D detector)
+*     inactivate                To inactivate detector (0D detector)
 *     verbose                   To display additional informations
 *     3He_pressure=[3 in bars]  The 3He gas pressure in detector. 3He_pressure=0 is perfect detector (default)
 *

--- a/mcstas-comps/obsolete/Virtual_input.comp
+++ b/mcstas-comps/obsolete/Virtual_input.comp
@@ -40,7 +40,7 @@
 * To create a 'source' file collecting all neutron states, use:
 *   COMPONENT MySourceCreator = Virtual_output(filename = "MySource.list")
 * at the position where will be the Virtual_input.
-* Then unactivate the part of the simulation description before (and including)
+* Then inactivate the part of the simulation description before (and including)
 * the component MySourceCreator. Put the new instrument source:
 *   COMPONENT Source = Virtual_input(filename="MySource.list")
 * at the same position as 'MySourceCreator'.
@@ -49,7 +49,7 @@
 *
 * %P
 * INPUT PARAMETERS
-* filename: [str]    Name of the neutron input file. Empty string "" unactivates component 
+* filename: [str]    Name of the neutron input file. Empty string "" inactivates component 
 *
 * Optional input parameters
 * repeat_count: [1]  Number of times the source must be generated/repeated 

--- a/mcstas-comps/optics/Guide_anyshape.comp
+++ b/mcstas-comps/optics/Guide_anyshape.comp
@@ -26,7 +26,7 @@
 * R0,Qc,alpha,W,m, or from a reflectivity file 'reflect' with a 2 column
 * format [q(Angs-1) R(0-1)].
 *
-* The complex OFF/PLY geometry option handles any closed non-convex polyhedra.
+* The complex OFF/PLY geometry option handles any closed non-convex polyhedral.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).
 *   Such files may be generated from XYZ data using:
 *     qhull < coordinates.xyz Qx Qv Tv o > geomview.off

--- a/mcstas-comps/optics/Refractor.comp
+++ b/mcstas-comps/optics/Refractor.comp
@@ -45,7 +45,7 @@
 * separated with a minimal thickness zdepth along the Z axis.
 *
 * Optionally, you can specify the 'geometry' parameter as a OFF/PLY file name.
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the PLY, OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/samples/Incoherent.comp
+++ b/mcstas-comps/samples/Incoherent.comp
@@ -41,7 +41,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the PLY, OFF and NOFF file format but not COFF (colored faces).

--- a/mcstas-comps/samples/Isotropic_Sqw.comp
+++ b/mcstas-comps/samples/Isotropic_Sqw.comp
@@ -29,7 +29,7 @@
 * scattering is constant isotropic (Vanadium like).
 * In case you only have one S(q,w) data containing both coherent and
 * incoherent contributions you should e.g. use 'Sqw_coh' and set 'sigma_coh'
-* to the total scattering cross section. Set sigma_coh and sigma_inc to -1 to unactivate.
+* to the total scattering cross section. Set sigma_coh and sigma_inc to -1 to inactivate.
 *
 * The implementation will automatically nornalise S(q,w) so that S(q) -> 1 at
 * large q (parameter norm=-1). Alternatively, the S(q,w) data will be multiplied
@@ -65,7 +65,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF, PLY and NOFF file format but not COFF (colored faces).
@@ -189,9 +189,9 @@
 * INPUT PARAMETERS:
 * Sqw_coh: [str]              Name of the file containing the values of Q, w and S(Q,w) Coherent part; Q in Angs-1, E in meV, S(q,w) in meV-1. Use 0, NULL or "" to disable.
 * Sqw_inc: [str]              Name of the file containing the values of Q, w and S(Q,w). Incoherent (self) part. Use 0, NULL or "" to scatter isotropically (V-like).
-* sigma_coh: [barns]          Coherent Scattering cross-section. Use -1 to unactivate.
-* sigma_inc: [barns]          Incoherent Scattering cross-section. Use -1 to unactivate.
-* sigma_abs: [barns]          Absorption cross-section at 2200 m/s. Use -1 to unactivate.
+* sigma_coh: [barns]          Coherent Scattering cross-section. Use -1 to inactivate.
+* sigma_inc: [barns]          Incoherent Scattering cross-section. Use -1 to inactivate.
+* sigma_abs: [barns]          Absorption cross-section at 2200 m/s. Use -1 to inactivate.
 * rho: [AA-3]                 Density of scattering elements (nb atoms/unit cell V_0).
 * T: [K]                      Temperature of sample, detailed balance. Use T=-1 to disable it, and T=-2 to guess it from non-classical S(q,w) input.
 *
@@ -211,7 +211,7 @@
 * weight: [g/mol]             atomic/molecular weight of material
 * density: [g/cm^3]           density of material. V_rho=density/weight/1e24*N_A
 * threshold: [1]              Value under which S(Q,w) is not accounted for. to set according to the S(Q,w) values, i.e. not too low.
-* p_interact: [1]             Force a given fraction of the beam to scatter, keeping intensity right, to enhance small signals (-1 unactivate).
+* p_interact: [1]             Force a given fraction of the beam to scatter, keeping intensity right, to enhance small signals (-1 inactivate).
 * norm: [1]                   Normalize S(q,w) when -1 (default). Use raw data when 1, multiplier for S(q,w) when norm>0.
 * classical: [1]              Assumes the S(q,w) data from the files is a classical S(q,w), and multiply that data by exp(hw/2kT) on up/down energy sides. Use 0 when obtained from raw experiments, 1 from molecular dynamics. Use -1 to guess from a data set including both energy sides.
 * quantum_correction: [str]   Specify the type of quantum correction to use "Boltzmann"/"Schofield","harmonic"/"Bader" or "standard"/"Frommhold" (default)

--- a/mcstas-comps/samples/PowderN.comp
+++ b/mcstas-comps/samples/PowderN.comp
@@ -264,7 +264,7 @@ struct line_info_struct
   double neutron_passed;
   long   xs_compute, xs_reuse, xs_calls;
 };
- off_struct offdata;
+
   // PN_list_compare *****************************************************************
 
   int PN_list_compare (void const *a, void const *b)

--- a/mcstas-comps/samples/PowderN.comp
+++ b/mcstas-comps/samples/PowderN.comp
@@ -51,7 +51,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF_file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the PLY, OFF and NOFF file format but not COFF (colored faces).
@@ -157,8 +157,8 @@
 * concentric: [1]      Indicate that this component has a hollow geometry and may contain other components. It should then be duplicated after the inside part (only for box, cylinder, sphere).
 * geometry: [str]      Name of an Object File Format (OFF) or PLY file for complex geometry. The OFF/PLY file may be generated from XYZ coordinates using qhull/powercrust.
 * barns: [1]           Flag to indicate if |F|^2 from 'reflections' is in barns or fm^2 (barns=1 for laz, barns=0 for lau type files).
-* sigma_abs: [barns]   Absorption cross section per unit cell at 2200 m/s. Use a negative value to unactivate it.
-* sigma_inc: [barns]   Incoherent cross section per unit cell. Use a negative value to unactivate it.
+* sigma_abs: [barns]   Absorption cross section per unit cell at 2200 m/s. Use a negative value to inactivate it.
+* sigma_inc: [barns]   Incoherent cross section per unit cell. Use a negative value to inactivate it.
 * Vc: [AA^3]           Volume of unit cell=nb atoms per cell/density of atoms.
 * DW: [1]              Global Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2
 * weight: [g/mol]      Atomic/molecular weight of material.

--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -80,7 +80,7 @@
 *   sphere:          radius (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the PLY, OFF and NOFF file format but not COFF (colored faces).
@@ -188,7 +188,7 @@
 *
 * p_transmit: [1]                                         Monte Carlo probability for neutrons to be transmitted without any scattering. Used to improve statistics from weak reflections
 * sigma_abs: [barns]                                      Absorption cross-section per unit cell at 2200 m/s
-* sigma_inc: [barns]                                      Incoherent scattering cross-section per unit cell Use -1 to unactivate
+* sigma_inc: [barns]                                      Incoherent scattering cross-section per unit cell Use -1 to inactivate
 * aa: [deg]                                               Unit cell angles alpha, beta and gamma. Then uses norms of vectors a,b and c as lattice parameters
 * bb: [deg]                                               Beta angle
 * cc: [deg]                                               Gamma angle

--- a/mcstas-comps/samples/Single_magnetic_crystal.comp
+++ b/mcstas-comps/samples/Single_magnetic_crystal.comp
@@ -37,7 +37,7 @@
 *   sphere:          radius (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the neutron ray with the object  
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces). 

--- a/mcstas-comps/share/monitor_nd-lib.c
+++ b/mcstas-comps/share/monitor_nd-lib.c
@@ -322,7 +322,7 @@ void Monitor_nD_Init(MonitornD_Defines_type *DEFS,
           Set_Coord_Mode = DEFS->COORD_FIL;
           if (Flag_No) { strcpy(Vars->Mon_File,""); Vars->Coord_Number = 0; Flag_End = 1; }
         }
-        if (!strcmp(token, "unactivate")) {
+        if (!strcmp(token, "inactivate")) {
           Flag_End = 1; Vars->Coord_Number = 0; iskeyword=1; }
         if (!strcmp(token, "all"))    { Flag_All = 1;  iskeyword=1; }
         if (!strcmp(token, "sphere")) { Vars->Flag_Shape = DEFS->SHAPE_SPHERE; iskeyword=1; }
@@ -780,7 +780,7 @@ void Monitor_nD_Init(MonitornD_Defines_type *DEFS,
       }
     }
     if (Vars->Coord_Number == 0 && Vars->Flag_Verbose)
-      printf("Monitor_nD: %s is unactivated (0D)\n", Vars->compcurname);
+      printf("Monitor_nD: %s is inactivated (0D)\n", Vars->compcurname);
     Vars->Cylinder_Height = fabs(Vars->mymax - Vars->mymin);
 
     if (Vars->Flag_Verbose)

--- a/mcstas-comps/share/monitor_nd_noacc-lib.c
+++ b/mcstas-comps/share/monitor_nd_noacc-lib.c
@@ -330,7 +330,7 @@ void Monitor_nd_noaccInit(Monitornd_noaccDefines_type *DEFS,
           Set_Coord_Mode = DEFS->COORD_FIL;
           if (Flag_No) { strcpy(Vars->Mon_File,""); Vars->Coord_Number = 0; Flag_End = 1; }
         }
-        if (!strcmp(token, "unactivate")) {
+        if (!strcmp(token, "inactivate")) {
           Flag_End = 1; Vars->Coord_Number = 0; iskeyword=1; }
         if (!strcmp(token, "all"))    { Flag_All = 1;  iskeyword=1; }
         if (!strcmp(token, "sphere")) { Vars->Flag_Shape = DEFS->SHAPE_SPHERE; iskeyword=1; }
@@ -788,7 +788,7 @@ void Monitor_nd_noaccInit(Monitornd_noaccDefines_type *DEFS,
       }
     }
     if (Vars->Coord_Number == 0 && Vars->Flag_Verbose)
-      printf("Monitor_nD: %s is unactivated (0D)\n", Vars->compcurname);
+      printf("Monitor_nD: %s is inactivated (0D)\n", Vars->compcurname);
     Vars->Cylinder_Height = fabs(Vars->mymax - Vars->mymin);
 
     if (Vars->Flag_Verbose)

--- a/mcstas-comps/sources/Monitor_Optimizer.comp
+++ b/mcstas-comps/sources/Monitor_Optimizer.comp
@@ -129,7 +129,7 @@ TRACE
         if (Vars->Monitor_Counts < 3*Vars->nbins)
         {
           printf("Source_Optimizer: monitor only reached %.1f counts. \n", Vars->Monitor_Counts);
-          printf("* WARNING *       You'd better unactivate it or increase number of neutrons\n");
+          printf("* WARNING *       You'd better inactivate it or increase number of neutrons\n");
         }
       }
     }

--- a/mcstas-comps/sources/Source_Optimizer.comp
+++ b/mcstas-comps/sources/Source_Optimizer.comp
@@ -55,7 +55,7 @@
 *     verbose         displays optimization process (debug purpose).
 *     auto            uses the shortest possible 'step 1' and 'step 2' and sets 'step' value as required (default).
 *     smooth          remove possible spikes generated in steps 1 and 2 (default is smooth).
-*     unactivate      to unactivate the Optimizer.
+*     inactivate      to inactivate the Optimizer.
 *     no or not       revert next option
 *     bins=[value=10] set the Number of cells for sampling neutron states
 *     step=[value=10] Optimizer step in % of simulation.
@@ -142,7 +142,7 @@ SHARE
 /* here we define a structure of constants (some kind of DEFINES) */
   struct Optim_Defines
   {
-    char PHASE_UNACTIVATE; /* to unactivate Optimizer */
+    char PHASE_UNACTIVATE; /* to inactivate Optimizer */
     char PHASE_SET_LIMITS; /* set array limits to 0, then ask for GET_LIMITS */
     char PHASE_GET_LIMITS; /* compute array limits, then ask for SET_REF */
     char PHASE_SET_REF;    /* set Ref and New_Source to to 0, then ask for GET_REF */
@@ -337,7 +337,7 @@ INITIALIZE
   char Token_Mode     = DEFS.COORD_VAR;
 
 /* init OPTIM */
-  DEFS.PHASE_UNACTIVATE =0; /* to unactivate Optimizer */
+  DEFS.PHASE_UNACTIVATE =0; /* to inactivate Optimizer */
   DEFS.PHASE_SET_LIMITS =1; /* set array limits to 0, then ask for GET_LIMITS */
   DEFS.PHASE_GET_LIMITS =2; /* compute array limits, then ask for SET_REF */
   DEFS.PHASE_SET_REF    =3; /* set Ref and New_Source to to 0, then ask for GET_REF */
@@ -446,7 +446,7 @@ INITIALIZE
   if (strstr(option_copy,"SetDivS"))     Vars.Flag_Type       |= DEFS.DO_DIVS;
   else
     if (strstr(option_copy,"SetS"))      Vars.Flag_Type       |= DEFS.DO_S;
-  if (strstr(option_copy,"unactivate"))  Vars.Phase = DEFS.PHASE_UNACTIVATE;
+  if (strstr(option_copy,"inactivate"))  Vars.Phase = DEFS.PHASE_UNACTIVATE;
 
   if (Vars.Flag_Type == 0) Vars.Flag_Type = (DEFS.DO_XY|DEFS.DO_DIVV|DEFS.DO_DIVS);
 
@@ -582,7 +582,7 @@ INITIALIZE
   if ((Vars.Reference_sz = (double*)malloc(Vars.nbins * sizeof(double))) == NULL) { fprintf(stderr,"Optimizer : not enough memory\n"); exit(-1); }
 
   if (Vars.Phase == DEFS.PHASE_UNACTIVATE)
-    { if (Vars.Flag_Verbose) printf("Source_Optimizer: %s is unactivated\n", NAME_CURRENT_COMP);
+    { if (Vars.Flag_Verbose) printf("Source_Optimizer: %s is inactivated\n", NAME_CURRENT_COMP);
       Vars.Flag_Verbose = 0; }
 /* end initialize */
 %}
@@ -665,7 +665,7 @@ TRACE
         if (Vars.Monitor_Number == 0)
         {
           Vars.Phase = DEFS.PHASE_UNACTIVATE;
-          printf("Source_Optimizer: %s is unactivated (no Monitor_Optimizer found)\n", NAME_CURRENT_COMP);
+          printf("Source_Optimizer: %s is inactivated (no Monitor_Optimizer found)\n", NAME_CURRENT_COMP);
         }
      }
 

--- a/mcstas-comps/sources/Source_gen.comp
+++ b/mcstas-comps/sources/Source_gen.comp
@@ -116,7 +116,7 @@
 * flux_file_log: [1]    When true, will transform the flux table in log scale to improve the sampling.
 * xdiv_file: [str]      Name of the x-horiz. divergence distribution file, given as a free format text matrix, preceeded with a line '# xylimits: xmin xmax xdiv_min xdiv_max'
 * ydiv_file: [str]      Name of the y-vert. divergence distribution file, given as a free format text matrix, preceeded with a line '# xylimits: ymin ymax ydiv_min ydiv_max'
-* verbose: [0/1]        display info about the source. -1 unactivate source.
+* verbose: [0/1]        display info about the source. -1 inactivate source.
 *
 * %L
 * P. Ageron, Nucl. Inst. Meth. A 284 (1989) 197
@@ -472,7 +472,7 @@ INITIALIZE
   }
   else
     if (verbose == -1)
-      printf("Source_gen: component %s unactivated", NAME_CURRENT_COMP);
+      printf("Source_gen: component %s inactivated", NAME_CURRENT_COMP);
   );
 %}
 

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -57,7 +57,7 @@
 * order: [1]                                              Limit multiple scattering up to given order (0: all, 1: first, 2: second, ...)
 * p_transmit: [1]                                         Monte Carlo probability for neutrons to be transmitted without any scattering. Used to improve statistics from weak reflections
 * sigma_abs: [barns]                                      Absorption cross-section per unit cell at 2200 m/s
-* sigma_inc: [barns]                                      Incoherent scattering cross-section per unit cell Use -1 to unactivate
+* sigma_inc: [barns]                                      Incoherent scattering cross-section per unit cell Use -1 to inactivate
 * aa: [deg]                                               Unit cell angles alpha, beta and gamma. Then uses norms of vectors a,b and c as lattice parameters
 * bb: [deg]                                               Beta angle
 * cc: [deg]                                               Gamma angle

--- a/mcstas/src/instrument.y
+++ b/mcstas/src/instrument.y
@@ -2319,7 +2319,7 @@ check_instrument_formals(List formallist, char *instrname)
         liter2 = list_iterate(formallist);
         while((formal2 = list_next(liter2))) {
         	if (formal != formal2 && strlen(formal2->id) && !strcmp(formal->id, formal2->id)) {
-        		strcpy(formal2->id, "");  /* unactivate recurrent previous definition */
+        		strcpy(formal2->id, "");  /* inactivate recurrent previous definition */
         		if (verbose) print_warn(NULL, "Instrument parameter name %s is used multiple times "
               "in instrument %s. Using last definition %s\n", formal->id, instrname,
               	formal->isoptional ? exp_tostring(formal->default_value) : "");

--- a/mcstas/src/mcformat.c.in
+++ b/mcstas/src/mcformat.c.in
@@ -1572,7 +1572,7 @@ void mcformat_scan_compare(int nb)
         /* find Scan_distances[j] in Scans_to_merge */
         if (Scans_to_merge[scan_index2] >= 0 && Scans_to_merge[scan_index2] == Scan_distances[j]) {
           Monitor_column[k++] = scan_index2;
-          Scans_to_merge[scan_index2]=-1; /*unactivate that scan element */
+          Scans_to_merge[scan_index2]=-1; /*inactivate that scan element */
         }
       }
       /* sort each monitor column with ipar value */
@@ -1614,7 +1614,7 @@ void mcformat_scan_compare(int nb)
     } /* for j */
     Scan.header=header;
 
-    Scans_to_merge[scan_index1]=-1; /* unactivate that scan element */
+    Scans_to_merge[scan_index1]=-1; /* inactivate that scan element */
 
     char *title=str_cat("Scan of ",
       Files_to_Merge[scan_index1].mcinputtable[ipar_var].name, NULL);

--- a/mcstas/src/py-instrument.y
+++ b/mcstas/src/py-instrument.y
@@ -2253,7 +2253,7 @@ check_instrument_formals(List formallist, char *instrname)
         liter2 = list_iterate(formallist);
         while((formal2 = list_next(liter2))) {
         	if (formal != formal2 && strlen(formal2->id) && !strcmp(formal->id, formal2->id)) {
-        		strcpy(formal2->id, "");  /* unactivate recurrent previous definition */
+        		strcpy(formal2->id, "");  /* inactivate recurrent previous definition */
         		if (verbose) print_warn(NULL, "Instrument parameter name %s is used multiple times "
               "in instrument %s. Using last definition %s\n", formal->id, instrname,
               	formal->isoptional ? exp_tostring(formal->default_value) : "");

--- a/mcxtrace-comps/misc/Shape.comp
+++ b/mcxtrace-comps/misc/Shape.comp
@@ -28,7 +28,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the X ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF and NOFF file format but not COFF (colored faces).

--- a/mcxtrace-comps/monitors/Monitor_nD.comp
+++ b/mcxtrace-comps/monitors/Monitor_nD.comp
@@ -124,7 +124,7 @@
 *     signal=[var]              Will monitor [var] instead of usual intensity
 *     slit or absorb            Absorb photons that are out detector
 *     source                    The monitor will save photon states
-*     unactivate                To unactivate detector (0D detector)
+*     inactivate                To inactivate detector (0D detector)
 *     verbose                   To display additional informations
 *
 * Detector shape options (specified as xwidth,yheight,zdepth or x/y/z/min/max)

--- a/mcxtrace-comps/samples/Fluorescence.comp
+++ b/mcxtrace-comps/samples/Fluorescence.comp
@@ -44,7 +44,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the photon ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF, PLY and NOFF file format but not COFF (colored faces).
@@ -95,7 +95,7 @@
 * thickness: [m]      Thickness of hollow sample Negative value extends the hollow volume outside of the box/cylinder.
 * concentric: [1]     Indicate that this component has a hollow geometry and may contain other components. It should then be duplicated after the inside part (only for box, cylinder, sphere) [1]
 * geometry:  [str]    Name of an Object File Format (OFF) or PLY file for complex geometry. The OFF/PLY file may be generated from XYZ coordinates using qhull/powercrust.
-* p_interact: [1]     Force a given fraction of the beam to scatter, keeping intensity right, to enhance small signals (-1 unactivate).
+* p_interact: [1]     Force a given fraction of the beam to scatter, keeping intensity right, to enhance small signals (-1 inactivate).
 * focus_xw:  [m]      Horiz. dimension of a rectangular area.
 * focus_yh:  [m]      Vert.  dimension of a rectangular area.
 * focus_aw:  [deg]    Horiz. angular dimension of a rectangular area.

--- a/mcxtrace-comps/samples/Fluorescence.comp
+++ b/mcxtrace-comps/samples/Fluorescence.comp
@@ -150,6 +150,9 @@ NOACC
 /* ========================================================================== */
 
 SHARE %{
+  #ifndef FLUORESCENCE_DECL
+  #define FLUORESCENCE_DECL
+
   #ifndef XRAYLIB_LINES_MAX
   #define XRAYLIB_LINES_MAX 383
   #define FLUORESCENCE 0  // Fluo
@@ -220,21 +223,22 @@ int XRMC_SelectFromDistribution(double x_arr[], int N)
 
 /* XRMC_SelectInteraction: select interaction type Fluo/Compton/Rayleigh
  * Return the interaction type from a random choice within cross sections 'xs'
- *   type = XRMC_SelectInteraction(xs[3]);
+ *   type = XRMC_SelectInteraction(xs[3], 3);
  * 'xs' is computed with XRMC_CrossSections.
  * type is one of FLUORESCENCE | RAYLEIGH | COMPTON
  */
-int XRMC_SelectInteraction(double *xs)
+int XRMC_SelectInteraction(double *xs, int nb_processes)
 {
-  double sum_xs, cum_xs[4];
+  double sum_xs, cum_xs[5];
   int    i;
   
+  if (nb_processes < 1 || nb_processes > 4) return 0;
   cum_xs[0]=sum_xs=0;
-  for (i=0; i< 3; i++) {
+  for (i=0; i< nb_processes; i++) {
     sum_xs += xs[i];
     cum_xs[i+1]= sum_xs;
   }
-  return XRMC_SelectFromDistribution(cum_xs, 4);
+  return XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
 } // XRMC_SelectInteraction
 
 /* XRMC_SelectFluorescenceEnergy: select outgoing fluo photon energy, when incoming with 'E0'
@@ -362,6 +366,8 @@ double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE)
     removeSpacesFromStr(formula);
     return(ret);
   } // fluo_get_material
+  
+  #endif // FLUORESCENCE_DECL
 %}
 
 /* ========================================================================== */
@@ -795,7 +801,7 @@ do { /* while (intersect) Loop over multiple scattering events */
     if (dsigma < 1) p *= dsigma; // < 1
 
     /* MC choose process from cross sections 'xs': fluo, Compton, Rayleigh */
-    type = XRMC_SelectInteraction(xs);
+    type = XRMC_SelectInteraction(xs, 3);
     
     /* choose Z (element) on associated XS, taking into account mass-fractions */
     switch (type) {

--- a/mcxtrace-comps/samples/Isotropic_Sqw.comp
+++ b/mcxtrace-comps/samples/Isotropic_Sqw.comp
@@ -62,7 +62,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the photon ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the OFF, PLY and NOFF file format but not COFF (colored faces).
@@ -193,7 +193,7 @@
 * density: [g/cm^3]           density of material. V_rho=density/weight/1e24*N_A
 * sigma_coh: [barns]          Thomson cross-section of the material. For an atom, this is f*0.665 barns, where f is the number of free electrons, f -> atomic number Z.
 * threshold: [1]              Value under which S(Q,w) is not accounted for. to set according to the S(Q,w) values, i.e. not too low.
-* p_interact: [1]             Force a given fraction of the beam to scatter, keeping intensity right, to enhance small signals (-1 unactivate).
+* p_interact: [1]             Force a given fraction of the beam to scatter, keeping intensity right, to enhance small signals (-1 inactivate).
 * norm: [1]                   Normalize S(q,w) when -1 (default). Use raw data when 1, multiplier for S(q,w) when norm>0.
 * classical: [1]              Assumes the S(q,w) data from the files is a classical S(q,w), and multiply that data by exp(hw/2kT) on up/down energy sides. Use 0 when obtained from raw experiments, 1 from molecular dynamics. Use -1 to guess from a data set including both energy sides.
 * quantum_correction: [str]   Specify the type of quantum correction to use "Boltzmann"/"Schofield","harmonic"/"Bader" or "standard"/"Frommhold" (default)

--- a/mcxtrace-comps/samples/PowderN.comp
+++ b/mcxtrace-comps/samples/PowderN.comp
@@ -48,7 +48,7 @@
 *   hollow sphere:   radius and thickness>0 (yheight=0)
 *   any shape:       geometry=OFF_file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the xray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the PLY, OFF and NOFF file format but not COFF (colored faces).

--- a/mcxtrace-comps/samples/PowderN.comp
+++ b/mcxtrace-comps/samples/PowderN.comp
@@ -265,8 +265,6 @@ SHARE
       t_Table mat_table;
       int mat_column_order[5]; /*column signification for the coeff. in material data file*/
   };
-
-  off_struct offdata;
   
   // shared functions **********************************************************
   

--- a/mcxtrace-comps/samples/Single_crystal.comp
+++ b/mcxtrace-comps/samples/Single_crystal.comp
@@ -80,7 +80,7 @@
 *   sphere:          radius (yheight=0)
 *   any shape:       geometry=OFF/PLY file
 *
-*   The complex geometry option handles any closed non-convex polyhedra.
+*   The complex geometry option handles any closed non-convex polyhedral.
 *   It computes the intersection points of the photon ray with the object
 *   transparently, so that it can be used like a regular sample object.
 *   It supports the PLY, OFF and NOFF file format but not COFF (colored faces).
@@ -193,7 +193,7 @@
 * Optional input parameters
 *
 * p_transmit:        [1] Monte Carlo probability for photons to be transmitted without any scattering. Used to improve statistics from weak reflections
-* sigma_inc:     [barns] Incoherent scattering cross-section per unit cell (uniform). Fully isotropic and constant. Use -1 to unactivate
+* sigma_inc:     [barns] Incoherent scattering cross-section per unit cell (uniform). Fully isotropic and constant. Use -1 to inactivate
 * aa:              [deg] Unit cell angles alpha, beta and gamma. Then uses norms of vectors a,b and c as lattice parameters
 * bb:              [deg] Beta angle
 * cc:              [deg] Gamma angle

--- a/mcxtrace-comps/share/monitor_nd-lib.c
+++ b/mcxtrace-comps/share/monitor_nd-lib.c
@@ -304,7 +304,7 @@ void Monitor_nD_Init(MonitornD_Defines_type *DEFS,
           Set_Coord_Mode = DEFS->COORD_FIL;
           if (Flag_No) { strcpy(Vars->Mon_File,""); Vars->Coord_Number = 0; Flag_End = 1; }
         }
-        if (!strcmp(token, "unactivate")) {
+        if (!strcmp(token, "inactivate")) {
           Flag_End = 1; Vars->Coord_Number = 0; iskeyword=1; }
         if (!strcmp(token, "all"))    { Flag_All = 1;  iskeyword=1; }
         if (!strcmp(token, "sphere")) { Vars->Flag_Shape = DEFS->SHAPE_SPHERE; iskeyword=1; }
@@ -730,7 +730,7 @@ void Monitor_nD_Init(MonitornD_Defines_type *DEFS,
       }
     }
     if (Vars->Coord_Number == 0 && Vars->Flag_Verbose)
-      printf("Monitor_nD: %s is unactivated (0D)\n", Vars->compcurname);
+      printf("Monitor_nD: %s is inactivated (0D)\n", Vars->compcurname);
     Vars->Cylinder_Height = fabs(Vars->mymax - Vars->mymin);
 
     if (Vars->Flag_Verbose)

--- a/mcxtrace/src/instrument.y
+++ b/mcxtrace/src/instrument.y
@@ -2297,7 +2297,7 @@ check_instrument_formals(List formallist, char *instrname)
         liter2 = list_iterate(formallist);
         while((formal2 = list_next(liter2))) {
         	if (formal != formal2 && strlen(formal2->id) && !strcmp(formal->id, formal2->id)) {
-        		strcpy(formal2->id, "");  /* unactivate recurrent previous definition */
+        		strcpy(formal2->id, "");  /* inactivate recurrent previous definition */
         		if (verbose) print_warn(NULL, "Instrument parameter name %s is used multiple times "
               "in instrument %s. Using last definition %s\n", formal->id, instrname,
               	formal->isoptional ? exp_tostring(formal->default_value) : "");

--- a/mcxtrace/src/instrument.y
+++ b/mcxtrace/src/instrument.y
@@ -21,6 +21,7 @@
 *******************************************************************************/
 %{
 
+#define _GNU_SOURCE
 #include <math.h>
 #include <string.h>
 #include <stdio.h>
@@ -1266,7 +1267,29 @@ component: removable cpuonly split "COMPONENT" instname '=' instref
 	    }
 	  }
         }
-        if ($13->linenum)   comp->extend= $13;  /* EXTEND block*/
+        if ($13->linenum) {
+	  if (comp->extend->linenum>0) {
+	    fprintf(stderr, "\n-----------------------------------------------------------\n");
+	    fprintf(stderr, "WARNING: Existing (COPY) EXTEND block in COMPONENT %s:\n", comp->name);
+	    List_handle liter = list_iterate(comp->extend->lines);
+	    List_handle liter2 = list_iterate($13->lines);
+	    char *line, *line2;
+	    fprintf(stderr, "  EXTEND %%{\n");
+	    while((line = list_next(liter))) {
+	      fprintf(stderr, "  %s",line);
+	    }
+	    list_iterate_end(liter);
+	    fprintf(stderr, "  %%}\n");
+	    fprintf(stderr, "\nis overwritten by:\n");
+	    fprintf(stderr, "  EXTEND %%{\n");
+	    while((line2 = list_next(liter2))) {
+	      fprintf(stderr, "  %s",line2);
+	    }
+	    list_iterate_end(liter2);
+	    fprintf(stderr, "  %%}\n-----------------------------------------------------------\n");
+	  }
+	  comp->extend= $13;  /* EXTEND block*/
+	}
         if (list_len($14))  comp->jump  = $14;
 
         /* one or more metadata statements -- the Component definition *can also* add to this list */
@@ -2202,7 +2225,7 @@ main(int argc, char *argv[])
       fprintf(stderr, "  {EXTEND C_code}\n");
       fprintf(stderr, "  {JUMP [reference|PREVIOUS|MYSELF|NEXT] [ITERATE number_of_times | WHEN condition]\n");
       fprintf(stderr, "END\n");
-      fprintf(stderr, "as well as '\%{ ... \%}' blocks.\n\n");
+      fprintf(stderr, "as well as '%%{ ... %%}' blocks.\n\n");
     }
     exit(1);
   }

--- a/mcxtrace/src/mcformat.c.in
+++ b/mcxtrace/src/mcformat.c.in
@@ -1572,7 +1572,7 @@ void mcformat_scan_compare(int nb)
         /* find Scan_distances[j] in Scans_to_merge */
         if (Scans_to_merge[scan_index2] >= 0 && Scans_to_merge[scan_index2] == Scan_distances[j]) {
           Monitor_column[k++] = scan_index2;
-          Scans_to_merge[scan_index2]=-1; /*unactivate that scan element */
+          Scans_to_merge[scan_index2]=-1; /*inactivate that scan element */
         }
       }
       /* sort each monitor column with ipar value */
@@ -1614,7 +1614,7 @@ void mcformat_scan_compare(int nb)
     } /* for j */
     Scan.header=header;
 
-    Scans_to_merge[scan_index1]=-1; /* unactivate that scan element */
+    Scans_to_merge[scan_index1]=-1; /* inactivate that scan element */
 
     char *title=str_cat("Scan of ",
       Files_to_Merge[scan_index1].mcinputtable[ipar_var].name, NULL);

--- a/mcxtrace/src/py-instrument.y
+++ b/mcxtrace/src/py-instrument.y
@@ -2254,7 +2254,7 @@ check_instrument_formals(List formallist, char *instrname)
         liter2 = list_iterate(formallist);
         while((formal2 = list_next(liter2))) {
         	if (formal != formal2 && strlen(formal2->id) && !strcmp(formal->id, formal2->id)) {
-        		strcpy(formal2->id, "");  /* unactivate recurrent previous definition */
+        		strcpy(formal2->id, "");  /* inactivate recurrent previous definition */
         		if (verbose) print_warn(NULL, "Instrument parameter name %s is used multiple times "
               "in instrument %s. Using last definition %s\n", formal->id, instrname,
               	formal->isoptional ? exp_tostring(formal->default_value) : "");

--- a/obsolete-files/CHANGES
+++ b/obsolete-files/CHANGES
@@ -829,7 +829,7 @@ Changes in McStas v1.6-ill (alpha), October 29th, 2001.
       -USR2: finish simulation and save results
       -QUIT: end simulation immediately
  - The 2D detectors now also output the errors/counts on signal as 1D detectors.
-   Set p2=NULL in DETECTOR_OUT_2D to unactivate error saving in components.
+   Set p2=NULL in DETECTOR_OUT_2D to inactivate error saving in components.
  - We tried to lower the number of components by merging similar ones.
  - There are now new MACROS for the component programmer.
      * mccompcurindex is the number (index) of the current component

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -305,8 +305,6 @@ class McStas:
 
         # Final assembly of compiler commandline
         args = ['-o', self.binpath, self.cpath] + lexer.split(cflags)
-        # display compile command
-        LOG.info('%s %s', options.cc, ' '.join(args))
         Process(lexer.quote(options.cc)).run(args)
 
     def run(self, pipe=False, extra_opts=None, override_mpi=None):


### PR DESCRIPTION
The **PowderN** components have a misplaced and redundant `off_struct offdata` declaration that has nothing to do here. It is actually also in the DECLARE block, so that all is fine.