### PR TITLE
Monitor_nD pixel id and buffer fix

### DIFF
--- a/mcstas-comps/share/monitor_nd-lib.c
+++ b/mcstas-comps/share/monitor_nd-lib.c
@@ -894,6 +894,7 @@ void Monitor_nD_Init(MonitornD_Defines_type *DEFS,
 	for (id_index=0;id_index<30;id_index++) {
 		if (strcmp(Vars->Coord_Var[id_index], "id") == 0) break;
 	}
+	if (id_index == 30) id_index = Vars->Coord_Number-1; // Revert to earlier behavior is id not found
 	long pix=Vars->Coord_Min[id_index];
 
 	MCDETECTOR detector;


### PR DESCRIPTION
Two updates to monitor_nD event handling:

1) Buffer was dependent on ParticleCount, which incremented on all particles reaching the trace function, but it should only be incremented whenever the ray is actually within bounds. This caused many 0's in the output as rows were basically skipped.
2) The pixel id had to be the second last variable to function correctly with the BINS matrix, code was added to find the right column.