### PR TITLE
Fix compilation of McXtrace Test_PowderN instr

### DIFF
--- a/mcxtrace-comps/examples/Tests_samples/Test_PowderN/Test_PowderN.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_PowderN/Test_PowderN.instr
@@ -81,7 +81,7 @@ EXTEND %{
 %}
 
 COMPONENT FlPow = FluoPowder(
-  radius=0.5e-4, yheight=1e-3, material=reflections, powder_d_phi=d_phi,
+  radius=0.5e-4, yheight=1e-3, material=reflections, d_phi=d_phi,
   packing_factor = 0.5, p_interact=frac_c)
 WHEN (index == 3)
 AT (0, 0, 0) RELATIVE sample_cradle


### PR DESCRIPTION
Failed in nightlies, correct parameter naming in instr.