### PR TITLE
mcrun: remove gcc command as it is displayed with --verbose

### DIFF
--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -305,8 +305,6 @@ class McStas:
 
         # Final assembly of compiler commandline
         args = ['-o', self.binpath, self.cpath] + lexer.split(cflags)
-        # display compile command
-        LOG.info('%s %s', options.cc, ' '.join(args))
         Process(lexer.quote(options.cc)).run(args)
 
     def run(self, pipe=False, extra_opts=None, override_mpi=None):


### PR DESCRIPTION
Smaller chunk of https://github.com/mccode-dev/McCode/pull/1939