### PR TITLE
Suppress const char in the cif2hkl fcts

### DIFF
--- a/mcstas-comps/samples/PowderN.comp
+++ b/mcstas-comps/samples/PowderN.comp
@@ -283,7 +283,7 @@ struct line_info_struct
   //   used to convert CIF/CFL/INS file into F2(hkl)
   //   the CIF2HKL env var can point to a cif2hkl executable
   //   else the McCode binary is attempted, then the system.
-  char *cif2hkl(const char *infile, char *options) {
+  char *cif2hkl(char *infile, char *options) {
     char cmd[1024];
     int  ret = 0;
     int  found = 0;

--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -391,7 +391,7 @@ struct hkl_data
   //   used to convert CIF/CFL/INS file into F2(hkl)
   //   the CIF2HKL env var can point to a cif2hkl executable
   //   else the McCode binary is attempted, then the system.
-  char *cif2hkl(const char *infile, const char *options) {
+  char *cif2hkl(char *infile, char *options) {
     char cmd[1024];
     int  ret = 0;
     int  found = 0;

--- a/mcxtrace-comps/samples/PowderN.comp
+++ b/mcxtrace-comps/samples/PowderN.comp
@@ -278,7 +278,7 @@ SHARE
   //   used to convert CIF/CFL/INS file into F2(hkl)
   //   the CIF2HKL env var can point to a cif2hkl executable
   //   else the McCode binary is attempted, then the system.
-  char *cif2hkl(const char *infile, const char *options) {
+  char *cif2hkl(char *infile, char *options) {
     char cmd[1024];
     int  ret = 0;
     int  found = 0;

--- a/mcxtrace-comps/samples/Single_crystal.comp
+++ b/mcxtrace-comps/samples/Single_crystal.comp
@@ -404,7 +404,7 @@ SHARE
   //   used to convert CIF/CFL/INS file into F2(hkl)
   //   the CIF2HKL env var can point to a cif2hkl executable
   //   else the McCode binary is attempted, then the system.
-  char *cif2hkl(const char *infile, const char *options) {
+  char *cif2hkl(char *infile, char *options) {
     char cmd[1024];
     int  ret = 0;
     int  found = 0;


### PR DESCRIPTION
The const char filenames in fact only yield more warnings, suppressing.