### PR TITLE
Grammar multiple comp copy extend

### DIFF
--- a/cmake/Modules/InstallMCCODE.cmake
+++ b/cmake/Modules/InstallMCCODE.cmake
@@ -261,35 +261,27 @@ macro(installMCCODE)
   )
 
 
-  ## Generate lex.yy.c with flex
+  ## Generate lex.yy.c with flex (C generator)
   add_custom_command(
     OUTPUT work/src/lex.yy.c
     COMMAND "${FLEX_EXECUTABLE}" -i "${PROJECT_SOURCE_DIR}/src/instrument.l"
     WORKING_DIRECTORY work/src
     DEPENDS "${PROJECT_SOURCE_DIR}/src/instrument.l"
   )
-  ## Generate py-lex.yy.c with flex
+  ## Generate py-lex.yy.c with flex (Python generator)
   add_custom_command(
     OUTPUT work/src/py-lex.yy.c
     COMMAND "${FLEX_EXECUTABLE}" -DGENERATE_PY -o py-lex.yy.c -i "${PROJECT_SOURCE_DIR}/src/instrument.l"
     WORKING_DIRECTORY work/src
     DEPENDS "${PROJECT_SOURCE_DIR}/src/instrument.l"
   )
-  ## Generate instrument.tab.{h,c} with bison
+  ## Generate instrument.tab.{h,c} with bison (both for C and Python generators)
   add_custom_command(
     OUTPUT work/src/instrument.tab.h work/src/instrument.tab.c
     COMMAND "${BISON_EXECUTABLE}" -v -d "${PROJECT_SOURCE_DIR}/src/instrument.y"
     WORKING_DIRECTORY work/src
     DEPENDS "${PROJECT_SOURCE_DIR}/src/instrument.y" work/src/lex.yy.c
   )
-  ## Generate py-instrument.tab.{h,c} with bison for Python
-  add_custom_command(
-    OUTPUT work/src/py-instrument.tab.h work/src/py-instrument.tab.c
-    COMMAND "${BISON_EXECUTABLE}" -v -d "${PROJECT_SOURCE_DIR}/src/py-instrument.y"
-    WORKING_DIRECTORY work/src
-    DEPENDS "${PROJECT_SOURCE_DIR}/src/py-instrument.y" work/src/py-lex.yy.c
-  )
-
 
   # Handling of system-provided random functions on windows - 
   # needed only in the link step for mccode and -format
@@ -325,7 +317,7 @@ macro(installMCCODE)
   add_executable(
     ${FLAVOR}-pygen
     work/src/pygen.c
-    work/src/py-cexp.c
+    work/src/cexp.c
     work/src/coords.c
     work/src/debug.c
     work/src/file.c
@@ -339,8 +331,8 @@ macro(installMCCODE)
 
     # files generated with flex and bison
     work/src/py-lex.yy.c
-    work/src/py-instrument.tab.h
-    work/src/py-instrument.tab.c
+    work/src/instrument.tab.h
+    work/src/instrument.tab.c
   )
   target_compile_definitions(${FLAVOR}-pygen PUBLIC GENERATE_PY=1)
 

--- a/mccode/src/instrument.l
+++ b/mccode/src/instrument.l
@@ -41,11 +41,7 @@
 #endif
 
 #include "mccode.h"
-#ifdef GENERATE_PY
-#include "py-instrument.tab.h"
-#else
 #include "instrument.tab.h"
-#endif
 
 /* Fix things for bison option %pure_parser. */
 #define YY_DECL int yylex(YYSTYPE *yylvalp)

--- a/mccode/src/py-cexp.c
+++ b/mccode/src/py-cexp.c
@@ -1,2 +1,0 @@
-#define GENERATE_PY
-#include "cexp.c"

--- a/mccode/src/py-instrument.l
+++ b/mccode/src/py-instrument.l
@@ -1,1 +1,0 @@
-instrument.l

--- a/mccode/src/py-instrument.y
+++ b/mccode/src/py-instrument.y
@@ -1,1 +1,0 @@
-instrument.y

--- a/mcstas-comps/CMakeLists.txt
+++ b/mcstas-comps/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 include(MCUtil)
 setupMCCODE("mcstas")
 
-option( ENABLE_CIF2HKL "Build Third Party code cif2hkl (fortran)" ON )#TODO: Only enable enable Fortran if this is on
+option( ENABLE_CIF2HKL "Build Third Party code cif2hkl (fortran)" ON )#TODO: Only enable Fortran if this is on
 if ( ENABLE_CIF2HKL )
   set(DEBIDEPS "${FLAVOR}, libnexus-dev, libgsl-dev")
 else()

--- a/mcxtrace-comps/CMakeLists.txt
+++ b/mcxtrace-comps/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CPACK_NSIS_DISPLAY_NAME "${MCCODE_STRING} Components")
 
 include(CPack)
 
-option( ENABLE_CIF2HKL "Build Third Party code cif2hkl (fortran)" ON )#TODO: Only enable enable Fortran if this is on
+option( ENABLE_CIF2HKL "Build Third Party code cif2hkl (fortran)" ON )#TODO: Only enable Fortran if this is on
 if ( ENABLE_CIF2HKL )
   enable_language( Fortran )
   add_executable(

--- a/tools/Python/mcplot/html/CMakeLists.txt
+++ b/tools/Python/mcplot/html/CMakeLists.txt
@@ -53,7 +53,7 @@ set(CPACK_NSIS_DISPLAY_NAME "${NSIS_NAME}")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${NSIS_NAME}")
 
 # Debian
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}, python3-scipy, python3-pillow, python3-numpy")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "${FLAVOR}, python3-scipy, python3-pillow, python3-numpy, python3-pyqt5.qtsvg, python3-pyqt6.qtsvg")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "${FLAVOR}-tools-python-${P}plot-html-3.5.1")
 
 # RPM


### PR DESCRIPTION
This is a PR to allow multiple `%{ %}/COPY/EXTEND` blocks in component definition sections SHARE DECLARE INIT TRACE SAVE FINALLY DISPLAY. 

Up to now, only syntax:
- `%{ %}`
- `COPY(compdef) EXTEND`

where allowed. 

The new syntax allows to mix/alternate as many blocks as required, to e.g. set some C code, append something from a component, possibly an other one, and end with an EXTEND. 

An immediate application will be to shorten a lot the new FluoPowder and FluoCrystal by having e.g.:
```
SHARE COPY(Powder) COPY(Fluorescence)
```
and this syntax could probably be applied as well to the INIT and DECLARE blocks. This way, we may reduce a lot code duplication, without creating dedicated .c/.h libraries.

There is full backward compatibility.