### PR TITLE
Allowed negative values for chi and kappa in the Source_custom component

### DIFF
--- a/mcstas-comps/contrib/Source_custom.comp
+++ b/mcstas-comps/contrib/Source_custom.comp
@@ -10,13 +10,15 @@
 * %I
 * Written by: Pablo Gila-Herranz, based on 'Source_pulsed' by K. Lieutenant
 * Date: April 2025
-* Version: 2.0
+* Version: 2.0.1
 * Origin: Materials Physics Center (CFM-MPC), CSIC-UPV/EHU
 *
 * A flexible pulsed or continuous source with customisable parameters. Multiple pulses can be simulated over time.
 *
 * %D
 * Produces a custom pulse spectrum with a wavelength distribution as a sum of up to 3 Maxwellian distributions and one of undermoderated neutrons.
+*
+* <b>Usage:</b>
 *
 * By default, all Maxwellian distributions are assumed to come from anywhere in the moderator.
 * A custom radius r_i can be defined such that the central circle is at temperature T1,
@@ -27,11 +29,15 @@
 * The input flux is in units of [1/(cm^2 sr s AA)], and the output flux is per second, regardless of the number of pulses.
 * This means that the intensity spreads over n_pulses, so that the units of neutrons per second are preserved.
 * To simulate only the neutron counts of a single pulse, the input flux should be divided by the frequency.
+* Bear in mind that the maximum emission time is given by t_pulse * tmax_multiplier,
+* so short pulses with long tails may require a higher tmax_multiplier value (3 by default).
 *
 * To simulate a continuous source, set a pulse length equal to the pulse period (e.g. t_pulse=1.0, freq=1.0).
 * Note that this continuous beam is simulated over time, unlike other continuous sources in McStas which produce a Dirac delta at time 0.
 *
 * Parameters xwidth and yheight must be provided for rectangular moderators, otherwise a circular shape is assumed.
+*
+* <b>Model description:</b>
 *
 * The normalised Maxwellian distribution for moderated neutrons is defined by [1]
 *   $M(\lambda)=\frac{2a^2}{T^2\lambda^5}\exp\left(-\frac{a}{T\lambda^{2}}\right)$
@@ -45,7 +51,7 @@
 *   $N_{t>t_p}=\exp\left(-\frac{t-t_p}{\tau}\right)-\exp\left(-\frac{t}{\tau/n}\right)$
 * where tp is the pulse period, tau is the pulse decay time constant, and n is the ratio of decay to ascend time constants.
 *
-* Parameters for some sources:
+* <b>Parameters for some sources:</b>
 *
 *   HBS thermal source:
 *     t_pulse=0.016, freq=24.0, xwidth=0.04, yheight=0.04,
@@ -67,7 +73,7 @@
 *     t_pulse=1, freq=1, xwidth=0.1, yheight=0.1,
 *     T1=296.2, I1=8.5e+11, T2=40.68, I2=5.2e+11
 *
-* References:
+* <b>References:</b>
 *   [1] J. M. Carpenter et al, Nuclear Instruments and Methods in Physics Research Section A, 234, 542–551 (1985).
 *   [2] J. M. Carpenter and W. B. Yelon, Methods in Experimental Physics 23, p. 127, Chapter 2, Neutron Sources (1986).
 *
@@ -103,6 +109,9 @@
 * n_um:           [1]        Ratio of pulse decay constant to pulse ascend constant of under-moderated neutrons
 * chi_um:        [1/AA]      Factor for the wavelength dependence of under-moderated neutrons
 * kap_um:         [1]        Scaling factor for the flux of under-moderated neutrons
+*
+* %L
+* This model is implemented in an <a href="https://github.com/pablogila/Source_custom">interactive notebook</a> to fit custom neutron sources.
 *
 * %E
 *******************************************************************************/
@@ -173,7 +182,7 @@ INITIALIZE
       ||       T2 < 0.0 ||        I2 < 0.0 ||             tau2 < 0.0
       ||       T3 < 0.0 ||        I3 < 0.0 ||             tau3 < 0.0
       ||    n_mod < 0.0 ||      I_um < 0.0 ||           tau_um < 0.0
-      ||     n_um < 0.0 ||    chi_um < 0.0 ||           kap_um < 0.0){
+      ||     n_um < 0.0){
     printf("Source_custom: %s: Error: negative input parameter!\n"
            "ERROR          Exiting\n", NAME_CURRENT_COMP);
     exit(-1);


### PR DESCRIPTION
Small but important update to the Source_custom component.
Negative values for the chi and kappa parameters, used to model under-moderated neutrons, are now allowed.
A link to a Jupyter notebook with utilities for fitting custom sources is also included.

No regressions have been introduced, this is fully compatible with previous versions.
Following semantic versioning, the component version has been bumped to 2.0.1.