### PR TITLE
This allows any compiled instrument to run with --trace=0

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -4531,12 +4531,14 @@ mcenabletrace(int mode)
   mcdotrace = mode;
   #pragma acc update device ( mcdotrace )
  } else {
-   fprintf(stderr,
-           "Error: trace not enabled (mcenabletrace)\n"
-           "Please re-run the " MCCODE_NAME " compiler "
-                   "with the --trace option, or rerun the\n"
-           "C compiler with the MC_TRACE_ENABLED macro defined.\n");
-   exit(1);
+   if (mode>0) {
+     fprintf(stderr,
+	     "Error: trace not enabled (mcenabletrace)\n"
+	     "Please re-run the " MCCODE_NAME " compiler "
+	     "with the --trace option, or rerun the\n"
+	     "C compiler with the MC_TRACE_ENABLED macro defined.\n");
+     exit(1);
+   }
  }
 }
 


### PR DESCRIPTION
In 3.5.27 and earlier recent releases, running e.g.

1. `mcstas my.instr` (leaving out `--trace`)
2. `mcrun my.instr` (for compilation) 

results in this type of error message, since mcrun passes `--trace=0` to the resulting binary:
```
mcrun PSI_DMC.instr 
INFO: No output directory specified (--dir)
INFO: Using directory: "PSI_DMC_20250511_195047"
INFO: Using existing c-file: ./PSI_DMC.c
INFO: Recompiling: ./PSI_DMC.out
ld: warning: duplicate -rpath '/Applications/McStas-3.5.27.app/Contents/Resources/miniconda3/lib' ignored
INFO: ===
Error: trace not enabled (mcenabletrace)
Please re-run the mcstas compiler with the --trace option, or rerun the
C compiler with the MC_TRACE_ENABLED macro defined.
```

This PR allows any compiled instrument to run with `--trace=0` irrespective of compiled-in support.

To actually use  visualisation mode, --trace needs to be assigned a value (1/2), since introduction of the modernised mc/mxdisplay with `--trace=2` or legacy -`-trace=1`. 

The instruments now only report an error if `--trace` are  built without `MCDISPLAY` support and actually given a non-zero value.