### PR TITLE
mcxtrace: samples: fluo: fix again the Fluo share

### DIFF
--- a/mcxtrace-comps/samples/FluoCrystal.comp
+++ b/mcxtrace-comps/samples/FluoCrystal.comp
@@ -312,16 +312,20 @@ EXTEND %{
    */
   int XRMC_SelectInteraction(double *xs, int nb_processes)
   {
-    double sum_xs, cum_xs[5];
+    double sum_xs, *cum_xs;
     int    i;
 
     if (xs == NULL || nb_processes < 1) return 0;
+    cum_xs = malloc((nb_processes+1)*sizeof(double));
+    if (!cum_xs)          return 0;
     cum_xs[0]=sum_xs=0;
     for (i=0; i< nb_processes; i++) {
       sum_xs += xs[i];
       cum_xs[i+1]= sum_xs;
     }
-    return XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
+    i = XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
+    free(cum_xs);
+    return i;
   } // XRMC_SelectInteraction
 
   /* XRMC_SelectFluorescenceEnergy: select outgoing fluo photon energy, when incoming with 'E0'

--- a/mcxtrace-comps/samples/FluoPowder.comp
+++ b/mcxtrace-comps/samples/FluoPowder.comp
@@ -295,16 +295,20 @@ EXTEND %{
    */
   int XRMC_SelectInteraction(double *xs, int nb_processes)
   {
-    double sum_xs, cum_xs[5];
+    double sum_xs, *cum_xs;
     int    i;
 
     if (xs == NULL || nb_processes < 1) return 0;
+    cum_xs = malloc((nb_processes+1)*sizeof(double));
+    if (!cum_xs)          return 0;
     cum_xs[0]=sum_xs=0;
     for (i=0; i< nb_processes; i++) {
       sum_xs += xs[i];
       cum_xs[i+1]= sum_xs;
     }
-    return XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
+    i = XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
+    free(cum_xs);
+    return i;
   } // XRMC_SelectInteraction
 
   /* XRMC_SelectFluorescenceEnergy: select outgoing fluo photon energy, when incoming with 'E0'

--- a/mcxtrace-comps/samples/Fluorescence.comp
+++ b/mcxtrace-comps/samples/Fluorescence.comp
@@ -281,16 +281,20 @@ SHARE %{
    */
   int XRMC_SelectInteraction(double *xs, int nb_processes)
   {
-    double sum_xs, cum_xs[5];
+    double sum_xs, *cum_xs;
     int    i;
-    
+
     if (xs == NULL || nb_processes < 1) return 0;
+    cum_xs = malloc((nb_processes+1)*sizeof(double));
+    if (!cum_xs)          return 0;
     cum_xs[0]=sum_xs=0;
     for (i=0; i< nb_processes; i++) {
       sum_xs += xs[i];
       cum_xs[i+1]= sum_xs;
     }
-    return XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
+    i = XRMC_SelectFromDistribution(cum_xs, nb_processes+1);
+    free(cum_xs);
+    return i;
   } // XRMC_SelectInteraction
 
   /* XRMC_SelectFluorescenceEnergy: select outgoing fluo photon energy, when incoming with 'E0'


### PR DESCRIPTION
fix **again** the Fluo share that reverted to a static xs[5] array in process selection.
Should really implement a multiple SHARE COPY grammar to avoid duplicating such Fluo comp shares.