### PR TITLE
mcrun and msvc: drop -lm and -o instr.exe

### DIFF
--- a/cmake/Modules/PlatformDefaults.cmake
+++ b/cmake/Modules/PlatformDefaults.cmake
@@ -259,7 +259,7 @@ function( detect_platform_variables resultvarname )
     set( MCCODE_CFLAGS "${MCCODE_CFLAGS} -I\$\{CONDA_PREFIX\}/include -Wl,-rpath,\$\{CONDA_PREFIX\}/lib -L\$\{CONDA_PREFIX\}/lib" )
   endif()
 
-  foreach( flag "-fno-PIC" "-fPIE" "-flto" "-O3" "-mtune=native" "-march=native" "-fno-math-errno" "-ftree-vectorize" "-g" "-DNDEBUG" "-D_POSIX_SOURCE" "-std=c99" )
+  foreach( flag "-fno-PIC" "-fPIE" "-flto" "-O3" "-mtune=native" "-march=native" "-fno-math-errno" "-ftree-vectorize" "-g" "-DNDEBUG" "-D_POSIX_SOURCE" "-std=c99" "-lm" )
     #NB: plethora of "unset(tmp_test_c_flag_result ...)" statements below is
     #added for safety, to prevent CMake's CACHE system to give unpredictable
     #results.

--- a/cmake/Modules/PlatformDefaults.cmake
+++ b/cmake/Modules/PlatformDefaults.cmake
@@ -259,7 +259,7 @@ function( detect_platform_variables resultvarname )
     set( MCCODE_CFLAGS "${MCCODE_CFLAGS} -I\$\{CONDA_PREFIX\}/include -Wl,-rpath,\$\{CONDA_PREFIX\}/lib -L\$\{CONDA_PREFIX\}/lib" )
   endif()
 
-  foreach( flag "-fno-PIC" "-fPIE" "-flto" "-O3" "-mtune=native" "-march=native" "-fno-math-errno" "-ftree-vectorize" "-g" "-DNDEBUG" "-D_POSIX_SOURCE" "-std=c99" "-lm")
+  foreach( flag "-fno-PIC" "-fPIE" "-flto" "-O3" "-mtune=native" "-march=native" "-fno-math-errno" "-ftree-vectorize" "-g" "-DNDEBUG" "-D_POSIX_SOURCE" "-std=c99" )
     #NB: plethora of "unset(tmp_test_c_flag_result ...)" statements below is
     #added for safety, to prevent CMake's CACHE system to give unpredictable
     #results.

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -304,7 +304,10 @@ class McStas:
                 cflags=cflags.replace("${CONDA_PREFIX}",os.environ.get('CONDA_PREFIX'))
 
         # Final assembly of compiler commandline
-        args = ['-o', self.binpath, self.cpath] + lexer.split(cflags)
+        if not os.environ.get('CONDA_PREFIX') and "cl.exe" in mccode_config.compilation['CC'].lower():
+            args = ['-o', self.binpath, self.cpath] + lexer.split(cflags)
+        else:
+            args = [self.cpath] + lexer.split(cflags)
         Process(lexer.quote(options.cc)).run(args)
 
     def run(self, pipe=False, extra_opts=None, override_mpi=None):

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -175,7 +175,7 @@ class McStas:
 
         # Setup cflags, use -lm anywhere else than Windows-conda with cl.exe
         cflags = ''
-        if not os.environ.get('CONDA_PREFIX') and "cl.exe" in mccode_config.compilation['CC'].lower():
+        if not "cl.exe" in mccode_config.compilation['CC'].lower():
             cflags += '-lm ' # math library
 
         # Special support for conda environment with compilers included. To be
@@ -304,7 +304,7 @@ class McStas:
                 cflags=cflags.replace("${CONDA_PREFIX}",os.environ.get('CONDA_PREFIX'))
 
         # Final assembly of compiler commandline
-        if not os.environ.get('CONDA_PREFIX') and "cl.exe" in mccode_config.compilation['CC'].lower():
+        if not "cl.exe" in mccode_config.compilation['CC'].lower():
             args = ['-o', self.binpath, self.cpath] + lexer.split(cflags)
         else:
             args = [self.cpath] + lexer.split(cflags)


### PR DESCRIPTION
Newer versions of msvc are complaining about "-o" to become deprecated and "-lm" not supported:
```
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34808 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

cl : Command line warning D9035 : option 'o' has been deprecated and will be removed in a future release
cl : Command line warning D9002 : ignoring unknown option '-lm'
```
This PR adds minimal changes in `mccode.py` to suppress these warnings.