### PR TITLE
McXtrace: samples: fluo: add M-lines via XrayLib Kissel CSb calls

### DIFF
--- a/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
@@ -39,7 +39,7 @@
 * %End
 *******************************************************************************/
 DEFINE INSTRUMENT Test_FluoPowder(E0=15, dE=0.05, L1=10, string material="LaB6.cif",
-    int index=3)
+    int index=3, delta_d_d=3e-4)
 
 USERVARS %{
   int scatt_type; // 3=diff 0=fluo
@@ -79,7 +79,7 @@ SPLIT COMPONENT sample_cradle = Arm()
 AT (0, 0, L1) RELATIVE PREVIOUS
 
 COMPONENT Pow = PowderN(
-    radius=0.5e-6, reflections=material)
+    radius=0.5e-6, reflections=material, delta_d_d=delta_d_d)
 WHEN (index == 1)
 AT (0, 0, 0) RELATIVE sample_cradle
 EXTEND %{
@@ -88,7 +88,7 @@ EXTEND %{
 %}
 
 COMPONENT SX = Single_crystal(
-    radius=0.5e-6, reflections=material,powder=1, mosaic=5)
+    radius=0.5e-6, reflections=material,powder=1, mosaic=5, delta_d_d=delta_d_d)
 WHEN (index == 2)
 AT (0, 0, 0) RELATIVE sample_cradle
 EXTEND %{
@@ -98,7 +98,7 @@ EXTEND %{
 
 COMPONENT FL_pow = FluoPowder(
     radius=0.5e-6, material=material,
-    escape_ratio=0.01, pileup_ratio=0.01)
+    escape_ratio=0.01, pileup_ratio=0.01, delta_d_d=delta_d_d)
 WHEN (index == 3)
 AT (0, 0, 0) RELATIVE sample_cradle
 EXTEND %{

--- a/mcxtrace-comps/samples/FluoCrystal.comp
+++ b/mcxtrace-comps/samples/FluoCrystal.comp
@@ -122,7 +122,7 @@
 * (...)
 *
 *
-* The fluorescence is computed via the XRayLib (apt install libxrl-dev).
+* The fluorescence is computed via the XRayLib (apt install libxrl-dev) https://github.com/tschoonj/xraylib.
 *
 * %Parameters
 * material:     [str] A CIF/LAZ/LAU file e.g. "LaB6.cif" to handle diffraction or chemical formulae, e.g. "Pb2SnO4" (no diffraction).
@@ -150,6 +150,7 @@
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
 * flag_sx:        [1] When 0, the crystal diffraction is ignored.
 * flag_lorentzian:[1] When 1, the fluorescence line shapes are assumed to be Lorentzian, else Gaussian.
+* flag_kissel:    [1] When 1, to handle M-lines XRF from Kissel (else only K and L-lines, but faster).
 * escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. 0 inactivates.
 * escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
 * pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. 0 inactivates.
@@ -177,7 +178,7 @@
 * type: scattering event type 0=fluorescence, 1=Rayleigh, 2=Compton, 3=transmit (absorbsion), 4=diffraction, 5=detector escape peak, 6=detector pile-up/sum/coincidence peak
 *
 * %Link
-* The XRayLib https://github.com/tschoonj/xraylib
+* The XRayLib https://github.com/tschoonj/xraylib http://dx.doi.org/10.1016/j.sab.2011.09.011
 * %Link
 * Fluorescence https://en.wikipedia.org/wiki/Fluorescence
 * %Link
@@ -205,6 +206,7 @@ SETTING PARAMETERS(
   target_x = 0, target_y = 0, target_z = 0, focus_r = 0,
   focus_xw=0, focus_yh=0, focus_aw=0, focus_ah=0, int target_index=0,
   int flag_compton=1, int flag_rayleigh=1, int flag_lorentzian=0,
+  int flag_kissel=0,
   string sx_refl="",  int flag_sx=1,
   delta_d_d=1e-3,     int barns=1,
   recip_cell=0,
@@ -224,7 +226,8 @@ NOACC
 
 /* ========================================================================== */
 
-SHARE COPY Single_crystal EXTEND %{
+SHARE COPY Single_crystal
+EXTEND %{
   #ifndef FLUORESCENCE_DECL
   #define FLUORESCENCE_DECL
 
@@ -240,19 +243,20 @@ SHARE COPY Single_crystal EXTEND %{
   #include <xraylib/xraylib.h>
 
   /* See XrayLib code (c) T. Schoonjans
-  * /usr/include/xraylib/xraylib-parser.h      for compoundData
-  * /usr/include/xraylib/xraylib.h             for XS
-  */
+   * /usr/include/xraylib/xraylib-parser.h      for compoundData
+   * /usr/include/xraylib/xraylib.h             for XS
+   */
 
   /* inspired from:
-  * https://github.com/golosio/xrmc src/photon/photon.cpp (c) Bruno Golosio
-  */
+   * https://github.com/golosio/xrmc src/photon/photon.cpp (c) Bruno Golosio
+   */
 
-  /* XRMC_CrossSections: Compute interaction cross sections in [barn/atom] for fluo/Rayleigh/Compton via VRayLib
-  * Return total cross section, given Z and E0:
-  *   total_xs = XRMC_CrossSections(Z, E0, xs[3]);
-  */
-  double XRMC_CrossSections(int Z, double E0, double *xs) {
+  /* XRMC_CrossSections: Compute interaction cross sections in [barn/atom]
+   * When kissel=1, M-lines are computed, but computation is 10x slower.
+   * Return total cross section, given Z and E0:
+   *   total_xs = XRMC_CrossSections(Z, E0, xs[3], flag_kissel);
+   */
+  double XRMC_CrossSections(int Z, double E0, double *xs, int kissel) {
     int    i_line;
 
     if (xs == NULL) return 0;
@@ -261,7 +265,9 @@ SHARE COPY Single_crystal EXTEND %{
     // loop on possible fluorescence lines
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) {
       // cumulative sum of the line cross sections
-      xs[FLUORESCENCE] += CSb_FluorLine(Z, -i_line, E0, NULL); /* XRayLib */
+      xs[FLUORESCENCE] += kissel ?
+      CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
+      : CSb_FluorLine(Z, -i_line, E0, NULL);
     }
 
     // coherent and incoherent cross sections
@@ -273,10 +279,10 @@ SHARE COPY Single_crystal EXTEND %{
   } // XRMC_CrossSections
 
   /* XRMC_SelectFromDistribution: select a random element from a distribution
-  *   index = XRMC_SelectFromDistribution(cum_sum[N], N);
-  * index is returned within 0 and N-1
-  * The x_arr must be a continuously increasing cumulated sum, which last element is the max
-  */
+   *   index = XRMC_SelectFromDistribution(cum_sum[N], N);
+   * index is returned within 0 and N-1
+   * The x_arr must be a continuously increasing cumulated sum, which last element is the max
+   */
   int XRMC_SelectFromDistribution(double x_arr[], int N)
   {
     if (x_arr == NULL || N <=0) return (0);
@@ -299,33 +305,30 @@ SHARE COPY Single_crystal EXTEND %{
   } // XRMC_SelectFromDistribution
 
   /* XRMC_SelectInteraction: select interaction type Fluo/Compton/Rayleigh
-  * Return the interaction type from a random choice within cross sections 'xs'
-  *   type = XRMC_SelectInteraction(xs[3], 3);
-  * 'xs' is computed with XRMC_CrossSections.
-  * type is one of FLUORESCENCE | RAYLEIGH | COMPTON
-  */
+   * Return the interaction type from a random choice within cross sections 'xs'
+   *   type = XRMC_SelectInteraction(xs[3], 3, flag_kissel);
+   * 'xs' is computed with XRMC_CrossSections.
+   * type is one of FLUORESCENCE | RAYLEIGH | COMPTON
+   */
   int XRMC_SelectInteraction(double *xs, int nb_processes)
   {
-    double sum_xs, *cum_xs;
+    double sum_xs, cum_xs[5];
     int    i;
 
     if (xs == NULL || nb_processes < 1) return 0;
-    cum_xs = malloc((nb_processes+1)*sizeof(double));
-    if (!cum_xs)          return 0;
     cum_xs[0]=sum_xs=0;
     for (i=0; i< nb_processes; i++) {
       sum_xs += xs[i];
       cum_xs[i+1]= sum_xs;
     }
-    i = XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
-    free(cum_xs);
-    return i;
+    return XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
   } // XRMC_SelectInteraction
 
   /* XRMC_SelectFluorescenceEnergy: select outgoing fluo photon energy, when incoming with 'E0'
-  *   Ef = XRMC_SelectFluorescenceEnergy(Z, E0, &dE);
-  */
-  double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE)
+   * When kissel=1, M-lines are included, but computation is 10x slower
+   *   Ef = XRMC_SelectFluorescenceEnergy(Z, E0, &dE, kissel);
+   */
+  double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE, int kissel)
   {
     int i_line;
     double sum_xs, cum_xs_lines[XRAYLIB_LINES_MAX+1];
@@ -333,7 +336,9 @@ SHARE COPY Single_crystal EXTEND %{
     // compute cumulated XS for all fluo lines
     cum_xs_lines[0] = sum_xs = 0;
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) { // loop on fluorescent lines
-      double xs = CSb_FluorLine(Z, -i_line, E0, NULL); /* XRayLib */
+      double xs = kissel ?
+      CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
+      : CSb_FluorLine(Z, -i_line, E0, NULL);
       // when a line is inactive: E=xs=0
       sum_xs += xs;
       cum_xs_lines[i_line+1] = sum_xs; // cumulative sum of their cross sections
@@ -349,23 +354,23 @@ SHARE COPY Single_crystal EXTEND %{
   // Function removing spaces from string
   char * removeSpacesFromStr(char *string)
   {
-      // non_space_count to keep the frequency of non space characters
-      int non_space_count = 0;
-      if (string == NULL) return NULL;
+    // non_space_count to keep the frequency of non space characters
+    int non_space_count = 0;
+    if (string == NULL) return NULL;
 
-      //Traverse a string and if it is non space character then, place it at index non_space_count
-      for (int i = 0; string[i] != '\0'; i++)
+    //Traverse a string and if it is non space character then, place it at index non_space_count
+    for (int i = 0; string[i] != '\0'; i++)
+    {
+      if (isalpha(string[i]) || isdigit(string[i]))
       {
-          if (isalpha(string[i]) || isdigit(string[i]))
-          {
-              string[non_space_count] = string[i];
-              non_space_count++; //non_space_count incremented
-          }
+        string[non_space_count] = string[i];
+        non_space_count++; //non_space_count incremented
       }
+    }
 
-      //Finally placing final character at the string end
-      string[non_space_count] = '\0';
-      return string;
+    //Finally placing final character at the string end
+    string[non_space_count] = '\0';
+    return string;
   }
 
   // ok = fluo_get_material(material, formula)
@@ -380,10 +385,10 @@ SHARE COPY Single_crystal EXTEND %{
     FILE *file = Open_File(filename, "r", NULL);
     if (!file)
       exit(fprintf(stderr, "%s: ERROR: can not open file %s\n",
-      __FILE__, filename));
+                   __FILE__, filename));
 
-    // Read the file, and search tokens in rows
-    formula[0]=0;
+      // Read the file, and search tokens in rows
+      formula[0]=0;
     while (fgets(Line, sizeof(Line), file) != NULL) {
       char *token = NULL;
       int   flag_exit=0;
@@ -400,9 +405,9 @@ SHARE COPY Single_crystal EXTEND %{
       // search for CIF token
       // single line: search " '\'" delimiter after CIF token, marks reading the formula
       if (!strncasecmp(Line, "_chemical_formula_structural", 28)
-       || !strncasecmp(Line, "_chemical_formula_sum", 21)
-       || !strncasecmp(Line, "_chemical_formula_moiety", 24)
-       || flag_found_cif) {
+        || !strncasecmp(Line, "_chemical_formula_sum", 21)
+        || !strncasecmp(Line, "_chemical_formula_moiety", 24)
+        || flag_found_cif) {
         if  (flag_found_cif) { flag_found_cif=0; /* can not span on more that 2 lines */}
         else flag_found_cif=1;
         // search for delimiter after the CIF token
@@ -418,12 +423,12 @@ SHARE COPY Single_crystal EXTEND %{
         }
         if (first_non_space)
           next_non_space  = strpbrk(first_non_space+1, "\'\n\r"); // position of formula end
-        if (next_non_space) {
-          flag_exit = 1;
-          token = first_non_space;
-        }
-      } else if (!strncasecmp(Line, "# TITLE", 7) && strchr(Line, '['))
-        token = Line+7;
+          if (next_non_space) {
+            flag_exit = 1;
+            token = first_non_space;
+          }
+        } else if (!strncasecmp(Line, "# TITLE", 7) && strchr(Line, '['))
+          token = Line+7;
       else if (!strncasecmp(Line, "# Atom", 6))
         token = Line+6;
       else if (!strncasecmp(Line, "Atom", 4))
@@ -518,7 +523,10 @@ INITIALIZE %{
                         "ERROR       Please check parameter values (xwidth, yheight, zdepth, radius).\n", NAME_CURRENT_COMP));
 
   if (!material || !strlen(material) || !strcmp(material, "NULL") || !strcmp(material, "0"))
-    exit(fprintf(stderr, "ERROR: FluoCrystal: %s: Null material specification\n", NAME_CURRENT_COMP));
+    exit(fprintf(stderr, "ERROR: FluoCrystal: %s: Null material specification.\n", NAME_CURRENT_COMP));
+
+  if (order > 1 && flag_lorentzian)
+    fprintf(stderr, "FluoCrystal: WARNING: %s: Using flag_lorentzian=1 Lorentzian line-shape with order>1 may create artifacts.\n", NAME_CURRENT_COMP);
 
   // test if the material is given as a file
   char formula[16384];
@@ -873,7 +881,7 @@ do { /* while (intersect) Loop over multiple scattering events */
         double xs_Z[3];
 
         // get Fluorescence xs
-        XRMC_CrossSections(Z, E, xs_Z); // [barn/atom]
+        XRMC_CrossSections(Z, E, xs_Z, flag_kissel); // [barn/atom]
         sigma_barn            += frac*CSb_Total(Z, E, NULL); // Fluo+Compton+Rayleigh
         cum_xs_fluo[i_Z+1]     = cum_xs_fluo[i_Z]    +frac*xs_Z[FLUORESCENCE];
         cum_xs_Rayleigh[i_Z+1] = cum_xs_Rayleigh[i_Z]+frac*xs_Z[RAYLEIGH];
@@ -1067,7 +1075,7 @@ do { /* while (intersect) Loop over multiple scattering events */
       case FLUORESCENCE: /* 0 Fluo: choose line */
         n_fluo++;
         p_fluo += p;
-        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE);      // dE in keV
+        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);      // dE in keV
         if (dE) {
           if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
           else                 dE  *= randnorm();          // Gaussian distribution
@@ -1111,7 +1119,7 @@ do { /* while (intersect) Loop over multiple scattering events */
       // handle detector pile-up peak: get an other fluo line and sum it
       i_Z = XRMC_SelectFromDistribution(cum_xs_fluo,     compound->nElements+1);
       Z   = compound->Elements[i_Z];
-      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE);
+      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);
       kf += Ef*E2K;
       type= FLUORESCENCE_PILEUP;
     }

--- a/mcxtrace-comps/samples/FluoPowder.comp
+++ b/mcxtrace-comps/samples/FluoPowder.comp
@@ -120,7 +120,7 @@
 * (...)
 *
 *
-* The fluorescence is computed via the XRayLib (apt install libxrl-dev).
+* The fluorescence is computed via the XRayLib (apt install libxrl-dev) https://github.com/tschoonj/xraylib.
 *
 * %Parameters
 * material:     [str] A CIF/LAZ/LAU file e.g. "LaB6.cif" to handle diffraction or chemical formulae, e.g. "Pb2SnO4" (no diffraction).
@@ -148,13 +148,14 @@
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
 * flag_powder:    [1] When 0, the powder diffraction is ignored.
 * flag_lorentzian:[1] When 1, the fluorescence line shapes are assumed to be Lorentzian, else Gaussian.
+* flag_kissel:    [1] When 1, to handle M-lines XRF from Kissel (else only K and L-lines, but faster).
 * escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. 0 inactivates.
 * escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
 * pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. 0 inactivates.
 * order:          [1] Limit multiple fluorescence up to given order. Last iteration is absorption only.
 * barns:          [1] Flag to indicate if |F|^2 from 'material' is in barns or fm^2, (barns=1 for laz/cif, barns=0 for lau type files).
 * d_phi:        [deg] Angle corresponding to the difraction vertical angular range to focus to, e.g. detector height. 0 for no focusing. You may as well define focus_ah or focus_yh and target.
-* delta_d_d:     [AA] Global relative difraction Delta_d/d spreading when the 'w' column is not available. Use 0 if ideal.
+* delta_d_d:     [AA] Global relative difraction Delta_d/d spreading when the 'w' column is not available, e.g. 1e-4 to 1e-3. Use 0 if ideal.
 * DW:             [1] Global difraction Debye-Waller factor when the 'DW' column is not available. Use 1 if included in F2.
 * nb_atoms:       [1] Number of sub-unit per unit cell, that is ratio of sigma for chemical formula to sigma per unit cell.
 * powder_format: [{}] List of structure file column indexes. See the PowderN component.
@@ -166,7 +167,7 @@
 * type: scattering event type 0=FLUORESCENCE fluorescence, 1=RAYLEIGH Rayleigh, 2=COMPTON Compton, 3=TRANSMISSION Transmit (absorbsion), 4=DIFFRACTION Diffraction, 5=FLUORESCENCE_ESCAPE Detector escape peak, 6=FLUORESCENCE_PILEUP Detector pile-up/sum/coincidence peak
 *
 * %Link
-* The XRayLib https://github.com/tschoonj/xraylib
+* The XRayLib https://github.com/tschoonj/xraylib http://dx.doi.org/10.1016/j.sab.2011.09.011
 * %Link
 * Fluorescence https://en.wikipedia.org/wiki/Fluorescence
 * %Link
@@ -194,6 +195,7 @@ SETTING PARAMETERS(
   target_x = 0, target_y = 0, target_z = 0, focus_r = 0,
   focus_xw=0, focus_yh=0, focus_aw=0, focus_ah=0, int target_index=0,
   int flag_compton=1, int flag_rayleigh=1, int flag_lorentzian=0, int flag_powder=1,
+  int flag_kissel=0,
   string powder_refl="",
   vector powder_format={0,0,0,0,0,0,0,0}, Vc=0, delta_d_d=0, DW=0,
   d_phi=0, int nb_atoms=1, int barns=1, int tth_sign=0,
@@ -207,7 +209,8 @@ NOACC
 
 /* ========================================================================== */
 
-SHARE COPY PowderN EXTEND %{
+SHARE COPY PowderN
+EXTEND %{
   #ifndef FLUORESCENCE_DECL
   #define FLUORESCENCE_DECL
 
@@ -223,19 +226,20 @@ SHARE COPY PowderN EXTEND %{
   #include <xraylib/xraylib.h>
 
   /* See XrayLib code (c) T. Schoonjans
-  * /usr/include/xraylib/xraylib-parser.h      for compoundData
-  * /usr/include/xraylib/xraylib.h             for XS
-  */
+   * /usr/include/xraylib/xraylib-parser.h      for compoundData
+   * /usr/include/xraylib/xraylib.h             for XS
+   */
 
   /* inspired from:
-  * https://github.com/golosio/xrmc src/photon/photon.cpp (c) Bruno Golosio
-  */
+   * https://github.com/golosio/xrmc src/photon/photon.cpp (c) Bruno Golosio
+   */
 
   /* XRMC_CrossSections: Compute interaction cross sections in [barn/atom]
-  * Return total cross section, given Z and E0:
-  *   total_xs = XRMC_CrossSections(Z, E0, xs[3]);
-  */
-  double XRMC_CrossSections(int Z, double E0, double *xs) {
+   * When kissel=1, M-lines are computed, but computation is 10x slower.
+   * Return total cross section, given Z and E0:
+   *   total_xs = XRMC_CrossSections(Z, E0, xs[3], flag_kissel);
+   */
+  double XRMC_CrossSections(int Z, double E0, double *xs, int kissel) {
     int    i_line;
 
     if (xs == NULL) return 0;
@@ -244,7 +248,9 @@ SHARE COPY PowderN EXTEND %{
     // loop on possible fluorescence lines
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) {
       // cumulative sum of the line cross sections
-      xs[FLUORESCENCE] += CSb_FluorLine(Z, -i_line, E0, NULL); /* XRayLib */
+      xs[FLUORESCENCE] += kissel ?
+      CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
+      : CSb_FluorLine(Z, -i_line, E0, NULL);
     }
 
     // coherent and incoherent cross sections
@@ -256,10 +262,10 @@ SHARE COPY PowderN EXTEND %{
   } // XRMC_CrossSections
 
   /* XRMC_SelectFromDistribution: select a random element from a distribution
-  *   index = XRMC_SelectFromDistribution(cum_sum[N], N);
-  * index is returned within 0 and N-1
-  * The x_arr must be a continuously increasing cumulated sum, which last element is the max
-  */
+   *   index = XRMC_SelectFromDistribution(cum_sum[N], N);
+   * index is returned within 0 and N-1
+   * The x_arr must be a continuously increasing cumulated sum, which last element is the max
+   */
   int XRMC_SelectFromDistribution(double x_arr[], int N)
   {
     if (x_arr == NULL || N <=0) return (0);
@@ -282,33 +288,30 @@ SHARE COPY PowderN EXTEND %{
   } // XRMC_SelectFromDistribution
 
   /* XRMC_SelectInteraction: select interaction type Fluo/Compton/Rayleigh
-  * Return the interaction type from a random choice within cross sections 'xs'
-  *   type = XRMC_SelectInteraction(xs[3], 3);
-  * 'xs' is computed with XRMC_CrossSections.
-  * type is one of FLUORESCENCE | RAYLEIGH | COMPTON
-  */
+   * Return the interaction type from a random choice within cross sections 'xs'
+   *   type = XRMC_SelectInteraction(xs[3], 3, flag_kissel);
+   * 'xs' is computed with XRMC_CrossSections.
+   * type is one of FLUORESCENCE | RAYLEIGH | COMPTON
+   */
   int XRMC_SelectInteraction(double *xs, int nb_processes)
   {
-    double sum_xs, *cum_xs;
+    double sum_xs, cum_xs[5];
     int    i;
 
     if (xs == NULL || nb_processes < 1) return 0;
-    cum_xs = malloc((nb_processes+1)*sizeof(double));
-    if (!cum_xs)          return 0;
     cum_xs[0]=sum_xs=0;
     for (i=0; i< nb_processes; i++) {
       sum_xs += xs[i];
       cum_xs[i+1]= sum_xs;
     }
-    i = XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
-    free(cum_xs);
-    return i;
+    return XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
   } // XRMC_SelectInteraction
 
   /* XRMC_SelectFluorescenceEnergy: select outgoing fluo photon energy, when incoming with 'E0'
-  *   Ef = XRMC_SelectFluorescenceEnergy(Z, E0, &dE);
-  */
-  double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE)
+   * When kissel=1, M-lines are included, but computation is 10x slower
+   *   Ef = XRMC_SelectFluorescenceEnergy(Z, E0, &dE, kissel);
+   */
+  double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE, int kissel)
   {
     int i_line;
     double sum_xs, cum_xs_lines[XRAYLIB_LINES_MAX+1];
@@ -316,7 +319,9 @@ SHARE COPY PowderN EXTEND %{
     // compute cumulated XS for all fluo lines
     cum_xs_lines[0] = sum_xs = 0;
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) { // loop on fluorescent lines
-      double xs = CSb_FluorLine(Z, -i_line, E0, NULL); /* XRayLib */
+      double xs = kissel ?
+      CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
+      : CSb_FluorLine(Z, -i_line, E0, NULL);
       // when a line is inactive: E=xs=0
       sum_xs += xs;
       cum_xs_lines[i_line+1] = sum_xs; // cumulative sum of their cross sections
@@ -332,23 +337,23 @@ SHARE COPY PowderN EXTEND %{
   // Function removing spaces from string
   char * removeSpacesFromStr(char *string)
   {
-      // non_space_count to keep the frequency of non space characters
-      int non_space_count = 0;
-      if (string == NULL) return NULL;
+    // non_space_count to keep the frequency of non space characters
+    int non_space_count = 0;
+    if (string == NULL) return NULL;
 
-      //Traverse a string and if it is non space character then, place it at index non_space_count
-      for (int i = 0; string[i] != '\0'; i++)
+    //Traverse a string and if it is non space character then, place it at index non_space_count
+    for (int i = 0; string[i] != '\0'; i++)
+    {
+      if (isalpha(string[i]) || isdigit(string[i]))
       {
-          if (isalpha(string[i]) || isdigit(string[i]))
-          {
-              string[non_space_count] = string[i];
-              non_space_count++; //non_space_count incremented
-          }
+        string[non_space_count] = string[i];
+        non_space_count++; //non_space_count incremented
       }
+    }
 
-      //Finally placing final character at the string end
-      string[non_space_count] = '\0';
-      return string;
+    //Finally placing final character at the string end
+    string[non_space_count] = '\0';
+    return string;
   }
 
   // ok = fluo_get_material(material, formula)
@@ -363,10 +368,10 @@ SHARE COPY PowderN EXTEND %{
     FILE *file = Open_File(filename, "r", NULL);
     if (!file)
       exit(fprintf(stderr, "%s: ERROR: can not open file %s\n",
-      __FILE__, filename));
+                   __FILE__, filename));
 
-    // Read the file, and search tokens in rows
-    formula[0]=0;
+      // Read the file, and search tokens in rows
+      formula[0]=0;
     while (fgets(Line, sizeof(Line), file) != NULL) {
       char *token = NULL;
       int   flag_exit=0;
@@ -383,9 +388,9 @@ SHARE COPY PowderN EXTEND %{
       // search for CIF token
       // single line: search " '\'" delimiter after CIF token, marks reading the formula
       if (!strncasecmp(Line, "_chemical_formula_structural", 28)
-       || !strncasecmp(Line, "_chemical_formula_sum", 21)
-       || !strncasecmp(Line, "_chemical_formula_moiety", 24)
-       || flag_found_cif) {
+        || !strncasecmp(Line, "_chemical_formula_sum", 21)
+        || !strncasecmp(Line, "_chemical_formula_moiety", 24)
+        || flag_found_cif) {
         if  (flag_found_cif) { flag_found_cif=0; /* can not span on more that 2 lines */}
         else flag_found_cif=1;
         // search for delimiter after the CIF token
@@ -401,12 +406,12 @@ SHARE COPY PowderN EXTEND %{
         }
         if (first_non_space)
           next_non_space  = strpbrk(first_non_space+1, "\'\n\r"); // position of formula end
-        if (next_non_space) {
-          flag_exit = 1;
-          token = first_non_space;
-        }
-      } else if (!strncasecmp(Line, "# TITLE", 7) && strchr(Line, '['))
-        token = Line+7;
+          if (next_non_space) {
+            flag_exit = 1;
+            token = first_non_space;
+          }
+        } else if (!strncasecmp(Line, "# TITLE", 7) && strchr(Line, '['))
+          token = Line+7;
       else if (!strncasecmp(Line, "# Atom", 6))
         token = Line+6;
       else if (!strncasecmp(Line, "Atom", 4))
@@ -500,7 +505,10 @@ INITIALIZE %{
                         "ERROR       Please check parameter values (xwidth, yheight, zdepth, radius).\n", NAME_CURRENT_COMP));
 
   if (!material || !strlen(material) || !strcmp(material, "NULL") || !strcmp(material, "0"))
-    exit(fprintf(stderr, "ERROR: FluoPowder: %s: Null material specification\n", NAME_CURRENT_COMP));
+    exit(fprintf(stderr, "ERROR: FluoPowder: %s: Null material specification.\n", NAME_CURRENT_COMP));
+
+  if (order > 1 && flag_lorentzian)
+    fprintf(stderr, "FluoPowder: WARNING: %s: Using flag_lorentzian=1 Lorentzian line-shape with order>1 may create artifacts.\n", NAME_CURRENT_COMP);
 
   // test if the material is given as a file
   char formula[16384];
@@ -863,7 +871,7 @@ do { /* while (intersect) Loop over multiple scattering events */
         double xs_Z[3];
 
         // get Fluorescence xs
-        XRMC_CrossSections(Z, E, xs_Z); // [barn/atom]
+        XRMC_CrossSections(Z, E, xs_Z, flag_kissel); // [barn/atom]
         sigma_barn            += frac*CSb_Total(Z, E, NULL); // Fluo+Compton+Rayleigh
         cum_xs_fluo[i_Z+1]     = cum_xs_fluo[i_Z]    +frac*xs_Z[FLUORESCENCE];
         cum_xs_Compton[i_Z+1]  = cum_xs_Compton[i_Z] +frac*xs_Z[COMPTON];
@@ -1078,7 +1086,7 @@ do { /* while (intersect) Loop over multiple scattering events */
       case FLUORESCENCE: /* 0 Fluo: choose line */
         n_fluo++;
         p_fluo += p;
-        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE);      // dE in keV
+        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);      // dE in keV
         if (dE) {
           if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
           else                 dE  *= randnorm();          // Gaussian distribution
@@ -1134,7 +1142,7 @@ do { /* while (intersect) Loop over multiple scattering events */
       // handle detector pile-up peak: get an other fluo line and sum it
       i_Z = XRMC_SelectFromDistribution(cum_xs_fluo,     compound->nElements+1);
       Z   = compound->Elements[i_Z];
-      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE);
+      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);
       kf += Ef*E2K;             // pile-up
       type= FLUORESCENCE_PILEUP;
     }

--- a/mcxtrace-comps/samples/Fluorescence.comp
+++ b/mcxtrace-comps/samples/Fluorescence.comp
@@ -116,7 +116,7 @@
 * (...)
 *
 *
-* The computation is made via the XRayLib (apt install libxrl-dev).
+* The computation is made via the XRayLib (apt install libxrl-dev) https://github.com/tschoonj/xraylib.
 *
 * %Parameters
 * material:  [str]    Chemical formulae, e.g. "LaB6", "Pb2SnO4". If may also be a CIF/LAZ/LAU file.
@@ -144,6 +144,7 @@
 * flag_compton:   [1] When 0, the Compton  scattering is ignored.
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
 * flag_lorentzian:[1] When 1, the line shapes are assumed to be Lorentzian, else Gaussian.
+* flag_kissel:    [1] When 1, to handle M-lines XRF from Kissel (else only K and L-lines, but faster).
 * escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. 0 inactivates.
 * escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
 * pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. 0 inactivates.
@@ -153,7 +154,7 @@
 * type: scattering event type 0=FLUORESCENCE fluorescence, 1=RAYLEIGH Rayleigh, 2=COMPTON Compton, 3=TRANSMISSION Transmit (absorbsion), 4=DIFFRACTION Diffraction (not handled here), 5=FLUORESCENCE_ESCAPE Detector escape peak, 6=FLUORESCENCE_PILEUP Detector pile-up/sum/coincidence peak
 *
 * %Link
-* The XRayLib https://github.com/tschoonj/xraylib
+* The XRayLib https://github.com/tschoonj/xraylib http://dx.doi.org/10.1016/j.sab.2011.09.011
 * %Link
 * Fluorescence https://en.wikipedia.org/wiki/Fluorescence
 * %Link
@@ -181,6 +182,7 @@ SETTING PARAMETERS(
   target_x = 0, target_y = 0, target_z = 0, focus_r = 0,
   focus_xw=0, focus_yh=0, focus_aw=0, focus_ah=0, int target_index=0,
   int flag_compton=1, int flag_rayleigh=1, int flag_lorentzian=0,
+  int flag_kissel=0,
   escape_ratio=0, escape_energy=1.739,
   pileup_ratio=0,
   int order=1)
@@ -206,6 +208,7 @@ SHARE %{
   #define TRANSMISSION 4
   #define FLUORESCENCE_ESCAPE 5 // Detector escape      peak fluorescence
   #define FLUORESCENCE_PILEUP 6 // Detector pile-up/sum peak fluorescence
+
   #include <xraylib/xraylib.h>
   
 /* See XrayLib code (c) T. Schoonjans
@@ -218,10 +221,11 @@ SHARE %{
  */
   
   /* XRMC_CrossSections: Compute interaction cross sections in [barn/atom]
+   * When kissel=1, M-lines are computed, but computation is 10x slower.
    * Return total cross section, given Z and E0:
-   *   total_xs = XRMC_CrossSections(Z, E0, xs[3]);
+   *   total_xs = XRMC_CrossSections(Z, E0, xs[3], flag_kissel);
    */
-  double XRMC_CrossSections(int Z, double E0, double *xs) {
+  double XRMC_CrossSections(int Z, double E0, double *xs, int kissel) {
     int    i_line;
     
     if (xs == NULL) return 0;
@@ -230,7 +234,9 @@ SHARE %{
     // loop on possible fluorescence lines
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) { 
       // cumulative sum of the line cross sections
-      xs[FLUORESCENCE] += CSb_FluorLine(Z, -i_line, E0, NULL); /* XRayLib */
+      xs[FLUORESCENCE] += kissel ?
+        CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
+      : CSb_FluorLine(Z, -i_line, E0, NULL);
     }
 
     // coherent and incoherent cross sections
@@ -288,9 +294,10 @@ SHARE %{
   } // XRMC_SelectInteraction
 
   /* XRMC_SelectFluorescenceEnergy: select outgoing fluo photon energy, when incoming with 'E0'
-   *   Ef = XRMC_SelectFluorescenceEnergy(Z, E0, &dE);
+   * When kissel=1, M-lines are included, but computation is 10x slower
+   *   Ef = XRMC_SelectFluorescenceEnergy(Z, E0, &dE, kissel);
    */
-  double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE)
+  double XRMC_SelectFluorescenceEnergy(int Z, double E0, double *dE, int kissel)
   {
     int i_line;
     double sum_xs, cum_xs_lines[XRAYLIB_LINES_MAX+1];
@@ -298,7 +305,9 @@ SHARE %{
     // compute cumulated XS for all fluo lines
     cum_xs_lines[0] = sum_xs = 0;
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) { // loop on fluorescent lines
-      double xs = CSb_FluorLine(Z, -i_line, E0, NULL); /* XRayLib */
+      double xs = kissel ?
+        CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
+      : CSb_FluorLine(Z, -i_line, E0, NULL);
       // when a line is inactive: E=xs=0
       sum_xs += xs;
       cum_xs_lines[i_line+1] = sum_xs; // cumulative sum of their cross sections
@@ -478,7 +487,10 @@ INITIALIZE %{
                         "ERROR       Please check parameter values (xwidth, yheight, zdepth, radius).\n", NAME_CURRENT_COMP));
   
   if (!material || !strlen(material) || !strcmp(material, "NULL") || !strcmp(material, "0")) 
-    exit(fprintf(stderr, "Fluorescence: ERROR: %s: Null material specification\n", NAME_CURRENT_COMP));
+    exit(fprintf(stderr, "Fluorescence: ERROR: %s: Null material specification.\n", NAME_CURRENT_COMP));
+
+  if (order > 1 && flag_lorentzian)
+    fprintf(stderr, "Fluorescence: WARNING: %s: Using flag_lorentzian=1 Lorentzian line-shape with order>1 may create artifacts.\n", NAME_CURRENT_COMP);
     
   // test if the material is given as a file
   char path[1024];
@@ -760,7 +772,7 @@ do { /* while (intersect) Loop over multiple scattering events */
         double xs_Z[3];
 
         // get Fluorescence xs
-        XRMC_CrossSections(Z, E, xs_Z); // [barn/atom]
+        XRMC_CrossSections(Z, E, xs_Z, flag_kissel); // [barn/atom]
         sigma_barn            += frac*CSb_Total(Z, E, NULL); // Photo+Compton+Rayleigh
         cum_xs_fluo[i_Z+1]     = cum_xs_fluo[i_Z]    +frac*xs_Z[FLUORESCENCE];
         cum_xs_Compton[i_Z+1]  = cum_xs_Compton[i_Z] +frac*xs_Z[COMPTON];
@@ -890,7 +902,7 @@ do { /* while (intersect) Loop over multiple scattering events */
       case FLUORESCENCE: /* 0 Fluo: choose line */
         n_fluo++;
         p_fluo += p;
-        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE);      // dE in keV
+        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);      // dE in keV
         if (dE) {
           if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
           else                 dE  *= randnorm();          // Gaussian distribution
@@ -926,7 +938,7 @@ do { /* while (intersect) Loop over multiple scattering events */
       // handle detector pile-up peak: get an other fluo line and sum it
       i_Z = XRMC_SelectFromDistribution(cum_xs_fluo,     compound->nElements+1);
       Z   = compound->Elements[i_Z];
-      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE);
+      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);
       kf += Ef*E2K;             // pile-up
       type= FLUORESCENCE_PILEUP;
     }


### PR DESCRIPTION
McXtrace fluorescence samples:

- add capability to handle M-lines XRF via the XrayLib Kissel XS functions.
- see https://github.com/tschoonj/xraylib/wiki/The-xraylib-API-list-of-all-functions#x-ray-fluorescence-cross-sections
- factor 10x slower computation is expected.

Should not affect much the tests as this option is ... optional (only for low energy XRF).