### PR TITLE
Update plotfuncs.py: fix log scale when min(data) ~ 0

### DIFF
--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -198,7 +198,7 @@ def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, f
         if len(idx) > 0:
             ymin = np.min(idx)/10
             if ymin <= 0:
-                ymin=1e-37 # kind of 1/FLTMAX
+                ymin=100*sys.float_info.min # Small, finite value.
             dataset[dataset<=0] = ymin
             dataset = np.reshape(dataset, datashape)
             dataset = np.log10(dataset)

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -197,6 +197,8 @@ def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, f
         idx = dataset[dataset>0]
         if len(idx) > 0:
             ymin = np.min(idx)/10
+            if ymin <= 0:
+                ymin=1e-37 # kind of 1/FLTMAX
             dataset[dataset<=0] = ymin
             dataset = np.reshape(dataset, datashape)
             dataset = np.log10(dataset)


### PR DESCRIPTION
In some datasets, mcplot the L-key for log10 bring a divide by 0. It seems the ymin is set to (nearly ?) 0. In this case, we use 1/FLTMAX ~1e-37