### PR TITLE
mccode-legacy: Use actual number of segments 'seg' instead of maximal 'segno'

### DIFF
--- a/mcstas-comps/optics/Guide_tapering.comp
+++ b/mcstas-comps/optics/Guide_tapering.comp
@@ -627,7 +627,7 @@ MCDISPLAY
 
   
 
-  for (ii=0; ii < segno; ii++)
+  for (ii=0; ii < seg; ii++)
   {
      multiline(5,
         -w1_in[ii]/2.0, -h1_in[ii]/2.0,l_seg*(double)ii,


### PR DESCRIPTION
Use actual number of segments 'seg' instead of maximal 'segno'
(lead to visualisation artefacts)