### PR TITLE
McGui: show current instrument name in dialogues

### DIFF
--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -663,7 +663,9 @@ class McGuiAppController():
 
             comps = get_compnames(text=open(self.state.getInstrumentFile(), 'rb').read().decode())
             _a, mcplots, mcdisplays, formats = mccode_config.get_options()
+            # create or display the Run Dialog
             fixed_params, new_instr_params, inspect, mcdisplay, autoplotter, Format = self.view.showStartSimDialog(
+                self.state.getInstrumentFile(),
                 instr_params, comps, mcdisplays, mcplots, formats, mccode_config.configuration["NDBUFFERSIZE"])
 
             if Format != None:

--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -501,6 +501,10 @@ class McGuiAppController():
                 if not os.path.splitext(a)[1] == '.py':
                     if self.state.getInstrumentFile() == '':
                         self.state.loadInstrument(a)
+                        prefix = 'mx'
+                        if mccode_config.configuration["MCCODE"] == "mcstas":
+                            prefix = 'mc'
+                        self.view.mw.setWindowTitle(prefix + 'gui-py: ' + os.path.basename(str(a)))
                         
         # Shouldn't really be necessary, but otherwise App menu is inactive on macOS
         # (was initially put in message/status update mechanism, but that caused other side-effects, see
@@ -952,6 +956,11 @@ class McGuiAppController():
                 self.state.loadInstrument(instr)
                 self.emitter.message("Instrument opened: " + os.path.basename(str(instr)), gui=True)
                 self.emitter.status("Instrument: " + os.path.basename(str(instr)))
+                # set window title
+                prefix = 'mx'
+                if mccode_config.configuration["MCCODE"] == "mcstas":
+                    prefix = 'mc'
+                self.view.mw.setWindowTitle(prefix + 'gui-py: ' + os.path.basename(str(instr)))
     
     def handleMcdoc(self):
         cmd='%sdoc' % mccode_config.get_mccode_prefix()

--- a/tools/Python/mcgui/viewclasses.py
+++ b/tools/Python/mcgui/viewclasses.py
@@ -173,9 +173,10 @@ class McView(object):
         if dlg.exec():
             return dlg.selectedFiles()[0]
 
-    def showStartSimDialog(self, params, comps, mcdisplays, mcplots, formats, buffersize):
+    def showStartSimDialog(self, instr, params, comps, mcdisplays, mcplots, formats, buffersize):
         if self.__ssd == None:
             self.__ssd = McStartSimDialog()
+        self.__ssd.ui.gbxGrid.setTitle('Instrument parameters: '+ os.path.basename(str(instr)))
         self.__ssd.createParamsWidgets(params)
         self.__ssd.set_components(comps)
         self.__ssd.set_mcdisplays(mcdisplays)


### PR DESCRIPTION
Few commits to:

- show instrument name in main window title
- show instrument in the Run dialogue. I could not set the title itself. Better than nothing.

This way we know what dialog/instr pair we are looking at...