### PR TITLE
Comp updates from work on ESS SKADI

### DIFF
--- a/mcstas-comps/contrib/TOFSANSdet.comp
+++ b/mcstas-comps/contrib/TOFSANSdet.comp
@@ -165,19 +165,19 @@ INITIALIZE
   Ntc = floor( ddmin(ddmax(Nt,10.0),2000.0)+ 0.50);
   Nqc = floor( ddmin(ddmax(Nq,1.00),2000.0)+ 0.50);
 
-  TSdNf = (double*)malloc(sizeof(double)*Nxc*Nyc*Ntc*3);
-  TSdpf = (double*)malloc(sizeof(double)*Nxc*Nyc*Ntc*3);
-  TSdp2f= (double*)malloc(sizeof(double)*Nxc*Nyc*Ntc*3);
-
-  for (i=0; i<Nxc; i++)
-    for (j=0; j<Nyc; j++)
-      for (s=0; s<Ntc; s++)
-        for(k=0; k<3; k++)
-        {
-          TSdN(i,j,s,k)  = 0.0;
-          TSdp(i,j,s,k)  = 0.0;
-          TSdp2(i,j,s,k) = 0.0;
-        };
+  #ifndef USE_MPI
+  printf("Attempting allocation of 3 arrays sized (%lu bytes/double) x %lu elements = %lu Mb\n",sizeof(double),Nxc*Nyc*Ntc*3,sizeof(double)*Nxc*Nyc*Ntc*3/(1024*1024));
+  #else
+  MPI_MASTER(
+	     printf("Attempting allocation %i copies of 3 arrays sized (%lu double) x %lu elements = %lu Mb\n",mpi_node_count,sizeof(double),Nxc*Nyc*Ntc*3,mpi_node_count*sizeof(double)*Nxc*Nyc*Ntc*3/(1024*1024));
+  );
+  #endif
+  TSdNf = (double*)calloc(Nxc*Nyc*Ntc*3,sizeof(double));
+  TSdpf = (double*)calloc(Nxc*Nyc*Ntc*3,sizeof(double));
+  TSdp2f= (double*)calloc(Nxc*Nyc*Ntc*3,sizeof(double));
+  MPI_MASTER(
+	printf("Done with big-array allocations\n");
+  );
 
   ds1c = ddmax(ds1,0.0);
   ds2c = ddmax(ds2,0.0);

--- a/mcstas-comps/contrib/TOFSANSdet.comp
+++ b/mcstas-comps/contrib/TOFSANSdet.comp
@@ -166,10 +166,10 @@ INITIALIZE
   Nqc = floor( ddmin(ddmax(Nq,1.00),2000.0)+ 0.50);
 
   #ifndef USE_MPI
-  printf("Attempting allocation of 3 arrays sized (%lu bytes/double) x %lu elements = %lu Mb\n",sizeof(double),Nxc*Nyc*Ntc*3,sizeof(double)*Nxc*Nyc*Ntc*3/(1024*1024));
+  printf("%s: Attempting allocation of 3 arrays sized (%lu bytes/double) x %lu elements = %lu Mb\n",_comp->_name,sizeof(double),Nxc*Nyc*Ntc*3,sizeof(double)*Nxc*Nyc*Ntc*3/(1024*1024));
   #else
   MPI_MASTER(
-	     printf("Attempting allocation %i copies of 3 arrays sized (%lu double) x %lu elements = %lu Mb\n",mpi_node_count,sizeof(double),Nxc*Nyc*Ntc*3,mpi_node_count*sizeof(double)*Nxc*Nyc*Ntc*3/(1024*1024));
+	     printf("%s: Attempting allocation %i copies of 3 arrays sized (%lu double) x %lu elements = %lu Mb\n",_comp->_name,mpi_node_count,sizeof(double),Nxc*Nyc*Ntc*3,mpi_node_count*sizeof(double)*Nxc*Nyc*Ntc*3/(1024*1024));
   );
   #endif
   TSdNf = (double*)calloc(Nxc*Nyc*Ntc*3,sizeof(double));

--- a/mcstas-comps/optics/Guide_tapering.comp
+++ b/mcstas-comps/optics/Guide_tapering.comp
@@ -246,10 +246,14 @@ w1c = (double*)malloc(sizeof(double)*segno);
          free(fu);exit(-1);
      } else {
         ii = 0;
-        while (!feof(num))
+	/* Use ret==NULL as termination criterion on while, otherwise
+	   the reading may on some systems continue until "800" segments */
+	int dymmy=1;
+	char *ret=&dymmy;
+        while (!feof(num) && ret)
         {
-          char *ret = fgets(segment[ii].st,128,num);
-          if (ii >  799 || !ret) {
+          ret = fgets(segment[ii].st,128,num);
+	  if (ii >  799 ) {
              fprintf(stderr,"%s: Number of segments is limited to 800 !! \n",NAME_CURRENT_COMP);
               free(fu);exit(-1);
           }
@@ -642,7 +646,7 @@ MCDISPLAY
 %{
   int i,ii;
 
-  for (ii=0; ii < segno; ii++)
+  for (ii=0; ii < seg; ii++)
   {
      multiline(5,
         -w1_in[ii]/2.0, -h1_in[ii]/2.0,l_seg*(double)ii,


### PR DESCRIPTION
Updates to:
1. `Guide_tapering`:
  a. Remove visualisation artefact (`segno`->`seg` in display section)
  b. Ad-hoc repair read of `option="file=[]"`
2. `TOFSANSdet`: `malloc`->`calloc` to avoid tripe-loop 0-ification and add memory footprint status msgs before/after