### PR TITLE
Mcxtrace fluo fix pow 0

### DIFF
--- a/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
@@ -23,10 +23,10 @@
 * - index=5: use Fluorescence+PowderN (slow, under estimates contributions)
 *
 * %Example: Test_FluoPowder.instr E0=15 index=1 Detector: Sph_mon_I=2.2379e-18
-* %Example: Test_FluoPowder.instr E0=15 index=2 Detector: Sph_mon_I=2.49656e-18
-* %Example: Test_FluoPowder.instr E0=15 index=3 Detector: Sph_mon_I=2.84012e-18
-* %Example: Test_FluoPowder.instr E0=15 index=4 Detector: Sph_mon_I=7.83812e-19
-* %Example: Test_FluoPowder.instr E0=15 index=5 Detector: Sph_mon_I=2.21276e-18
+* %Example: Test_FluoPowder.instr E0=15 index=2 Detector: Sph_mon_I=1.89376e-18
+* %Example: Test_FluoPowder.instr E0=15 index=3 Detector: Sph_mon_I=2.79924e-18
+* %Example: Test_FluoPowder.instr E0=15 index=4 Detector: Sph_mon_I=7.63749e-19
+* %Example: Test_FluoPowder.instr E0=15 index=5 Detector: Sph_mon_I=2.96629e-18
 *
 * %Parameters
 * E0:          [keV]  Source mean energy of xrays.
@@ -160,7 +160,7 @@ COMPONENT E_mon_flu = COPY(E_mon)(filename="Energy_flu")
 
 // ideal "banana" detector
 COMPONENT det_angle = Monitor_nD(options="abs theta limits=[5 90]",
-                                 radius=0.6, yheight=1e-2, bins=10000)
+                                 radius=0.6, yheight=5e-2, bins=512)
 AT (0,0,0) RELATIVE PREVIOUS
 
 END

--- a/mcxtrace-comps/examples/Tests_samples/Test_SX/Test_SX.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_SX/Test_SX.instr
@@ -14,13 +14,18 @@
 *
 * Simply a model source illuminating a SX sample.
 * The sample itself is a Mo bulk crystal.
+* The idea is to compare the fluorescence and diffraction patterns:
+* - index=1: use Single_crystal
+* - index=2: use FluoCrystal
+* - index=3: use Fluorescence+Single_crystal in a GROUP
 *
 * %Example: index=1 Detector: psd4pi_I=1.18843e-13
-* %Example: index=2 Detector: psd4pi_I=4.80386e-13
+* %Example: index=2 Detector: psd4pi_I=6.89931e-12
+* %Example: index=3 Detector: psd4pi_I=4.4547e-13
 *
 * %Parameters
 * reflections: [str] List of powder reflections, LAU/CIF format.
-* index:       [1]   Index of the sample component to use. 1=Single_crystal, 2=FluoCrystal
+* index:       [1]   Index of the sample component to use. 1=Single_crystal, 2=FluoCrystal, 3=Fluorescence+Single_crystal in a GROUP
 *
 * %End
 *******************************************************************************/
@@ -56,6 +61,24 @@ AT (0, 0, 0) RELATIVE sample_pos
 EXTEND %{
   if(!SCATTERED) ABSORB;
   else Stype=type;
+%}
+
+COMPONENT FluoG = Fluorescence(
+  radius = .5e-4, yheight = 1e-3, material=reflections)
+WHEN (index == 3)
+AT (0, 0, 0) RELATIVE sample_pos
+GROUP FluSX
+EXTEND %{
+  if (SCATTERED) Stype = type;
+%}
+
+COMPONENT SX = COPY(sample)(sigma_inc=-1)
+WHEN (index == 3)
+AT (0, 0, 0) RELATIVE sample_pos
+GROUP FluSX
+EXTEND %{
+  if (SCATTERED) Stype=DIFFRACTION;
+  else ABSORB;
 %}
 
 COMPONENT psd4pi = PSD_monitor_4PI(

--- a/mcxtrace-comps/samples/FluoCrystal.comp
+++ b/mcxtrace-comps/samples/FluoCrystal.comp
@@ -26,7 +26,7 @@
 *
 * The 'material' specification is given as a chemical formulae, e.g. "LaB6". It
 * may also be given as a file name (CIF/LAU/LAZ/FullProf format) in which case
-* the formulae is guessed (but may be approximative), and the powder
+* the formulae is guessed (but may be approximative), and the crystal
 * diffraction is computed, following same options as the <b>PowderN</b>
 * sample component. The fluorescence is handled for atoms from Z=5 to Z=90.
 *
@@ -85,7 +85,7 @@
 * In addition, it may be desirable to define a 'target' for the fluorescence
 * processes via e.g. the 'target_index' and the 'focus_xw / focus_yh' options.
 * This target should e.g. be the SDD area.
-* The powder scattering can be focused along an horizontal tore via the
+* The crystal scattering can be focused along an horizontal tore via the
 * 'sx_d_phi' and 'sx_sign' options. To get a vertical tore, rotate
 * the sample by 90 deg around Z.
 *
@@ -144,7 +144,7 @@
 * target_z:       [m] Position of target to focus at, along Z (for fluorescence).
 * flag_compton:   [1] When 0, the Compton  scattering is ignored.
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
-* flag_sx:    [1] When 0, the powder diffraction is ignored.
+* flag_sx:    [1] When 0, the crystal diffraction is ignored.
 * flag_lorentzian:[1] When 1, the fluorescence line shapes are assumed to be Lorentzian, else Gaussian.
 * escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. 0 inactivates.
 * escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
@@ -158,6 +158,21 @@
 * sx_refl:  [str] A CIF/LAZ/LAU reflection file as for PowderN. When not given, 'material' is used. Specify it when 'material' is a chemical formula.
 * sx_sign:    [1] Sign of the scattering angle. If 0, the sign is chosen randomly (left and right).
 * sx_Vc:   [AA^3] Volume of unit cell=nb atoms per cell/density of atoms.
+* sx_mosaic:   [arc minutes] Crystal mosaic (isotropic), gaussian RMS. Puts the crystal in the isotropic mosaic model state, thus disregarding other mosaicity parameters.
+* sx_mosaic_a: [arc minutes] Horizontal (rotation around lattice vector a) mosaic (anisotropic), gaussian RMS. Put the crystal in the anisotropic crystal vector state. I.e. model mosaicity through rotation around the crystal lattice vectors. Has precedence over in-plane mosaic model.
+* sx_mosaic_b: [arc minutes] Vertical (rotation around lattice vector b) mosaic (anisotropic), gaussian RMS.
+* sx_mosaic_c: [arc minutes] Out-of-plane (Rotation around lattice vector c) mosaic (anisotropic), gaussian RMS
+* sx_mosaic_AB: [arc_minutes, arc_minutes,1, 1, 1, 1, 1, 1]  In Plane mosaic rotation and plane vectors (anisotropic), mosaic_A, mosaic_B, A_h,A_k,A_l, B_h,B_k,B_l. Puts the crystal in the in-plane mosaic state. Vectors A and B define plane in which  the crystal roation is defined, and mosaic_A, mosaic_B, denotes the resp. mosaicities (gaussian RMS) with respect to the two reflections chosen by A and B (Miller indices).
+* sx_recip_cell:        [1] Choice of direct/reciprocal (0/1) unit cell definition
+* sx_ax:      [AA or AA^-1] Coordinates of first (direct/recip) unit cell vector
+* sx_ay:      [AA or AA^-1]   a on y axis
+* sx_az:      [AA or AA^-1]   a on z axis
+* sx_bx:      [AA or AA^-1] Coordinates of second (direct/recip) unit cell vector
+* sx_by:      [AA or AA^-1]   b on y axis
+* sx_bz:      [AA or AA^-1]   b on z axis
+* sx_cx:      [AA or AA^-1] Coordinates of third (direct/recip) unit cell vector
+* sx_cy:      [AA or AA^-1]   c on y axis
+* sx_cz:      [AA or AA^-1]   c on z axis
 * order:          [1] Limit multiple fluorescence up to given order. Last iteration is absorption only.
 *
 * CALCULATED PARAMETERS:

--- a/mcxtrace-comps/samples/FluoPowder.comp
+++ b/mcxtrace-comps/samples/FluoPowder.comp
@@ -947,7 +947,7 @@ do { /* while (intersect) Loop over multiple scattering events */
   if (intersect) { /* scattering event */
     int    i_Z=-1, Z, line=-1;
     double solid_angle;
-    double theta, dsigma, alpha;
+    double theta, dsigma, alpha=0;
     double Ef, dE;
     double kf=k, kf_x, kf_y, kf_z;  // next particle direction
 
@@ -1027,12 +1027,12 @@ do { /* while (intersect) Loop over multiple scattering events */
       { /* relate height of detector to the height on DS cone */
         arg = sin(powder_d_phi*DEG2RAD/2)/sin(2*theta);
         /* If full Debye-Scherrer cone is within powder_d_phi, don't focus */
-        if (arg < -1 || arg > 1) alpha = 0;
+        if (arg < -1 || arg > 1) powder_d_phi = 0;
         /* Otherwise, determine alpha to rotate from scattering plane
          *    into powder_d_phi focusing area */
         else alpha = 2*asin(arg);
       }
-      if (alpha) {
+      if (powder_d_phi) {
         /* Focusing */
         alpha  = fabs(alpha);
         alpha0 = 0.5*randpm1()*alpha;
@@ -1097,13 +1097,13 @@ do { /* while (intersect) Loop over multiple scattering events */
         if (Ex!=0 || Ey!=0 || Ez!=0){
           double EE=sqrt(Ex*Ex+Ey*Ey+Ez*Ez);
           double s=scalar_prod(kf_x,kf_y,kf_z,Ex,Ey,Ez)/EE;
-          p*=(1-s)*(1-s);
-        }else{
+          p *= (1-s)*(1-s);
+        } else {
           /*unpolarized light in - means an effective reduction according to only theta*/
-          p*=(1+cos(theta)*cos(theta))*0.5;
+          p *= (1+cos(theta)*cos(theta))*0.5;
         }
         if (alpha) {
-          p    *= alpha/PI;
+          p *= alpha/PI;
         }
         n_diff++;
         p_diff += p;

--- a/mcxtrace-comps/samples/PowderN.comp
+++ b/mcxtrace-comps/samples/PowderN.comp
@@ -1079,7 +1079,7 @@ TRACE
           }
           if (d_phi_thread) {
             /* Focusing */
-            alpha = fabs(alpha);
+            alpha  = fabs(alpha);
             alpha0 = 0.5*randpm1()*alpha;
             if(focus_flip){
                 alpha0+=M_PI_2;


### PR DESCRIPTION
**mcxtrace**
A fix in `FluoPowder` which "sometimes" brings diffraction I=0 due to a rounding error on some architectures (amd64 behaves differently than arm64).
Also add a Fluo+SX GROUP example in `Test_SX`.
There are still a few strange behaviours in the intensity for SX with fluorescence...