### PR TITLE
Correct implementation to use unit64_t (achieves a correct 64bit RNG also on Windows...)

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -3575,7 +3575,7 @@ long sort_absorb_last(_class_particle* particles, _class_particle* pbuffer, long
   // copy non-absorbed block
   #pragma acc parallel loop present(particles[0:buffer_len])
   for (long tidx = 0; tidx < accumlen; tidx++) { // tidx: thread index
-    unsigned long randstate[7];
+    randstate_t randstate[7];
     _class_particle sourcebuffer;
     _class_particle targetbuffer;
     // assign reduced weight to all particles
@@ -4164,14 +4164,14 @@ void _randvec_target_rect_real(double *xo, double *yo, double *zo, double *solid
 #define UPPER_MASK 0x80000000UL /* most significant w-r bits */
 #define LOWER_MASK 0x7fffffffUL /* least significant r bits */
 
-unsigned long mt[N]; /* the array for the state vector  */
+randstate_t mt[N]; /* the array for the state vector  */
 int mti=N+1; /* mti==N+1 means mt[N] is not initialized */
 
 // required for common rng alg interface (see RNG_ALG usage in mccode-r.h)
 void mt_srandom_empty() {}
 
 // initializes mt[N] with a seed
-void mt_srandom(unsigned long s)
+void mt_srandom(randstate_t s)
 {
     mt[0]= s & 0xffffffffUL;
     for (mti=1; mti<N; mti++) {
@@ -4188,7 +4188,7 @@ void mt_srandom(unsigned long s)
 /* Initialize by an array with array-length.
    Init_key is the array for initializing keys.
    key_length is its length. */
-void init_by_array(unsigned long init_key[], unsigned long key_length)
+void init_by_array(randstate_t init_key[], randstate_t key_length)
 {
     int i, j, k;
     mt_srandom(19650218UL);
@@ -4213,10 +4213,10 @@ void init_by_array(unsigned long init_key[], unsigned long key_length)
     mt[0] = 0x80000000UL; /* MSB is 1; assuring non-zero initial array */
 }
 /* generates a random number on [0,0xffffffff]-interval */
-unsigned long mt_random(void)
+randstate_t mt_random(void)
 {
-    unsigned long y;
-    unsigned long mag01[2]={0x0UL, MATRIX_A};
+    randstate_t y;
+    randstate_t mag01[2]={0x0UL, MATRIX_A};
     /* mag01[x] = x * MATRIX_A  for x=0,1 */
 
     if (mti >= N) { /* generate N words at one time */
@@ -4282,11 +4282,11 @@ rng.html>
       2^32*(2^32-1)*(2^63+2^32-1) > 2^127
 */
 
-/* the KISS state is stored as a vector of 7 unsigned long        */
+/* the KISS state is stored as a vector of 7 randstate_t        */
 /*   0  1  2  3  4      5  6   */
 /* [ x, y, z, w, carry, k, m ] */
 
-unsigned long *kiss_srandom(unsigned long state[7], unsigned long seed) {
+randstate_t *kiss_srandom(randstate_t state[7], randstate_t seed) {
   if (seed == 0) seed = 1ul;
   state[0] = seed | 1ul; // x
   state[1] = seed | 2ul; // y
@@ -4298,7 +4298,7 @@ unsigned long *kiss_srandom(unsigned long state[7], unsigned long seed) {
   return NULL;
 }
 
-unsigned long kiss_random(unsigned long state[7]) {
+randstate_t kiss_random(randstate_t state[7]) {
     state[0] = state[0] * 69069ul + 1ul;
     state[1] ^= state[1] << 13ul;
     state[1] ^= state[1] >> 17ul;

--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -4160,9 +4160,9 @@ void _randvec_target_rect_real(double *xo, double *yo, double *zo, double *solid
 /* Period parameters */
 #define N 624
 #define M 397
-#define MATRIX_A 0x9908b0dfUL   /* constant vector a */
-#define UPPER_MASK 0x80000000UL /* most significant w-r bits */
-#define LOWER_MASK 0x7fffffffUL /* least significant r bits */
+#define MATRIX_A UINT64_C(0x9908b0df)   /* constant vector a */
+#define UPPER_MASK UINT64_C(0x80000000) /* most significant w-r bits */
+#define LOWER_MASK UINT64_C(0x7fffffff) /* least significant r bits */
 
 randstate_t mt[N]; /* the array for the state vector  */
 int mti=N+1; /* mti==N+1 means mt[N] is not initialized */
@@ -4173,15 +4173,15 @@ void mt_srandom_empty() {}
 // initializes mt[N] with a seed
 void mt_srandom(randstate_t s)
 {
-    mt[0]= s & 0xffffffffUL;
+    mt[0]= s & UINT64_C(0xffffffff);
     for (mti=1; mti<N; mti++) {
         mt[mti] =
-            (1812433253UL * (mt[mti-1] ^ (mt[mti-1] >> 30)) + mti);
+            (UINT64_C(1812433253) * (mt[mti-1] ^ (mt[mti-1] >> 30)) + mti);
         /* See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. */
         /* In the previous versions, MSBs of the seed affect   */
         /* only MSBs of the array mt[].                        */
         /* 2002/01/09 modified by Makoto Matsumoto             */
-        mt[mti] &= 0xffffffffUL;
+        mt[mti] &= UINT64_C(0xffffffff);
         /* for >32 bit machines */
     }
 }
@@ -4191,50 +4191,50 @@ void mt_srandom(randstate_t s)
 void init_by_array(randstate_t init_key[], randstate_t key_length)
 {
     int i, j, k;
-    mt_srandom(19650218UL);
+    mt_srandom(UINT64_C(19650218));
     i=1; j=0;
     k = (N>key_length ? N : key_length);
     for (; k; k--) {
-        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1664525UL))
+        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * UINT64_C(1664525)))
           + init_key[j] + j; /* non linear */
-        mt[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
+        mt[i] &= UINT64_C(0xffffffff); /* for WORDSIZE > 32 machines */
         i++; j++;
         if (i>=N) { mt[0] = mt[N-1]; i=1; }
         if (j>=key_length) j=0;
     }
     for (k=N-1; k; k--) {
-        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1566083941UL))
+        mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * UINT64_C(1566083941)))
           - i; /* non linear */
-        mt[i] &= 0xffffffffUL; /* for WORDSIZE > 32 machines */
+        mt[i] &= UINT64_C(0xffffffff); /* for WORDSIZE > 32 machines */
         i++;
         if (i>=N) { mt[0] = mt[N-1]; i=1; }
     }
 
-    mt[0] = 0x80000000UL; /* MSB is 1; assuring non-zero initial array */
+    mt[0] = UINT64_C(0x80000000); /* MSB is 1; assuring non-zero initial array */
 }
 /* generates a random number on [0,0xffffffff]-interval */
 randstate_t mt_random(void)
 {
     randstate_t y;
-    randstate_t mag01[2]={0x0UL, MATRIX_A};
+    randstate_t mag01[2]={UINT64_C(0x0), MATRIX_A};
     /* mag01[x] = x * MATRIX_A  for x=0,1 */
 
     if (mti >= N) { /* generate N words at one time */
         int kk;
 
         if (mti == N+1)   /* if mt_srandom() has not been called, */
-            mt_srandom(5489UL); /* a default initial seed is used */
+            mt_srandom(UINT64_C(5489)); /* a default initial seed is used */
 
         for (kk=0;kk<N-M;kk++) {
             y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-            mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & 0x1UL];
+            mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & UINT64_C(0x1)];
         }
         for (;kk<N-1;kk++) {
             y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-            mt[kk] = mt[kk+(M-N)] ^ (y >> 1) ^ mag01[y & 0x1UL];
+            mt[kk] = mt[kk+(M-N)] ^ (y >> 1) ^ mag01[y & UINT64_C(0x1)];
         }
         y = (mt[N-1]&UPPER_MASK)|(mt[0]&LOWER_MASK);
-        mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & 0x1UL];
+        mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & UINT64_C(0x1)];
 
         mti = 0;
     }
@@ -4243,8 +4243,8 @@ randstate_t mt_random(void)
 
     /* Tempering */
     y ^= (y >> 11);
-    y ^= (y << 7) & 0x9d2c5680UL;
-    y ^= (y << 15) & 0xefc60000UL;
+    y ^= (y << 7) & UINT64_C(0x9d2c5680);
+    y ^= (y << 15) & UINT64_C(0xefc60000);
     y ^= (y >> 18);
 
     return y;
@@ -4287,27 +4287,27 @@ rng.html>
 /* [ x, y, z, w, carry, k, m ] */
 
 randstate_t *kiss_srandom(randstate_t state[7], randstate_t seed) {
-  if (seed == 0) seed = 1ul;
-  state[0] = seed | 1ul; // x
-  state[1] = seed | 2ul; // y
-  state[2] = seed | 4ul; // z
-  state[3] = seed | 8ul; // w
-  state[4] = 0ul;        // carry
-  state[5] = 0ul;        // carry
-  state[6] = 0ul;        // carry
+  if (seed == 0) seed = UINT64_C(1);
+  state[0] = seed | UINT64_C(1); // x
+  state[1] = seed | UINT64_C(2); // y
+  state[2] = seed | UINT64_C(4); // z
+  state[3] = seed | UINT64_C(8); // w
+  state[4] = UINT64_C(0); // carry
+  state[5] = UINT64_C(0); // carry
+  state[6] = UINT64_C(0); // carry
   return NULL;
 }
 
 randstate_t kiss_random(randstate_t state[7]) {
-    state[0] = state[0] * 69069ul + 1ul;
-    state[1] ^= state[1] << 13ul;
-    state[1] ^= state[1] >> 17ul;
-    state[1] ^= state[1] << 5ul;
-    state[5] = (state[2] >> 2ul) + (state[3] >> 3ul) + (state[4] >> 2ul);
+    state[0] = state[0] * UINT64_C(69069) + UINT64_C(1);
+    state[1] ^= state[1] << UINT64_C(13);
+    state[1] ^= state[1] >> UINT64_C(17);
+    state[1] ^= state[1] << UINT64_C(5);
+    state[5] = (state[2] >> UINT64_C(2)) + (state[3] >> UINT64_C(3)) + (state[4] >> UINT64_C(2));
     state[6] = state[3] + state[3] + state[2] + state[4];
     state[2] = state[3];
     state[3] = state[6];
-    state[4] = state[5] >> 30ul;
+    state[4] = state[5] >> UINT64_C(30);
     return state[0] + state[1] + state[3];
 }
 /* end of "KISS" rng */

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -619,18 +619,18 @@ void mcdis_sphere(double x, double y, double z, double r);
 
 
 #if RNG_ALG == _RNG_ALG_MT  // MT (currently not functional for gpu)
-#  define MC_RAND_MAX ((uint64_t)0xffffffff)
-#  define randstate_t uint64_t // this could be anything
+#  define MC_RAND_MAX UINT64_C(0xffffffff)
+#  define randstate_t unsigned long // this could be anything
 #  define RANDSTATE_LEN 1
 #  define srandom(seed) mt_srandom_empty()
 #  define random() mt_random()
 #  define _random() mt_random()
 #elif RNG_ALG == _RNG_ALG_KISS  // KISS
 #  ifndef ULONG_MAX
-#    define ULONG_MAX ((uint64_t)0xffffffffffffffffUL)
+#    define ULONG_MAX UINT64_C(0xffffffffffffffffUL)
 #  endif
 #  define MC_RAND_MAX ULONG_MAX
-#  define randstate_t uint64_t
+#  define randstate_t unsigned long
 #  define RANDSTATE_LEN 7
 #  define srandom(seed) kiss_srandom(_particle->randstate, seed)
 #  define random() kiss_random(_particle->randstate)

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -619,18 +619,18 @@ void mcdis_sphere(double x, double y, double z, double r);
 
 
 #if RNG_ALG == _RNG_ALG_MT  // MT (currently not functional for gpu)
-#  define MC_RAND_MAX ((unsigned long)0xffffffff)
-#  define randstate_t unsigned long // this could be anything
+#  define MC_RAND_MAX ((uint64_t)0xffffffff)
+#  define randstate_t uint64_t // this could be anything
 #  define RANDSTATE_LEN 1
 #  define srandom(seed) mt_srandom_empty()
 #  define random() mt_random()
 #  define _random() mt_random()
 #elif RNG_ALG == _RNG_ALG_KISS  // KISS
 #  ifndef ULONG_MAX
-#    define ULONG_MAX ((unsigned long)0xffffffffffffffffUL)
+#    define ULONG_MAX ((uint64_t)0xffffffffffffffffUL)
 #  endif
 #  define MC_RAND_MAX ULONG_MAX
-#  define randstate_t unsigned long
+#  define randstate_t uint64_t
 #  define RANDSTATE_LEN 7
 #  define srandom(seed) kiss_srandom(_particle->randstate, seed)
 #  define random() kiss_random(_particle->randstate)
@@ -650,15 +650,15 @@ double _randnorm2(randstate_t* state);
 #define randtriangle() _randtriangle(_particle->randstate)
 
 // Mersenne Twister rng
-unsigned long mt_random(void);
-void mt_srandom (unsigned long x);
+randstate_t mt_random(void);
+void mt_srandom (randstate_t x);
 void mt_srandom_empty();
 
 // KISS rng
 #pragma acc routine
-unsigned long *kiss_srandom(unsigned long state[7], unsigned long seed);
+randstate_t *kiss_srandom(randstate_t state[7], randstate_t seed);
 #pragma acc routine
-unsigned long kiss_random(unsigned long state[7]);
+randstate_t kiss_random(randstate_t state[7]);
 
 // Scrambler / hash function
 #pragma acc routine seq

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -619,21 +619,22 @@ void mcdis_sphere(double x, double y, double z, double r);
 
 
 #if RNG_ALG == _RNG_ALG_MT  // MT (currently not functional for GPU)
-#  define MC_RAND_MAX ((uint64_t)0xffffffffULL)
-#  define randstate_t uint64_t // this could be anything for MT
+#  define MC_RAND_MAX ((uint32_t)0xffffffffUL)
+#  define randstate_t uint32_t
 #  define RANDSTATE_LEN 1
 #  define srandom(seed) mt_srandom_empty()
 #  define random() mt_random()
 #  define _random() mt_random()
-
 #elif RNG_ALG == _RNG_ALG_KISS  // KISS
+#  ifndef UINT64_MAX
+#    define UINT64_MAX ((uint64_t)0xffffffffffffffffULL)
+#  endif
 #  define MC_RAND_MAX UINT64_MAX
 #  define randstate_t uint64_t
 #  define RANDSTATE_LEN 7
 #  define srandom(seed) kiss_srandom(_particle->randstate, seed)
 #  define random() kiss_random(_particle->randstate)
 #  define _random() kiss_random(state)
-
 #endif
 
 #pragma acc routine
@@ -648,8 +649,8 @@ double _randnorm2(randstate_t* state);
 #define randtriangle() _randtriangle(_particle->randstate)
 
 // Mersenne Twister rng
-randstate_t mt_random(void);
-void mt_srandom (randstate_t x);
+uint32_t mt_random(void);
+void mt_srandom (uint32_t x);
 void mt_srandom_empty();
 
 // KISS rng

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -618,31 +618,29 @@ void mcdis_sphere(double x, double y, double z, double r);
 #endif
 
 
-#if RNG_ALG == _RNG_ALG_MT  // MT (currently not functional for gpu)
-#  define MC_RAND_MAX UINT64_C(0xffffffff)
-#  define randstate_t unsigned long // this could be anything
+#if RNG_ALG == _RNG_ALG_MT  // MT (currently not functional for GPU)
+#  define MC_RAND_MAX ((uint64_t)0xffffffffULL)
+#  define randstate_t uint64_t // this could be anything for MT
 #  define RANDSTATE_LEN 1
 #  define srandom(seed) mt_srandom_empty()
 #  define random() mt_random()
 #  define _random() mt_random()
+
 #elif RNG_ALG == _RNG_ALG_KISS  // KISS
-#  ifndef ULONG_MAX
-#    define ULONG_MAX UINT64_C(0xffffffffffffffffUL)
-#  endif
-#  define MC_RAND_MAX ULONG_MAX
-#  define randstate_t unsigned long
+#  define MC_RAND_MAX UINT64_MAX
+#  define randstate_t uint64_t
 #  define RANDSTATE_LEN 7
 #  define srandom(seed) kiss_srandom(_particle->randstate, seed)
 #  define random() kiss_random(_particle->randstate)
 #  define _random() kiss_random(state)
+
 #endif
 
 #pragma acc routine
 double _randnorm2(randstate_t* state);
 
-
-// component writers interface
-#define randnorm() _randnorm2(_particle->randstate) // NOTE: can not use _randnorm on gpu
+// Component writer interface
+#define randnorm() _randnorm2(_particle->randstate)        // NOTE: can't use _randnorm on GPU
 #define rand01() _rand01(_particle->randstate)
 #define randpm1() _randpm1(_particle->randstate)
 #define rand0max(p1) _rand0max(p1, _particle->randstate)
@@ -656,9 +654,9 @@ void mt_srandom_empty();
 
 // KISS rng
 #pragma acc routine
-randstate_t *kiss_srandom(randstate_t state[7], randstate_t seed);
+uint64_t *kiss_srandom(uint64_t state[7], uint64_t seed);
 #pragma acc routine
-randstate_t kiss_random(randstate_t state[7]);
+uint64_t kiss_random(uint64_t state[7]);
 
 // Scrambler / hash function
 #pragma acc routine seq

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -608,16 +608,6 @@ void mcdis_sphere(double x, double y, double z, double r);
 
 /* random number generation. ================================================ */
 
-/* available random number generators */
-#define _RNG_ALG_MT         1
-#define _RNG_ALG_KISS       2
-
-/* selection of random number generator */
-#ifndef RNG_ALG
-#  define RNG_ALG  _RNG_ALG_KISS
-#endif
-
-
 #if RNG_ALG == _RNG_ALG_MT  // MT (currently not functional for GPU)
 #  define MC_RAND_MAX ((uint32_t)0xffffffffUL)
 #  define randstate_t uint32_t

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2386,13 +2386,15 @@ cogen_header(struct instr_def *instr, char *output_name)
   /* Basic includes */
   cout("");
   cout("#include <string.h>");
+  cout("#include <inttypes.h>");
   cout("");
 
-  /* McCode-specific typedefs */
+  /* McCode-specific typedefs and defines */
   cout("typedef double MCNUM;");
   cout("typedef struct {MCNUM x, y, z;} Coords;");
   cout("typedef MCNUM Rotation[3][3];");
   cout("#define MCCODE_BASE_TYPES");
+  cout("#define randstate_t uint64_t");
   cout("");
 
   /* the max number of user variables*/

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2394,7 +2394,19 @@ cogen_header(struct instr_def *instr, char *output_name)
   cout("typedef struct {MCNUM x, y, z;} Coords;");
   cout("typedef MCNUM Rotation[3][3];");
   cout("#define MCCODE_BASE_TYPES");
+  cout("");
+  cout("/* available random number generators */");
+  cout("#define _RNG_ALG_MT         1");
+  cout("#define _RNG_ALG_KISS       2");
+  cout("/* selection of random number generator */");
+  cout("#ifndef RNG_ALG");
+  cout("#  define RNG_ALG  _RNG_ALG_KISS");
+  cout("#endif");
+  cout("#if RNG_ALG == _RNG_ALG_MT // MT ");
+  cout("#define randstate_t uint32_t");
+  cout("#elif RNG_ALG == _RNG_ALG_KISS  // KISS");
   cout("#define randstate_t uint64_t");
+  cout("#endif");
   cout("");
 
   /* the max number of user variables*/

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2389,7 +2389,7 @@ cogen_header(struct instr_def *instr, char *output_name)
   cout("#include <inttypes.h>");
   cout("");
 
-  /* McCode-specific typedefs and defines */
+  /* McCode-specific typedefs */
   cout("typedef double MCNUM;");
   cout("typedef struct {MCNUM x, y, z;} Coords;");
   cout("typedef MCNUM Rotation[3][3];");

--- a/mcstas/src/cogen.c.in
+++ b/mcstas/src/cogen.c.in
@@ -2446,7 +2446,7 @@ cogen_header(struct instr_def *instr, char *output_name)
   cout("  double _mctmp_b; /* temp b */");
   cout("  double _mctmp_c; /* temp c */");
   //cout("  randstate_t randstate[RANDSTATE_LEN]");
-  cout("  unsigned long randstate[7];"); // for the KISS generator
+  cout("  randstate_t randstate[7];"); // for the KISS generator
   cout("  double t, p;     /* time, event weight */");
   cout("  long long _uid;  /* Unique event ID */");
   cout("  long _index;     /* component index where to send this event */");


### PR DESCRIPTION
We finally have full KISS RNG agreement between platforms

* macOS arm: ![macOS_arm](https://github.com/user-attachments/assets/8c2f3b31-8dff-49e6-a5ad-0915a918865b)
* Windows arm: ![Windows_arm](https://github.com/user-attachments/assets/5896a135-9288-4023-96c3-9bbb7bdce313)
* Linux arm (plot via Windows mcplot) ![Linux_arm_plot_via_Windows](https://github.com/user-attachments/assets/337cd608-23a7-4902-b36b-3dcfc53d2b7b)

(Original implementation was not using `uint64_t` but the less well-defined `unsigned long` base which ends up 32bit on windows...)