### PR TITLE
Possible workaround for openmpi v5 crashes on macOS

### DIFF
--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -26,7 +26,7 @@ jobs:
           - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'mpich'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'mpich'   }
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
-          - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
+          #- { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
           #- { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.12", mpi: 'msmpi'   }
 

--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -25,9 +25,9 @@ jobs:
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'mpich'   }
           - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'mpich'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'mpich'   }
-          #- { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
-          #- { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
-          #- { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
+          - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
+          - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
+          - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
           #- { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.12", mpi: 'msmpi'   }
 
     name: ${{ matrix.os }}.${{ matrix.CC }}.${{ matrix.mpi }}.python-${{ matrix.python }}
@@ -81,6 +81,7 @@ jobs:
     - name: Configure build and install mcstas
       id: mcstas-install
       run: |
+           if [ "$RUNNER_OS" == "macOS" ]; then mkdir ${HOME}/tmp; fi
            if [ "$RUNNER_OS" == "macOS" ]; then export SDKROOT=$(xcrun --sdk macosx --show-sdk-path); fi
            set -e
            set -u
@@ -219,6 +220,7 @@ jobs:
            export MCSTAS_EXECUTABLE="mcstas"
            export MCSTAS_PYGEN_EXECUTABLE="mcstas-pygen"
            export MCRUN_EXECUTABLE="mcrun"
+           if [ "$RUNNER_OS" == "macOS" ]; then export TMPDIR=${HOME}/tmp; fi
            if [ "$RUNNER_OS" == "Windows" ];
            then
              export MCSTAS_EXECUTABLE="mcstas.exe"
@@ -259,6 +261,7 @@ jobs:
            set -x
            export MCSTAS_EXECUTABLE="mcstas"
            export MCRUN_EXECUTABLE="mcrun"
+           if [ "$RUNNER_OS" == "macOS" ]; then export TMPDIR=${HOME}/tmp; fi
            if [ "$RUNNER_OS" == "Windows" ];
            then
              export MCSTAS_EXECUTABLE="mcstas.exe"
@@ -299,6 +302,7 @@ jobs:
            set -x
            export MCSTAS_EXECUTABLE="mcstas"
            export MCRUN_EXECUTABLE="mcrun"
+           if [ "$RUNNER_OS" == "macOS" ]; then export TMPDIR=${HOME}/tmp; fi
            if [ "$RUNNER_OS" == "Windows" ];
            then
              export MCSTAS_EXECUTABLE="mcstas.exe"

--- a/.github/workflows/mcstas-testsuite.yml
+++ b/.github/workflows/mcstas-testsuite.yml
@@ -20,7 +20,7 @@ jobs:
           - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'openmpi' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'mpich' }
-          #- { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
+          - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
           - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: windows-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'msmpi' }
 
@@ -167,6 +167,11 @@ jobs:
            if [ "$RUNNER_OS" == "Windows" ];
            then
              export MCTEST_EXECUTABLE="mctest.bat"
+           fi
+           if [ "$RUNNER_OS" == "macOS" ];
+           then
+             mkdir ${HOME}/tmp
+             export TMPDIR=${HOME}/tmp
            fi
            echo $PATH
            ${MCTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }} --mpi=2

--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -26,7 +26,7 @@ jobs:
           - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'mpich'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'mpich'   }
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
-          - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
+          #- { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
           #- { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.12", mpi: 'msmpi'   }
 

--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -25,9 +25,9 @@ jobs:
           - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'mpich'   }
           - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'mpich'   }
           - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'mpich'   }
-          #- { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
-          #- { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
-          #- { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
+          - { os: macos-13,      CC: clang,    CXX: clang++,    python: "3.11", mpi: 'openmpi'   }
+          - { os: macos-14,      CC: clang,    CXX: clang++,    python: "3.12", mpi: 'openmpi'   }
+          - { os: macos-15,      CC: clang,    CXX: clang++,    python: "3.13", mpi: 'openmpi'   }
           #- { os: windows-latest,  CC: gcc,    CXX: g++,        python: "3.12", mpi: 'msmpi'   }
 
     name: ${{ matrix.os }}.${{ matrix.CC }}.${{ matrix.mpi }}.python-${{ matrix.python }}
@@ -81,6 +81,7 @@ jobs:
     - name: Configure build and install mcxtrace
       id: mcxtrace-install
       run: |
+           if [ "$RUNNER_OS" == "macOS" ]; then mkdir ${HOME}/tmp; fi
            if [ "$RUNNER_OS" == "macOS" ]; then export SDKROOT=$(xcrun --sdk macosx --show-sdk-path); fi
            set -e
            set -u
@@ -219,6 +220,7 @@ jobs:
            export MCXTRACE_EXECUTABLE="mcxtrace"
            export MCXTRACE_PYGEN_EXECUTABLE="mcxtrace-pygen"
            export MXRUN_EXECUTABLE="mxrun"
+           if [ "$RUNNER_OS" == "macOS" ]; then export TMPDIR=${HOME}/tmp; fi
            if [ "$RUNNER_OS" == "Windows" ];
            then
              export MCXTRACE_EXECUTABLE="mcxtrace.exe"
@@ -258,6 +260,7 @@ jobs:
            set -x
            export MCXTRACE_EXECUTABLE="mcxtrace"
            export MXRUN_EXECUTABLE="mxrun"
+           if [ "$RUNNER_OS" == "macOS" ]; then export TMPDIR=${HOME}/tmp; fi
            if [ "$RUNNER_OS" == "Windows" ];
            then
              export MCXTRACE_EXECUTABLE="mcxtrace.exe"

--- a/.github/workflows/mcxtrace-testsuite.yml
+++ b/.github/workflows/mcxtrace-testsuite.yml
@@ -20,7 +20,7 @@ jobs:
           - { os: ubuntu-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'openmpi' }
           - { os: ubuntu-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'mpich' }
-          #- { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
+          - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'openmpi' }
           - { os: macos-latest, CC: clang,    CXX: clang++,    python: '3.12', mpi: 'mpich' }
           - { os: windows-latest, CC: gcc,    CXX: g++,    python: '3.12', mpi: 'msmpi' }
 
@@ -169,6 +169,11 @@ jobs:
            if [ "$RUNNER_OS" == "Windows" ];
            then
              export MXTEST_EXECUTABLE="mxtest.bat"
+           fi
+           if [ "$RUNNER_OS" == "macOS" ];
+           then
+             mkdir ${HOME}/tmp
+             export TMPDIR=${HOME}/tmp
            fi
            echo $PATH
            ${MXTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }} --mpi=2


### PR DESCRIPTION
It seems openmpi tests on macOS might be more stable with TMPDIR put to something nondefault...