### PR TITLE
Mcxtrace fluo fix 2

### DIFF
--- a/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
@@ -5,9 +5,10 @@
 *
 * %Identification
 * Written by: Emmanuel Farhi (emmanuel.farhi.synchrotron-soleil.fr)
-* Date: 2009
-* Origin: SOLEIL
-* Version: 1.0
+* Date: 2025
+* Origin: Synchrotron Soleil
+* Release: McXtrace 3.5
+* Version: $Revision$
 * %INSTRUMENT_SITE: Tests_samples
 *
 * Unit-test instrument for the FluoPowder sample component.
@@ -17,16 +18,16 @@
 * The default sample itself is an LaB6-powder.
 * The idea is to compare the fluorescence and diffraction patterns:
 * - index=1: use PowderN              (no fluorescence)
-* - index=2: use Single_crystal       (no fluorescence, very slow)
+* - index=2: use Single_crystal       (no fluorescence, slower, powder mode)
 * - index=3: use FluoPowder           (exact)
 * - index=4: use Fluorescence         (no diffraction)
-* - index=5: use Fluorescence+PowderN (slow, under estimates contributions)
+* - index=5: use Fluorescence+PowderN (under estimates contributions)
 *
-* %Example: Test_FluoPowder.instr E0=15 index=1 Detector: Sph_mon_I=2.2379e-18
+* %Example: Test_FluoPowder.instr E0=15 index=1 Detector: Sph_mon_I=2.23119e-18
 * %Example: Test_FluoPowder.instr E0=15 index=2 Detector: Sph_mon_I=1.89376e-18
-* %Example: Test_FluoPowder.instr E0=15 index=3 Detector: Sph_mon_I=2.79924e-18
+* %Example: Test_FluoPowder.instr E0=15 index=3 Detector: Sph_mon_I=2.83261e-18
 * %Example: Test_FluoPowder.instr E0=15 index=4 Detector: Sph_mon_I=7.63749e-19
-* %Example: Test_FluoPowder.instr E0=15 index=5 Detector: Sph_mon_I=2.96629e-18
+* %Example: Test_FluoPowder.instr E0=15 index=5 Detector: Sph_mon_I=2.11144e-18
 *
 * %Parameters
 * E0:          [keV]  Source mean energy of xrays.
@@ -37,7 +38,7 @@
 *
 * %End
 *******************************************************************************/
-DEFINE INSTRUMENT Test_FluoPowder(E0=15, dE=1, L1=10, string material="LaB6.cif",
+DEFINE INSTRUMENT Test_FluoPowder(E0=15, dE=0.05, L1=10, string material="LaB6.cif",
     int index=3)
 
 USERVARS %{
@@ -114,7 +115,7 @@ EXTEND %{
   scatt_type = type;
 %}
 
-COMPONENT FluoG = COPY(Fluo)
+COMPONENT FluoG = COPY(Fluo)(p_interact=0.5)
 WHEN (index == 5)
 AT (0, 0, 0) RELATIVE sample_cradle
 GROUP FluPow

--- a/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/Test_Fluorescence.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/Test_Fluorescence.instr
@@ -7,7 +7,7 @@
 * Written by: E. Farhi (emmanuel.farhi@synchrotron-soleil.fr)
 * Date: March '21
 * Origin: Synchrotron SOLEIL
-* Release: McXtrace 1.7
+* Release: McXtrace 3.5
 * Version: $Revision$
 * %INSTRUMENT_SITE: Tests_samples
 *
@@ -17,7 +17,7 @@
 * This instrument simply has a lab source, a few monitors and a sample 
 * to model material fluorescence, Compton and Rayleigh scattering. 
 * 
-* %Example: Test_Fluorescence.instr material=LaB6 -n1e5 Detector: emon_I=7.3e-13
+* %Example: Test_Fluorescence.instr material=LaB6 -n1e5 Detector: emon_I=1.04399e-12
 *
 * %Parameters
 * material: [str]  Material file to use, e.g. chemical formulae "Pb2SnO4"

--- a/mcxtrace-comps/examples/Tests_samples/Test_SX/Test_SX.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_SX/Test_SX.instr
@@ -7,55 +7,73 @@
 * Written by: E. Farhi
 * Date: Sept 26th 2019
 * Origin: Synchrotron Soleil
-* Version: 0.2
+* Release: McXtrace 3.5
+* Version: $Revision$
 * %INSTRUMENT_SITE: Tests_samples
 *
 * Unit-test instrument for the Single_crystal sample component.
 *
 * Simply a model source illuminating a SX sample.
-* The sample itself is a Mo bulk crystal.
+* The default sample itself is a Mo bulk crystal.
 * The idea is to compare the fluorescence and diffraction patterns:
 * - index=1: use Single_crystal
 * - index=2: use FluoCrystal
 * - index=3: use Fluorescence+Single_crystal in a GROUP
 *
-* %Example: index=1 Detector: psd4pi_I=1.18843e-13
-* %Example: index=2 Detector: psd4pi_I=6.89931e-12
-* %Example: index=3 Detector: psd4pi_I=4.4547e-13
+* %Example: index=1 Detector: psd_Diff_I=2.29638e-13
+* %Example: index=2 Detector: psd_Diff_I=6.60276e-14
+* %Example: index=3 Detector: psd_Diff_I=1.19386e-13
 *
 * %Parameters
 * reflections: [str] List of powder reflections, LAU/CIF format.
 * index:       [1]   Index of the sample component to use. 1=Single_crystal, 2=FluoCrystal, 3=Fluorescence+Single_crystal in a GROUP
+* E0:          [keV] Source mean energy of xrays.
+* dE:          [keV] Source energy half spread of x-rays.
 *
 * %End
 *******************************************************************************/
 
-DEFINE INSTRUMENT Test_SX(string reflections="Mo.lau", index=1)
+DEFINE INSTRUMENT Test_SX(string reflections="Mo.lau", int index=1, E0 = 7, dE = 6.9)
 
 USERVARS %{
   int Stype;
 %}
 
+INITIALIZE %{
+  MPI_MASTER(
+    switch (index) {
+      case 1:
+        printf("%s: Using Single_crystal (pure diffraction)\n", NAME_INSTRUMENT); break;
+      case 2:
+        printf("%s: Using FluoCrystal    (fluorescence+diffraction)\n", NAME_INSTRUMENT); break;
+      case 3:
+        printf("%s: Using Fluorescence+Single_crystal in a GROUP (fluorescence+diffraction)\n", NAME_INSTRUMENT); break;
+      default:
+        exit(printf("%s: Unknown sample index %i. Use index=1-4.", NAME_INSTRUMENT, index));
+    });
+  %}
+
 TRACE
 COMPONENT src = Source_flat(
     yheight = 1e-3, xwidth = 1e-3, dist = 10, focus_xw = 1e-3,
-    focus_yh = 1e-3, E0 = 7, dE = 6.9)
+    focus_yh = 1e-3, E0 = E0, dE = dE)
 AT (0, 0, 0) ABSOLUTE
 
 COMPONENT sample_pos=Arm()
 AT (0, 0, 10) RELATIVE PREVIOUS
 
 COMPONENT sample = Single_crystal(reflections=reflections, material_datafile="NULL", 
-    radius = .5e-4, yheight = 1e-3, mosaic=1)
+    radius = .5e-4, yheight = 1e-3, mosaic=5)
     WHEN(index==1)
 AT (0, 0, 0) RELATIVE sample_pos
 EXTEND %{
   if(!SCATTERED) ABSORB;
-  else Stype=DIFFRACTION;
+  else if (hkl_info.type == 'c') Stype=DIFFRACTION;
+  else Stype=FLUORESCENCE;
 %}
 
 COMPONENT sampleF = FluoCrystal(material=reflections,
-    radius = .5e-4, yheight = 1e-3, sx_mosaic=5)
+    radius = .5e-4, yheight = 1e-3, mosaic=5)
     WHEN(index==2)
 AT (0, 0, 0) RELATIVE sample_pos
 EXTEND %{
@@ -64,7 +82,7 @@ EXTEND %{
 %}
 
 COMPONENT FluoG = Fluorescence(
-  radius = .5e-4, yheight = 1e-3, material=reflections)
+  radius = .5e-4, yheight = 1e-3, material=reflections, p_interact=0.5)
 WHEN (index == 3)
 AT (0, 0, 0) RELATIVE sample_pos
 GROUP FluSX
@@ -77,8 +95,10 @@ WHEN (index == 3)
 AT (0, 0, 0) RELATIVE sample_pos
 GROUP FluSX
 EXTEND %{
-  if (SCATTERED) Stype=DIFFRACTION;
-  else ABSORB;
+  if (SCATTERED) {
+    if (hkl_info.type == 'c') Stype=DIFFRACTION;
+    else Stype=FLUORESCENCE;
+  } else ABSORB;
 %}
 
 COMPONENT psd4pi = PSD_monitor_4PI(

--- a/mcxtrace-comps/samples/FluoCrystal.comp
+++ b/mcxtrace-comps/samples/FluoCrystal.comp
@@ -8,9 +8,10 @@
 * Component: FluoCrystal
 *
 * %Identification
-* Written by: E. Farhi
+* Written by: Emmanuel Farhi (emmanuel.farhi.synchrotron-soleil.fr)
 * Date:       April 2025
 * Origin:     Synchrotron SOLEIL
+* Release:    McXtrace 3.5
 *
 * Sample model handling absorption, fluorescence, Compton, Rayleigh scattering and single crystal diffraction.
 *
@@ -35,8 +36,11 @@
 * For instance, a value order>=2 handles e.g. fluorescence iterative cascades
 * in the material. Leaving 'order=0' handles the single scattering only.
 *
+* The single crystal diffraction model is simplified wrt the <b>Single_crystal</b>
+* component. Use that latter with a Fluorescence in a GROUP for more complex features.
+*
 * Example: FluoCrystal(material="LaB6.cif",
-*  xwidth=0.001,yheight=0.001,zdepth=0.0001, p_interact=0.99, mosaic=1)
+*  xwidth=0.001,yheight=0.001,zdepth=0.0001, p_interact=0.99, mosaic=3)
 *
 * <b>Sample shape:</b>
 * Sample shape may be a cylinder, a sphere, a box or any other shape
@@ -85,12 +89,12 @@
 * In addition, it may be desirable to define a 'target' for the fluorescence
 * processes via e.g. the 'target_index' and the 'focus_xw / focus_yh' options.
 * This target should e.g. be the SDD area.
-* The crystal scattering can be focused along an horizontal tore via the
-* 'sx_d_phi' and 'sx_sign' options. To get a vertical tore, rotate
-* the sample by 90 deg around Z.
 *
 * This sample component can advantageously benefit from the SPLIT feature, e.g.
 * SPLIT COMPONENT sample = FluoCrystal(...)
+*
+* If you get strange results, check the crystal mosaicity and delta(d)/d parameters,
+* as this component is not suited for ideal/perfect mosaic crystals.
 *
 * <b>Detector artifacts:</b>
 * This component also simulates the escape and time coincidence peaks in a close-by
@@ -144,36 +148,30 @@
 * target_z:       [m] Position of target to focus at, along Z (for fluorescence).
 * flag_compton:   [1] When 0, the Compton  scattering is ignored.
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
-* flag_sx:    [1] When 0, the crystal diffraction is ignored.
+* flag_sx:        [1] When 0, the crystal diffraction is ignored.
 * flag_lorentzian:[1] When 1, the fluorescence line shapes are assumed to be Lorentzian, else Gaussian.
 * escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. 0 inactivates.
 * escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
 * pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. 0 inactivates.
-* sx_barns:   [1] Flag to indicate if |F|^2 from 'material' is in barns or fm^2, (barns=1 for laz, barns=0 for lau type files).
-* sx_d_phi: [deg] Angle corresponding to the vertical angular range to focus to, e.g. detector height. 0 for no focusing.
-* sx_delta_d_d: [1] Lattice spacing variance, gaussian RMS (longitudinal mosaic)
-* sx_DW:      [1] Global Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2.
-* sx_format: [{}] List of structure file column indexes. See the PowderN component.
-* sx_nb_atoms:[1] Number of sub-unit per unit cell, that is ratio of sigma for chemical formula to sigma per unit cell.
-* sx_refl:  [str] A CIF/LAZ/LAU reflection file as for PowderN. When not given, 'material' is used. Specify it when 'material' is a chemical formula.
-* sx_sign:    [1] Sign of the scattering angle. If 0, the sign is chosen randomly (left and right).
-* sx_Vc:   [AA^3] Volume of unit cell=nb atoms per cell/density of atoms.
-* sx_mosaic:   [arc minutes] Crystal mosaic (isotropic), gaussian RMS. Puts the crystal in the isotropic mosaic model state, thus disregarding other mosaicity parameters.
-* sx_mosaic_a: [arc minutes] Horizontal (rotation around lattice vector a) mosaic (anisotropic), gaussian RMS. Put the crystal in the anisotropic crystal vector state. I.e. model mosaicity through rotation around the crystal lattice vectors. Has precedence over in-plane mosaic model.
-* sx_mosaic_b: [arc minutes] Vertical (rotation around lattice vector b) mosaic (anisotropic), gaussian RMS.
-* sx_mosaic_c: [arc minutes] Out-of-plane (Rotation around lattice vector c) mosaic (anisotropic), gaussian RMS
-* sx_mosaic_AB: [arc_minutes, arc_minutes,1, 1, 1, 1, 1, 1]  In Plane mosaic rotation and plane vectors (anisotropic), mosaic_A, mosaic_B, A_h,A_k,A_l, B_h,B_k,B_l. Puts the crystal in the in-plane mosaic state. Vectors A and B define plane in which  the crystal roation is defined, and mosaic_A, mosaic_B, denotes the resp. mosaicities (gaussian RMS) with respect to the two reflections chosen by A and B (Miller indices).
-* sx_recip_cell:        [1] Choice of direct/reciprocal (0/1) unit cell definition
-* sx_ax:      [AA or AA^-1] Coordinates of first (direct/recip) unit cell vector
-* sx_ay:      [AA or AA^-1]   a on y axis
-* sx_az:      [AA or AA^-1]   a on z axis
-* sx_bx:      [AA or AA^-1] Coordinates of second (direct/recip) unit cell vector
-* sx_by:      [AA or AA^-1]   b on y axis
-* sx_bz:      [AA or AA^-1]   b on z axis
-* sx_cx:      [AA or AA^-1] Coordinates of third (direct/recip) unit cell vector
-* sx_cy:      [AA or AA^-1]   c on y axis
-* sx_cz:      [AA or AA^-1]   c on z axis
 * order:          [1] Limit multiple fluorescence up to given order. Last iteration is absorption only.
+* sx_refl:      [str] A CIF/LAZ/LAU reflection file as for PowderN. When not given, 'material' is used. Specify it when 'material' is a chemical formula.
+* barns:          [1] Flag to indicate if |F|^2 from 'material' is in barns or fm^2, (barns=1 for laz/cif, barns=0 for lau type files).
+* delta_d_d:      [1] Lattice spacing variance, gaussian RMS (longitudinal mosaic) e.g. 1e-4 to 1e-3.
+* mosaic:   [arc min] Crystal mosaic (isotropic), gaussian RMS. Puts the crystal in the isotropic mosaic model state, thus disregarding other mosaicity parameters, e.g. 1-10.
+* mosaic_a: [arc min] Horizontal (rotation around lattice vector a) mosaic (anisotropic), gaussian RMS. Put the crystal in the anisotropic crystal vector state. I.e. model mosaicity through rotation around the crystal lattice vectors. Has precedence over in-plane mosaic model.
+* mosaic_b: [arc min] Vertical (rotation around lattice vector b) mosaic (anisotropic), gaussian RMS.
+* mosaic_c: [arc min] Out-of-plane (Rotation around lattice vector c) mosaic (anisotropic), gaussian RMS
+* mosaic_AB: [arc_minutes, arc_minutes,1, 1, 1, 1, 1, 1]  In Plane mosaic rotation and plane vectors (anisotropic), mosaic_A, mosaic_B, A_h,A_k,A_l, B_h,B_k,B_l. Puts the crystal in the in-plane mosaic state. Vectors A and B define plane in which  the crystal roation is defined, and mosaic_A, mosaic_B, denotes the resp. mosaicities (gaussian RMS) with respect to the two reflections chosen by A and B (Miller indices).
+* recip_cell:     [1] Choice of direct/reciprocal (0/1) unit cell definition
+* ax:   [AA or AA^-1] Coordinates of first (direct/recip) unit cell vector
+* ay:   [AA or AA^-1]   a on y axis
+* az:   [AA or AA^-1]   a on z axis
+* bx:   [AA or AA^-1] Coordinates of second (direct/recip) unit cell vector
+* by:   [AA or AA^-1]   b on y axis
+* bz:   [AA or AA^-1]   b on z axis
+* cx:   [AA or AA^-1] Coordinates of third (direct/recip) unit cell vector
+* cy:   [AA or AA^-1]   c on y axis
+* cz:   [AA or AA^-1]   c on z axis
 *
 * CALCULATED PARAMETERS:
 * type: scattering event type 0=fluorescence, 1=Rayleigh, 2=Compton, 3=transmit (absorbsion), 4=diffraction, 5=detector escape peak, 6=detector pile-up/sum/coincidence peak
@@ -207,14 +205,15 @@ SETTING PARAMETERS(
   target_x = 0, target_y = 0, target_z = 0, focus_r = 0,
   focus_xw=0, focus_yh=0, focus_aw=0, focus_ah=0, int target_index=0,
   int flag_compton=1, int flag_rayleigh=1, int flag_lorentzian=1,
-  string sx_refl="",
-  int flag_sx=1, sx_delta_d_d=1e-4, int sx_barns=1, vector sx_mosaic_AB={0,0, 0,0,0, 0,0,0},
-  sx_recip_cell=0,
-  sx_ax = 0, sx_ay = 0, sx_az = 0,
-  sx_bx = 0, sx_by = 0, sx_bz = 0,
-  sx_cx = 0, sx_cy = 0, sx_cz = 0,
-  sx_aa=0,   sx_bb=0,   sx_cc=0,
-  sx_mosaic = -1, sx_mosaic_a = -1, sx_mosaic_b = -1, sx_mosaic_c = -1,
+  string sx_refl="",  int flag_sx=1,
+  delta_d_d=1e-3,     int barns=1,
+  recip_cell=0,
+  ax = 0, ay = 0, az = 0,
+  bx = 0, by = 0, bz = 0,
+  cx = 0, cy = 0, cz = 0,
+  aa=0,   bb=0,   cc=0,
+  vector mosaic_AB={0,0, 0,0,0, 0,0,0},
+  mosaic = 3, mosaic_a = -1, mosaic_b = -1, mosaic_c = -1,
   escape_ratio=0, escape_energy=1.739,
   pileup_ratio=0,
   int order=1)
@@ -257,6 +256,7 @@ SHARE COPY Single_crystal EXTEND %{
     int    i_line;
 
     if (xs == NULL) return 0;
+    for(i_line=0; i_line<=COMPTON; i_line++) xs[i_line]=0;
 
     // loop on possible fluorescence lines
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) {
@@ -279,6 +279,7 @@ SHARE COPY Single_crystal EXTEND %{
   */
   int XRMC_SelectFromDistribution(double x_arr[], int N)
   {
+    if (x_arr == NULL || N <=0) return (0);
     double x=rand01()*x_arr[N-1];
     if (x<x_arr[0]) {    // x is smaller than lower limit
       return 0;
@@ -308,7 +309,7 @@ SHARE COPY Single_crystal EXTEND %{
     double sum_xs, *cum_xs;
     int    i;
 
-    if (nb_processes < 1) return 0;
+    if (xs == NULL || nb_processes < 1 || nb_processes > TRANSMISSION) return 0;
     cum_xs = malloc((nb_processes+1)*sizeof(double));
     if (!cum_xs)          return 0;
     cum_xs[0]=sum_xs=0;
@@ -350,6 +351,7 @@ SHARE COPY Single_crystal EXTEND %{
   {
       // non_space_count to keep the frequency of non space characters
       int non_space_count = 0;
+      if (string == NULL) return NULL;
 
       //Traverse a string and if it is non space character then, place it at index non_space_count
       for (int i = 0; string[i] != '\0'; i++)
@@ -373,7 +375,8 @@ SHARE COPY Single_crystal EXTEND %{
 
     int  ret = 0;
     char Line[65535];
-    int flag_found_cif=0;
+    int  flag_found_cif=0;
+    if (filename == NULL || formula == NULL) return (0);
     FILE *file = Open_File(filename, "r", NULL);
     if (!file)
       exit(fprintf(stderr, "%s: ERROR: can not open file %s\n",
@@ -542,23 +545,23 @@ INITIALIZE %{
       hkl_info.ctr_FT2 =NULL;
       hkl_info.ctr_dir =NULL;
       /* transfer input parameters */
-      hkl_info.m_delta_d_d = sx_delta_d_d;
+      hkl_info.m_delta_d_d = delta_d_d;
       hkl_info.m_a  = 0;
       hkl_info.m_b  = 0;
       hkl_info.m_c  = 0;
-      hkl_info.m_aa = sx_aa;
-      hkl_info.m_bb = sx_bb;
-      hkl_info.m_cc = sx_cc;
-      hkl_info.m_ax = sx_ax;
-      hkl_info.m_ay = sx_ay;
-      hkl_info.m_az = sx_az;
-      hkl_info.m_bx = sx_bx;
-      hkl_info.m_by = sx_by;
-      hkl_info.m_bz = sx_bz;
-      hkl_info.m_cx = sx_cx;
-      hkl_info.m_cy = sx_cy;
-      hkl_info.m_cz = sx_cz;
-      hkl_info.recip= sx_recip_cell;
+      hkl_info.m_aa = aa;
+      hkl_info.m_bb = bb;
+      hkl_info.m_cc = cc;
+      hkl_info.m_ax = ax;
+      hkl_info.m_ay = ay;
+      hkl_info.m_az = az;
+      hkl_info.m_bx = bx;
+      hkl_info.m_by = by;
+      hkl_info.m_bz = bz;
+      hkl_info.m_cx = cx;
+      hkl_info.m_cy = cy;
+      hkl_info.m_cz = cz;
+      hkl_info.recip= recip_cell;
 
       /* default format h,k,l,F,F2  */
       hkl_info.column_order[0]=1;
@@ -569,16 +572,16 @@ INITIALIZE %{
       hkl_info.kix = hkl_info.kiy = hkl_info.kiz = 0;
       hkl_info.nb_reuses = hkl_info.nb_refl = hkl_info.nb_refl_count = 0;
       hkl_info.tau_count = 0;
-      hkl_info.flag_barns= sx_barns;
-      double* mosaic_ABin = sx_mosaic_AB;
+      hkl_info.flag_barns= barns;
+      double* mosaic_ABin = mosaic_AB;
 
       if (!sx_refl || !strlen(sx_refl) || !strcmp(sx_refl, "NULL") || !strcmp(sx_refl, "0"))
         strcpy(sx_refl, material);
-      i = read_hkl_data(sx_refl, &hkl_info, &hkl_list, sx_mosaic, sx_mosaic_a, sx_mosaic_b, sx_mosaic_c, mosaic_ABin,
+      i = read_hkl_data(sx_refl, &hkl_info, &hkl_list, mosaic, mosaic_a, mosaic_b, mosaic_c, mosaic_ABin,
                         hkl_info.ctr_size,hkl_info.ctr_k,hkl_info.ctr_FT2,hkl_info.ctr_dir);
       if (i == 0) {
         MPI_MASTER(
-        fprintf(stderr,"WARNING: FluoCrystal: %s: sx_mosaic or material file %s is not valid (CIF/LAU). Ignoring diffraction process.\n",
+        fprintf(stderr,"WARNING: FluoCrystal: %s: mosaic or material file %s is not valid (CIF/LAU). Ignoring diffraction process.\n",
                       NAME_CURRENT_COMP, sx_refl);
         );
         flag_sx=0;
@@ -873,9 +876,9 @@ do { /* while (intersect) Loop over multiple scattering events */
         XRMC_CrossSections(Z, E, xs_Z); // [barn/atom]
         sigma_barn            += frac*CSb_Total(Z, E, NULL); // Fluo+Compton+Rayleigh
         cum_xs_fluo[i_Z+1]     = cum_xs_fluo[i_Z]    +frac*xs_Z[FLUORESCENCE];
-        cum_xs_Compton[i_Z+1]  = cum_xs_Compton[i_Z] +frac*xs_Z[COMPTON];
         cum_xs_Rayleigh[i_Z+1] = cum_xs_Rayleigh[i_Z]+frac*xs_Z[RAYLEIGH];
-        for (i=0; i<3; i++) { xs[i] += frac*xs_Z[i]; }
+        cum_xs_Compton[i_Z+1]  = cum_xs_Compton[i_Z] +frac*xs_Z[COMPTON];
+        for (i=0; i<COMPTON+1; i++) { xs[i] += frac*xs_Z[i]; }
       } // for Z in compound
 
       if (flag_sx) {
@@ -888,10 +891,8 @@ do { /* while (intersect) Loop over multiple scattering events */
         xs[DIFFRACTION] = coh_xsect;
         sigma_barn     += xs[DIFFRACTION];
       } else {
-        coh_refl  = 0;
-        coh_xsect = 0;
-        tau_count = 0;
-        xs[DIFFRACTION] = 0;
+        xs[DIFFRACTION] = coh_refl = coh_xsect = 0;
+        tau_count       = 0;
       }
 
       // store values into cache for SPLIT
@@ -902,6 +903,9 @@ do { /* while (intersect) Loop over multiple scattering events */
       }
       reuse_cum_xs_diffraction  = xs[DIFFRACTION];
       reuse_sigma_barn          = sigma_barn;
+      hkl_info.coh_refl         = coh_refl;
+      hkl_info.coh_xsect        = coh_xsect;
+      hkl_info.tau_count        = tau_count;
 
     } else {
       // reuse cached values (SPLIT)
@@ -912,9 +916,8 @@ do { /* while (intersect) Loop over multiple scattering events */
         xs[FLUORESCENCE]      += reuse_cum_xs_fluo[i_Z+1];
         xs[COMPTON]           += reuse_cum_xs_Compton[i_Z+1];
         xs[RAYLEIGH]          += reuse_cum_xs_Rayleigh[i_Z+1];
-        xs[DIFFRACTION]        = reuse_cum_xs_diffraction;
       }
-
+      xs[DIFFRACTION]          = reuse_cum_xs_diffraction;
       sigma_barn = reuse_sigma_barn;
       if (flag_sx) {
         coh_refl  = hkl_info.coh_refl;
@@ -979,7 +982,7 @@ do { /* while (intersect) Loop over multiple scattering events */
     if (dsigma < 1) p *= dsigma; // < 1
 
     /* MC choose process from cross sections 'xs': fluo, Compton, Rayleigh, diff */
-    type = XRMC_SelectInteraction(xs, 4);
+    type = XRMC_SelectInteraction(xs, DIFFRACTION+1); // up to DIFFRACTION
 
     /* choose Z (element) on associated XS, taking into account mass-fractions */
     switch (type) {

--- a/mcxtrace-comps/samples/FluoPowder.comp
+++ b/mcxtrace-comps/samples/FluoPowder.comp
@@ -8,9 +8,10 @@
 * Component: FluoPowder
 *
 * %Identification
-* Written by: E. Farhi
+* Written by: Emmanuel Farhi (emmanuel.farhi.synchrotron-soleil.fr)
 * Date:       April 2025
 * Origin:     Synchrotron SOLEIL
+* Release:    McXtrace 3.5
 *
 * Sample model handling absorption, fluorescence, Compton, Rayleigh scattering and powder diffraction.
 *
@@ -87,7 +88,7 @@
 * processes via e.g. the 'target_index' and the 'focus_xw / focus_yh' options.
 * This target should e.g. be the SDD area.
 * The powder scattering can be focused along an horizontal tore via the
-* 'powder_d_phi' and 'powder_sign' options. To get a vertical tore, rotate
+* 'd_phi' and 'tth_sign' options. To get a vertical tore, rotate
 * the sample by 90 deg around Z.
 *
 * This sample component can advantageously benefit from the SPLIT feature, e.g.
@@ -150,16 +151,16 @@
 * escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. 0 inactivates.
 * escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
 * pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. 0 inactivates.
-* powder_barns:   [1] Flag to indicate if |F|^2 from 'material' is in barns or fm^2, (barns=1 for laz, barns=0 for lau type files).
-* powder_d_phi: [deg] Angle corresponding to the vertical angular range to focus to, e.g. detector height. 0 for no focusing.
-* powder_delta_d_d: [AA] Global relative Delta_d/d spreading when the 'w' column is not available. Use 0 if ideal.
-* powder_DW:      [1] Global Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2.
-* powder_format: [{}] List of structure file column indexes. See the PowderN component.
-* powder_nb_atoms:[1] Number of sub-unit per unit cell, that is ratio of sigma for chemical formula to sigma per unit cell.
-* powder_refl:  [str] A CIF/LAZ/LAU reflection file as for PowderN. When not given, 'material' is used. Specify it when 'material' is a chemical formula.
-* powder_sign:    [1] Sign of the scattering angle. If 0, the sign is chosen randomly (left and right).
-* powder_Vc:   [AA^3] Volume of unit cell=nb atoms per cell/density of atoms.
 * order:          [1] Limit multiple fluorescence up to given order. Last iteration is absorption only.
+* barns:          [1] Flag to indicate if |F|^2 from 'material' is in barns or fm^2, (barns=1 for laz/cif, barns=0 for lau type files).
+* d_phi:        [deg] Angle corresponding to the difraction vertical angular range to focus to, e.g. detector height. 0 for no focusing. You may as well define focus_ah or focus_yh and target.
+* delta_d_d:     [AA] Global relative difraction Delta_d/d spreading when the 'w' column is not available. Use 0 if ideal.
+* DW:             [1] Global difraction Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2.
+* nb_atoms:       [1] Number of sub-unit per unit cell, that is ratio of sigma for chemical formula to sigma per unit cell.
+* powder_format: [{}] List of structure file column indexes. See the PowderN component.
+* powder_refl:  [str] A CIF/LAZ/LAU reflection file as for PowderN. When not given, 'material' is used. Specify it when 'material' is a chemical formula.
+* tth_sign:       [1] Sign of the diffraction angle. If 0, the sign is chosen randomly (left and right).
+* Vc:          [AA^3] Volume of unit cell=nb atoms per cell/density of atoms.
 *
 * CALCULATED PARAMETERS:
 * type: scattering event type 0=FLUORESCENCE fluorescence, 1=RAYLEIGH Rayleigh, 2=COMPTON Compton, 3=TRANSMISSION Transmit (absorbsion), 4=DIFFRACTION Diffraction, 5=FLUORESCENCE_ESCAPE Detector escape peak, 6=FLUORESCENCE_PILEUP Detector pile-up/sum/coincidence peak
@@ -194,8 +195,8 @@ SETTING PARAMETERS(
   focus_xw=0, focus_yh=0, focus_aw=0, focus_ah=0, int target_index=0,
   int flag_compton=1, int flag_rayleigh=1, int flag_lorentzian=1, int flag_powder=1,
   string powder_refl="",
-  vector powder_format={0,0,0,0,0,0,0,0}, powder_Vc=0, powder_delta_d_d=0, powder_DW=0,
-  powder_d_phi=0, int powder_nb_atoms=1, int powder_barns=1, int powder_sign=0,
+  vector powder_format={0,0,0,0,0,0,0,0}, Vc=0, delta_d_d=0, DW=0,
+  d_phi=0, int nb_atoms=1, int barns=1, int tth_sign=0,
   escape_ratio=0, escape_energy=1.739,
   pileup_ratio=0,
   int order=1)
@@ -238,6 +239,7 @@ SHARE COPY PowderN EXTEND %{
     int    i_line;
 
     if (xs == NULL) return 0;
+    for(i_line=0; i_line<=COMPTON; i_line++) xs[i_line]=0;
 
     // loop on possible fluorescence lines
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) {
@@ -260,6 +262,7 @@ SHARE COPY PowderN EXTEND %{
   */
   int XRMC_SelectFromDistribution(double x_arr[], int N)
   {
+    if (x_arr == NULL || N <=0) return (0);
     double x=rand01()*x_arr[N-1];
     if (x<x_arr[0]) {    // x is smaller than lower limit
       return 0;
@@ -289,7 +292,7 @@ SHARE COPY PowderN EXTEND %{
     double sum_xs, *cum_xs;
     int    i;
 
-    if (nb_processes < 1) return 0;
+    if (xs == NULL || nb_processes < 1 || nb_processes > TRANSMISSION) return 0;
     cum_xs = malloc((nb_processes+1)*sizeof(double));
     if (!cum_xs)          return 0;
     cum_xs[0]=sum_xs=0;
@@ -331,6 +334,7 @@ SHARE COPY PowderN EXTEND %{
   {
       // non_space_count to keep the frequency of non space characters
       int non_space_count = 0;
+      if (string == NULL) return NULL;
 
       //Traverse a string and if it is non space character then, place it at index non_space_count
       for (int i = 0; string[i] != '\0'; i++)
@@ -354,7 +358,8 @@ SHARE COPY PowderN EXTEND %{
 
     int  ret = 0;
     char Line[65535];
-    int flag_found_cif=0;
+    int  flag_found_cif=0;
+    if (filename == NULL || formula == NULL) return (0);
     FILE *file = Open_File(filename, "r", NULL);
     if (!file)
       exit(fprintf(stderr, "%s: ERROR: can not open file %s\n",
@@ -518,16 +523,16 @@ INITIALIZE %{
     // set powder variable default before reading file
     if (flag_powder) {
       columns             = powder_format;
-      line_info.V_0       = powder_Vc;
+      line_info.V_0       = Vc;
       for (i=0; i< 8; i++) {
         line_info.column_order[i] = (int)columns[i];
       }
-      line_info.DWfactor  = powder_DW;
-      line_info.Dd        = powder_delta_d_d;
+      line_info.DWfactor  = DW;
+      line_info.Dd        = delta_d_d;
       line_info.rho       = density;
       line_info.at_weight = weight;
-      line_info.at_nb     = powder_nb_atoms;
-      line_info.flag_barns= powder_barns;
+      line_info.at_nb     = nb_atoms;
+      line_info.flag_barns= barns;
       strncpy(line_info.compname, NAME_CURRENT_COMP, 256);
       if (!powder_refl || !strlen(powder_refl) || !strcmp(powder_refl, "NULL") || !strcmp(powder_refl, "0"))
         strcpy(powder_refl, material);
@@ -660,6 +665,14 @@ INITIALIZE %{
     printf("WARNING: FluoPowder: %s: The target is not defined. Using 4PI for fluorescence.\n",
       NAME_CURRENT_COMP);
     );
+  }
+  // checks for d_pĥi focusing
+  if (flag_powder && !d_phi) {
+    if (focus_ah) d_phi=focus_ah;
+    else if (focus_yh && (target_x || target_y || target_z)) {
+      double target_dist2=target_x*target_x+target_y*target_y+target_z*target_z;
+      d_phi = atan2(focus_yh,sqrt(target_dist2));
+    }
   }
 
   n_fluo = n_Compton = n_Rayleigh = n_diff = 0;
@@ -947,7 +960,7 @@ do { /* while (intersect) Loop over multiple scattering events */
   if (intersect) { /* scattering event */
     int    i_Z=-1, Z, line=-1;
     double solid_angle;
-    double theta, dsigma, alpha=0;
+    double theta, dsigma, alpha;
     double Ef, dE;
     double kf=k, kf_x, kf_y, kf_z;  // next particle direction
 
@@ -956,7 +969,7 @@ do { /* while (intersect) Loop over multiple scattering events */
     if (dsigma < 1) p *= dsigma; // < 1
 
     /* MC choose process from cross sections 'xs': fluo, Compton, Rayleigh, diff */
-    type = XRMC_SelectInteraction(xs, 4);
+    type = XRMC_SelectInteraction(xs, DIFFRACTION+1); // up to DIFFRACTION
 
     /* choose Z (element) on associated XS, taking into account mass-fractions */
     switch (type) {
@@ -1014,25 +1027,25 @@ do { /* while (intersect) Loop over multiple scattering events */
         arg = line_info.q[line]/(2.0*k);
       if(fabs(arg) > 1) ABSORB; /* No bragg scattering possible   */
       theta  = asin(arg);       /* Bragg scattering law           */
-      if (powder_sign == 0) {
+      if (tth_sign == 0) {
         sg = randpm1();
         if (sg > 0) sg = 1; else sg=-1;
       }
       else  {
-        sg = powder_sign/fabs(powder_sign);
+        sg = tth_sign/fabs(tth_sign);
       }
 
       /* Choose point on Debye-Scherrer cone */
-      if (powder_d_phi)
+      if (d_phi)
       { /* relate height of detector to the height on DS cone */
-        arg = sin(powder_d_phi*DEG2RAD/2)/sin(2*theta);
-        /* If full Debye-Scherrer cone is within powder_d_phi, don't focus */
-        if (arg < -1 || arg > 1) powder_d_phi = 0;
+        arg = sin(d_phi*DEG2RAD/2)/sin(2*theta);
+        /* If full Debye-Scherrer cone is within d_phi, don't focus */
+        if (arg < -1 || arg > 1) alpha = 0;
         /* Otherwise, determine alpha to rotate from scattering plane
-         *    into powder_d_phi focusing area */
+         *    into d_phi focusing area */
         else alpha = 2*asin(arg);
       }
-      if (powder_d_phi) {
+      if (alpha) {
         /* Focusing */
         alpha  = fabs(alpha);
         alpha0 = 0.5*randpm1()*alpha;
@@ -1097,13 +1110,13 @@ do { /* while (intersect) Loop over multiple scattering events */
         if (Ex!=0 || Ey!=0 || Ez!=0){
           double EE=sqrt(Ex*Ex+Ey*Ey+Ez*Ez);
           double s=scalar_prod(kf_x,kf_y,kf_z,Ex,Ey,Ez)/EE;
-          p *= (1-s)*(1-s);
-        } else {
+          p*=(1-s)*(1-s);
+        }else{
           /*unpolarized light in - means an effective reduction according to only theta*/
-          p *= (1+cos(theta)*cos(theta))*0.5;
+          p*=(1+cos(theta)*cos(theta))*0.5;
         }
         if (alpha) {
-          p *= alpha/PI;
+          p    *= alpha/PI;
         }
         n_diff++;
         p_diff += p;

--- a/mcxtrace-comps/samples/Fluorescence.comp
+++ b/mcxtrace-comps/samples/Fluorescence.comp
@@ -225,6 +225,7 @@ double XRMC_CrossSections(int Z, double E0, double *xs) {
   int    i_line;
   
   if (xs == NULL) return 0;
+  for(i_line=0; i_line<=COMPTON; i_line++) xs[i_line]=0;
   
   // loop on possible fluorescence lines
   for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) { 
@@ -247,6 +248,7 @@ double XRMC_CrossSections(int Z, double E0, double *xs) {
  */
 int XRMC_SelectFromDistribution(double x_arr[], int N)
 {
+  if (x_arr == NULL || N <=0) return (0);
   double x=rand01()*x_arr[N-1];
   if (x<x_arr[0]) {    // x is smaller than lower limit
     return 0;
@@ -276,7 +278,7 @@ int XRMC_SelectInteraction(double *xs, int nb_processes)
   double sum_xs, cum_xs[5];
   int    i;
   
-  if (nb_processes < 1 || nb_processes > 4) return 0;
+  if (xs == NULL || nb_processes < 1 || nb_processes > TRANSMISSION) return 0;
   cum_xs[0]=sum_xs=0;
   for (i=0; i< nb_processes; i++) {
     sum_xs += xs[i];
@@ -314,6 +316,7 @@ double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE)
   {
       // non_space_count to keep the frequency of non space characters
       int non_space_count = 0;
+      if (string == NULL) return NULL;
    
       //Traverse a string and if it is non space character then, place it at index non_space_count
       for (int i = 0; string[i] != '\0'; i++)
@@ -337,7 +340,8 @@ double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE)
   
     int  ret = 0;
     char Line[65535];
-    int flag_found_cif=0;
+    int  flag_found_cif=0;
+    if (filename == NULL || formula == NULL) return (0);
     FILE *file = Open_File(filename, "r", NULL);
     if (!file)
       exit(fprintf(stderr, "%s: ERROR: can not open file %s\n", 
@@ -843,7 +847,7 @@ do { /* while (intersect) Loop over multiple scattering events */
     if (dsigma < 1) p *= dsigma; // < 1
 
     /* MC choose process from cross sections 'xs': fluo, Compton, Rayleigh */
-    type = XRMC_SelectInteraction(xs, 3);
+    type = XRMC_SelectInteraction(xs, COMPTON+1); // up to COMPTON
     
     /* choose Z (element) on associated XS, taking into account mass-fractions */
     switch (type) {

--- a/mcxtrace-comps/samples/PowderN.comp
+++ b/mcxtrace-comps/samples/PowderN.comp
@@ -138,28 +138,27 @@
 * reflections: [str] Input file for reflections (LAZ LAU CIF, FullProf, ShelX). Use only incoherent scattering if NULL or "".
 *
 * Optional parameters:
-* d_phi:       [deg] Angle corresponding to the vertical angular range to focus to, e.g. detector height. 0 for no focusing.
-* d_omega:     [deg] Horizontal focus range (only for incoherent scattering), 0 for no focusing.
-* tth_sign:      [1] Sign of the scattering angle. If 0, the sign is chosen randomly (left and right). ONLY functional in combination with d_phi and ONLY applies to bragg lines.
-* focus_flip:    [1] Controls the sense of d_phi. If 0 d_phi is measured against the xz-plane. If !=0 d_phi is measured against zy-plane.
-* tth_sign:      [1] Sign of the scattering angle. If 0, the sign is chosen randomly (left and right).
-* pack:          [1] Packing factor
-* delta_d_d:     [1] Global relative Delta_d/d spreading when the 'w' column is not available. Use 0 if ideal.
-* format:       [{}] Name of the format, or list of column indexes (see Description). N.b. no quotes!
-* p_inc:         [1] Fraction of incoherently scattered rays.
-* p_transmit:    [1] Fraction of transmitted (only attenuated) rays.
-* p_interact:    [1] Fraction of events interacting with sample, e.g. 1-p_transmit-p_inc.
+* barns:         [1] Flag to indicate if |F|^2 from 'reflections' is in barns or fm^2, (barns=1 for laz/cif, barns=0 for lau type files).
 * concentric:    [1] Indicate that this component has a hollow geometry and may contain other components. It should then be duplicated after the inside part (only for box, cylinder, sphere).
-* geometry:    [str] Name of an Object File Format (OFF) or PLY file for complex geometry. The OFF/PLY file may be generated from XYZ coordinates using qhull/powercrust.
-* barns:         [1] Flag to indicate if |F|^2 from 'reflections' is in barns or fm^2, (barns=1 for laz, barns=0 for lau type files).
-* Vc:         [AA^3] Volume of unit cell=nb atoms per cell/density of atoms.
-* DW:            [1] Global Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2.
-* weight:    [g/mol] Atomic/molecular weight of material.
+* d_omega:     [deg] Horizontal focus range (only for incoherent scattering), 0 for no focusing.
+* d_phi:       [deg] Angle corresponding to the vertical angular range to focus to, e.g. detector height. 0 for no focusing.
+* delta_d_d:     [1] Global relative Delta_d/d spreading when the 'w' column is not available. Use 0 if ideal.
 * density:  [g/cm^3] Density of material. rho=density/weight/1e24*N_A.
-* nb_atoms:      [1] Number of sub-unit per unit cell, that is ratio of sigma for chemical formula to sigma per unit cell.
-* material: [Be.txt] File where the material parameters for the absorption may be found. Format is similar to what may be found off the NIST website. 
+* DW:            [1] Global Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2.
+* focus_flip:    [1] Controls the sense of d_phi. If 0 d_phi is measured against the xz-plane. If !=0 d_phi is measured against zy-plane.
+* format:       [{}] Name of the format, or list of column indexes (see Description). N.b. no quotes!
+* geometry:    [str] Name of an Object File Format (OFF) or PLY file for complex geometry. The OFF/PLY file may be generated from XYZ coordinates using qhull/powercrust.
 * mat_format:   [{}] Format of the asorption parameter file.
+* material: [Be.txt] File where the material parameters for the absorption may be found. Format is similar to what may be found off the NIST website.
+* nb_atoms:      [1] Number of sub-unit per unit cell, that is ratio of sigma for chemical formula to sigma per unit cell.
+* p_inc:         [1] Fraction of incoherently scattered rays.
+* p_interact:    [1] Fraction of events interacting with sample, e.g. 1-p_transmit-p_inc.
+* p_transmit:    [1] Fraction of transmitted (only attenuated) rays.
+* pack:          [1] Packing factor
 * target_index:  [1] Relative index of component to focus incoherent scattering at, e.g. next is +1
+* tth_sign:      [1] Sign of the scattering angle. If 0, the sign is chosen randomly (left and right). ONLY functional in combination with d_phi and ONLY applies to bragg lines.
+* Vc:         [AA^3] Volume of unit cell=nb atoms per cell/density of atoms.
+* weight:    [g/mol] Atomic/molecular weight of material.
 *
 * CALCULATED PARAMETERS:
 * line_info: [struct]     Internal structure containing many members/info

--- a/mcxtrace-comps/samples/Single_crystal.comp
+++ b/mcxtrace-comps/samples/Single_crystal.comp
@@ -31,6 +31,8 @@
 * The mosaic may EITHER be specified isotropic by setting the mosaic input
 * parameter, OR anisotropic by setting the mosaic_a, mosaic_b, and mosaic_c
 * parameters.
+* If you get strange results, check the mosaicity and delta(d)/d parameters, as this
+* component is not suited for ideal/perfect mosaic crystals.
 * The crystal lattice can be bent locally, keeping the external geometry unchanged.
 * Curvature is spherical along vertical and horizontal axes.
 *
@@ -61,7 +63,7 @@
 *     (Also known as "phenomenological mosaicity").
 *     
 * <b>Powder-mode</b>
-* When these two modes are used (powder=1 ), a randomised transformation
+* When the powder mode is used (powder=0-1), a randomised transformation
 * of the particle direction is made before and after scattering, thereby letting 
 * the single crystal behave as a crystallite of either a powder (crystallite
 * orientation fully randomised).
@@ -148,7 +150,7 @@
 *
 * A diamond crystal plate, cut for (002) reflections
 *   Single_crystal(xwidth = 0.002, yheight = 0.1, zdepth = 0.1,
-*     mosaic = 30, reflections = "C-diamond.lau",
+*     mosaic = 5, delta_d_d=3e-4, reflections = "C-diamond.lau",
 *     ax=0,      ay=2.14,   az=-1.24,
 *     bx = 0,    by = 0,    bz =  2.47,
 *     cx = 6.71, cy = 0,    cz =  0)
@@ -169,12 +171,12 @@
 * yheight:            [m] Height of crystal
 * zdepth:             [m] Depth of crystal (no extinction simulated)
 * geometry:         [str] Name of an Object File Format (OFF) or PLY file for complex geometry. The OFF/PLY file may be generated from XYZ coordinates using qhull/powercrust
-* delta_d_d:          [1] Lattice spacing variance, gaussian RMS (longitudinal mosaic)
-* mosaic:   [arc minutes] Crystal mosaic (isotropic), gaussian RMS. Puts the crystal in the isotropic mosaic model state, thus disregarding other mosaicity parameters.
-* mosaic_a: [arc minutes] Horizontal (rotation around lattice vector a) mosaic (anisotropic), gaussian RMS. Put the crystal in the anisotropic crystal vector state. I.e. model mosaicity through rotation around the crystal lattice vectors. Has precedence over in-plane mosaic model.
+* delta_d_d:          [1] Lattice spacing variance, gaussian RMS (longitudinal mosaic) e.g. 1e-4 to 1e-3.
+* mosaic:   [arc minutes] Crystal mosaic (isotropic), gaussian RMS. Puts the crystal in the isotropic mosaic model state, thus disregarding other mosaicity parameters, e.g. 1-10.
+* mosaic_a: [arc minutes] Horizontal (rotation around lattice vector a) mosaic (anisotropic), gaussian RMS. Put the crystal in the anisotropic crystal vector state. i.e. model mosaicity through rotation around the crystal lattice vectors. Has precedence over in-plane mosaic model.
 * mosaic_b: [arc minutes] Vertical (rotation around lattice vector b) mosaic (anisotropic), gaussian RMS.
 * mosaic_c: [arc minutes] Out-of-plane (Rotation around lattice vector c) mosaic (anisotropic), gaussian RMS
-* mosaic_AB: [arc_minutes, arc_minutes,1, 1, 1, 1, 1, 1]  In Plane mosaic rotation and plane vectors (anisotropic), mosaic_A, mosaic_B, A_h,A_k,A_l, B_h,B_k,B_l. Puts the crystal in the in-plane mosaic state. Vectors A and B define plane in which  the crystal roation is defined, and mosaic_A, mosaic_B, denotes the resp. mosaicities (gaussian RMS) with respect to the two reflections chosen by A and B (Miller indices).
+* mosaic_AB: [arc_minutes, arc_minutes,1, 1, 1, 1, 1, 1]  In-plane mosaic rotation and plane vectors (anisotropic), mosaic_A, mosaic_B, A_h,A_k,A_l, B_h,B_k,B_l. Puts the crystal in the in-plane mosaic state. Vectors A and B define plane in which the crystal roation is defined, and mosaic_A, mosaic_B, denotes the resp. mosaicities (gaussian RMS) with respect to the two reflections chosen by A and B (Miller indices).
 *
 * recip_cell:        [1] Choice of direct/reciprocal (0/1) unit cell definition
 * ax:      [AA or AA^-1] Coordinates of first (direct/recip) unit cell vector 
@@ -197,7 +199,7 @@
 * aa:              [deg] Unit cell angles alpha, beta and gamma. Then uses norms of vectors a,b and c as lattice parameters
 * bb:              [deg] Beta angle
 * cc:              [deg] Gamma angle
-* barns:             [1] Flag to indicate if |F|^2 from 'reflections' is in barns or fm^2. barns=1 for laz and isotropic constant elastic scattering (reflections=NULL), barns=0 for lau type files
+* barns:             [1] Flag to indicate if |F|^2 from 'reflections' is in barns or fm^2. barns=1 for laz/cif and isotropic constant elastic scattering (reflections=NULL), barns=0 for lau type files
 * RX:                [m] Radius of horizontal along X lattice curvature. flat for 0
 * RY:                [m] Radius of vertical   along Y lattice curvature. flat for 0
 * powder:            [1] Flag to indicate powder mode, for simulation of Debye-Scherrer cones via random crystallite orientation. A powder texture can be approximated with powder within 0-1
@@ -290,7 +292,7 @@ vector ki.
 DEFINE COMPONENT Single_crystal
 
 SETTING PARAMETERS(string reflections=0, string geometry=0, vector mosaic_AB={0,0, 0,0,0, 0,0,0},
-  xwidth=0, yheight=0, zdepth=0, radius=0, delta_d_d=1e-4,
+  xwidth=0, yheight=0, zdepth=0, radius=0, delta_d_d=1e-3,
   mosaic = -1, mosaic_a = -1, mosaic_b = -1, mosaic_c = -1,
   recip_cell=0, barns=0,
   ax = 0, ay = 0, az = 0,
@@ -598,11 +600,13 @@ SHARE
 
     if (nb_atoms > 1) { info->sigma_i *= nb_atoms; }
     if (info->m_delta_d_d <=0) {
-      info->m_delta_d_d=1e-5;
+      info->m_delta_d_d=SC_mosaic > 0 ? SC_mosaic*MIN2RAD : MIN2RAD; // MIN2RAD = 3e-4
       MPI_MASTER(
         fprintf(stderr,"Single_crystal: %s: WARNING: Delta_d/d is <=0 (longitudinal mosaic). Setting delta_d_d=%g\n",
                 info->compname, info->m_delta_d_d);
       );
+    } else if (SC_mosaic < 0 && SC_mosaic_a < 0 && SC_mosaic_b < 0 && SC_mosaic_c < 0) {
+      if (info->m_delta_d_d > 0) SC_mosaic=info->m_delta_d_d/MIN2RAD;
     }
 
     /* special cases for the structure definition */
@@ -1504,7 +1508,7 @@ TRACE
 
     if (hkl_info.flag_barns) {
       /*If cross sections are given in barns, we need a scaling factor of 100 
-       to get scattering lengths in m, since V0 is assumed to be in AA*/
+        to get scattering lengths in m, since V0 is assumed to be in AA*/
       abs_xlen *= 100; inc_xlen *= 100;
     } /* else assume fm^2 */
     L = hkl_list;


### PR DESCRIPTION
I found an error the McXtrace Fluo samples: an array `xs` was not reset between calls. 

- The fluorescence cross section was thus continuously increasing, gradually "hiding" other processes e.g. diffraction.
- Would not "crash" but compute wrong fluorescence intensities.

Took time to find-out, and only thanks to tests and cross comparisons e.g. with GROUP Fluo+SX and Fluo+PowderN.
This is now fixed, and I updated test values.
Minor changes in SX and PowderN (cosmetics).