### PR TITLE
Add Open_File in header (used from e.g. PowderN)

### DIFF
--- a/common/lib/share/read_table-lib.h
+++ b/common/lib/share/read_table-lib.h
@@ -133,6 +133,8 @@ void *Table_File_List_store(t_Table *tab);
   Table_ParseHeader_backend(header,__VA_ARGS__,NULL);
 
 char **Table_ParseHeader_backend(char *header, ...);
+FILE *Open_File(char *name, const char *Mode, char *path);
+
 
 /* private functions */
 void Table_Free(t_Table *Table);


### PR DESCRIPTION
This should repair most of the non-compiles using mcstas-antlr in 
https://new-nightly.mcstas.org/todays-datafiles/2025-05-12_output.html