### PR TITLE
Sync MCPL components McStas <-> McXtrace

### DIFF
--- a/mcstas-comps/misc/MCPL_input.comp
+++ b/mcstas-comps/misc/MCPL_input.comp
@@ -26,12 +26,12 @@
 * %P
 * INPUT PARAMETERS
 *
-* filename: [str]       Name of neutron mcpl file to read.
-* verbose: [ ]          Print debugging information for first 10 particles read.
-* preload: [ ]          Load particles during INITIALIZE. On GPU preload is forced.
-* polarisationuse: [ ]  If !=0 read polarisation vectors from file.
-* Emin: [meV]           Lower energy bound. Particles found in the MCPL-file below the limit are skipped.
-* Emax: [meV]           Upper energy bound. Particles found in the MCPL-file above the limit are skipped.
+* filename: [str]       Name of neutron mcpl file to read
+* verbose: [ ]          Print debugging information for first 10 particles read
+* preload: [ ]          Load particles during INITIALIZE. On GPU preload is forced
+* polarisationuse: [ ]  If !=0 read polarisation vectors from file
+* Emin: [meV]           Lower energy bound. Particles found in the MCPL-file below the limit are skipped
+* Emax: [meV]           Upper energy bound. Particles found in the MCPL-file above the limit are skipped
 * repeat_count: [1]     Repeat contents of the MCPL file this number of times. NB: When running MPI, repeating is implicit and is taken into account by integer division. MUST be combined with _smear options!
 * v_smear: [1]          When repeating events, make a Gaussian MC choice within v_smear*V around particle velocity V
 * pos_smear: [m]        When repeating events, make a flat MC choice of position within pos_smear around particle starting position
@@ -326,6 +326,7 @@ TRACE
     sx=sy=sz=0;
   }
 
+  /*ekin is in MeV, in McStas meV*/ 
   if (!preload) {
     #ifndef OPENACC
     nrm = particle->ekin *1e9/VS2E;

--- a/mcstas-comps/misc/MCPL_input.comp
+++ b/mcstas-comps/misc/MCPL_input.comp
@@ -160,9 +160,11 @@ INITIALIZE
       VX = create_darr1d(nparticles);
       VY = create_darr1d(nparticles);
       VZ = create_darr1d(nparticles);
-      SX = create_darr1d(nparticles);
-      SY = create_darr1d(nparticles);
-      SZ = create_darr1d(nparticles);
+      if(polarisationuse){
+        SX = create_darr1d(nparticles);
+        SY = create_darr1d(nparticles);
+        SZ = create_darr1d(nparticles);
+      }
       T = create_darr1d(nparticles);
       P = create_darr1d(nparticles);
       E = create_darr1d(nparticles);

--- a/mcstas-comps/misc/MCPL_input.comp
+++ b/mcstas-comps/misc/MCPL_input.comp
@@ -150,7 +150,7 @@ INITIALIZE
     repeating = 0;
 #ifdef OPENACC
     preload=1;
-    printf("OpenACC, preload implicit:\n");	    
+    printf("OpenACC, preload implicit:\n");
 #endif
     if (preload) {
       printf("Preload requested, loading MCPLfile in INITIALIZE\n");
@@ -348,7 +348,6 @@ TRACE
     d1=VY[i];
     d2=VZ[i];
   }
-  
   if (ismpislave || repeating) {
     // Direction-MC:
     double tmpx,tmpy,tmpz;
@@ -402,7 +401,19 @@ FINALLY
           NAME_CURRENT_COMP,(long unsigned)ncount,(long unsigned)nparticles,(long unsigned)used_neutrons);
     }
 
-
+    destroy_darr1d(X);
+    destroy_darr1d(Y);
+    destroy_darr1d(Z);
+    destroy_darr1d(VX);
+    destroy_darr1d(VY);
+    destroy_darr1d(VZ);
+    if(polarisationuse){
+      destroy_darr1d(SX);
+      destroy_darr1d(SY);
+      destroy_darr1d(SZ);
+    }
+    destroy_darr1d(T);
+    destroy_darr1d(P);
 %}
 
 MCDISPLAY

--- a/mcstas-comps/misc/MCPL_output.comp
+++ b/mcstas-comps/misc/MCPL_output.comp
@@ -37,8 +37,8 @@
 * %P
 * INPUT PARAMETERS
 *
-* filename: [str]         Name of neutron file to write. If not given, the component name will be used.
-* verbose: [1]            If 1) Print summary information for created MCPL file. 2) Also print summary of first 10 particles information stored in the MCPL file. >2) Also print information for first 10 particles as they are being stored by McStas.
+* filename: [str]         Name of neutron file to write. If not given, the component name will be used
+* verbose: [1]            If 1) Print summary information for created MCPL file. 2) Also print summary of first 10 particles information stored in the MCPL file. >2) Also print information for first 10 particles as they are being stored by McStas
 * polarisationuse: [1]    Enable storing the polarisation state of the neutron.
 * doubleprec: [1]         Use double precision storage
 * userflag: [1]           Extra variable to attach to each neutron. The value of this variable will be packed into a 32 bit integer.
@@ -51,7 +51,7 @@
 
 DEFINE COMPONENT MCPL_output
 
-  SETTING PARAMETERS (int polarisationuse=0, int doubleprec=0, verbose=0, string userflag="",
+  SETTING PARAMETERS (int polarisationuse=0, int doubleprec=0, int verbose=0, string userflag="",
   string filename=0, string userflagcomment="", merge_mpi=1, keep_mpi_unmerged=0, buffermax=0)
 
 DEPENDENCY "@MCPLFLAGS@"
@@ -235,7 +235,7 @@ TRACE
   int fail;
 #ifdef OPENACC
   int cap;
-  #pragma acc atomic capture
+#pragma acc atomic capture
   {
     cap=captured++;
   }
@@ -274,7 +274,7 @@ TRACE
     }
 
     nrm =sqrt(vx*vx + vy*vy + vz*vz);
-    /*ekin is in MeV*/
+    /*ekin is in MeV, in McStas meV*/
     particle->ekin = VS2E*nrm*nrm/1e9;
     particle->direction[0] = vx/nrm;
     particle->direction[1] = vy/nrm;
@@ -319,15 +319,15 @@ SAVE
       Particle.position[0]=X[i]*100;
       Particle.position[1]=Y[i]*100;
       Particle.position[2]=Z[i]*100;
-      
+
       if(polarisationuse){
 	Particle.polarisation[0]=SX[i];
 	Particle.polarisation[1]=SY[i];
 	Particle.polarisation[2]=SZ[i];
       }
-      
+
       nrm =sqrt(VX[i]*VX[i] + VY[i]*VY[i] + VZ[i]*VZ[i]);
-      /*ekin is in MeV*/
+      /*ekin is in MeV, in McStas meV*/
       Particle.ekin = VS2E*nrm*nrm/1e9;
       Particle.direction[0] = VX[i]/nrm;
       Particle.direction[1] = VY[i]/nrm;
@@ -340,14 +340,14 @@ SAVE
       if(userflagenabled){
 	Particle.userflags = (uint32_t) U[i];
       }
-      
+
       if (verbose==3 && mcrun_num<10) {
 	printf("id=%ld\tpdg=2112\tekin=%g MeV\tx=%g cm\ty=%g cm\tz=%g cm\tux=%g\tuy=%g\tuz=%g\tt=%g ms\tweight=%g\tpolx=%g\tpoly=%g\tpolz=%g\n",
 	       mcrun_num, Particle.ekin, Particle.position[0], Particle.position[1], Particle.position[2],
 	       Particle.direction[0], Particle.direction[1], Particle.direction[2], Particle.time, Particle.weight,
 	       Particle.polarisation[0], Particle.polarisation[1], Particle.polarisation[2]);
       }
-      
+
       mcpl_add_particle(outputfile,&Particle);
     }
   }
@@ -405,7 +405,7 @@ FINALLY
 	fprintf(stderr,"Warning (%s): Could not remove one or more unmerged files.\n",NAME_CURRENT_COMP);
       }
     }
-    
+
     /*free the string storage*/
     sprintf(finalfile,merge_outfilename);
     free(merge_outfilename);

--- a/mcstas-comps/misc/MCPL_output_noacc.comp
+++ b/mcstas-comps/misc/MCPL_output_noacc.comp
@@ -37,8 +37,8 @@
 * %P
 * INPUT PARAMETERS
 *
-* filename: [str]         Name of neutron file to write. If not given, the component name will be used.
-* verbose: [1]            If 1) Print summary information for created MCPL file. 2) Also print summary of first 10 particles information stored in the MCPL file. >2) Also print information for first 10 particles as they are being stored by McStas.
+* filename: [str]         Name of neutron file to write. If not given, the component name will be used
+* verbose: [1]            If 1) Print summary information for created MCPL file. 2) Also print summary of first 10 particles information stored in the MCPL file. >2) Also print information for first 10 particles as they are being stored by McStas
 * polarisationuse: [1]    Enable storing the polarisation state of the neutron.
 * doubleprec: [1]         Use double precision storage
 * userflag: [1]           Extra variable to attach to each neutron. The value of this variable will be packed into a 32 bit integer.
@@ -51,7 +51,7 @@
 
 DEFINE COMPONENT MCPL_output_noacc
 
-  SETTING PARAMETERS (int polarisationuse=0, int doubleprec=0, verbose=0, string userflag="",
+  SETTING PARAMETERS (int polarisationuse=0, int doubleprec=0, int verbose=0, string userflag="",
   string filename=0, string userflagcomment="", merge_mpi=1, keep_mpi_unmerged=0, buffermax=0)
 
 DEPENDENCY "@MCPLFLAGS@"
@@ -89,7 +89,7 @@ INITIALIZE
 
 #if defined (USE_MPI)
   /* In case of MPI, simply redefine the filename used by each node */
-    sprintf(tmpstr, "Message(%s): You are using MCPL_output with MPI, hence your will get %i filenames %s.node_#i.mcpl{.gz} as output.\n",NAME_CURRENT_COMP,mpi_node_count,filename);
+    sprintf(tmpstr, "Message(%s): You are using MCPL_output with MPI, hence you will get %i filenames %s.node_#i.mcpl{.gz} as output.\n",NAME_CURRENT_COMP,mpi_node_count,filename);
     sprintf(extension,"node_%i.mcpl",mpi_node_rank);
 #else
     sprintf(extension,"mcpl");
@@ -215,7 +215,7 @@ TRACE
   }
 
   nrm =sqrt(vx*vx + vy*vy + vz*vz);
-  /*ekin is in MeV*/
+    /*ekin is in MeV, in McStas meV*/
   particle->ekin = VS2E*nrm*nrm/1e9;
   particle->direction[0] = vx/nrm;
   particle->direction[1] = vy/nrm;
@@ -232,7 +232,7 @@ TRACE
 
   MPI_MASTER(
   if (verbose==3 && mcrun_num<10) {
-    printf("id=%ld\tpdg=2112\tekin=%g MeV\tx=%g cm\ty=%g cm\tz=%g cm\tux=%g\tuy=%g\tuz=%g\tt=%g ms\tweight=%g\tpolx=%g\tpoly=%g\tpolz=%g\n",
+        printf("id=%lld\tpdg=2112\tekin=%g MeV\tx=%g cm\ty=%g cm\tz=%g cm\tux=%g\tuy=%g\tuz=%g\tt=%g ms\tweight=%g\tpolx=%g\tpoly=%g\tpolz=%g\n",
 	   mcrun_num, particle->ekin, particle->position[0], particle->position[1], particle->position[2],
 	   particle->direction[0], particle->direction[1], particle->direction[2], particle->time, particle->weight,
 	   particle->polarisation[0], particle->polarisation[1], particle->polarisation[2]);
@@ -301,7 +301,7 @@ FINALLY
                 fprintf(stderr,"Warning (%s): Could not remove one or more unmerged files.\n",NAME_CURRENT_COMP);
             }
         }
-    
+
         /*free the string storage*/
         sprintf(finalfile,merge_outfilename);
         free(merge_outfilename);

--- a/mcxtrace-comps/misc/MCPL_input.comp
+++ b/mcxtrace-comps/misc/MCPL_input.comp
@@ -216,7 +216,7 @@ INITIALIZE
 	      T[used_photons] = particle->time*1e-3;
 	      /*weight in unspecified units:*/
 	      P[used_photons] = particle->weight;
-              E[used_neutrons] = particle->ekin;
+              E[used_photons] = particle->ekin;
 	      used_photons++;
 	    }
 	    read_photons++;
@@ -232,7 +232,7 @@ INITIALIZE
     }
     repeat_tot=repeat_cnt*mpi_cnt;
     if (preload) {
-      mcset_ncount(repeat_tot*used_neutrons);
+      mcset_ncount(repeat_tot*used_photons);
     } else {
       mcset_ncount(repeat_tot*nparticles);
     }

--- a/mcxtrace-comps/misc/MCPL_input.comp
+++ b/mcxtrace-comps/misc/MCPL_input.comp
@@ -78,6 +78,7 @@ DArray1d KZ;
 DArray1d EX;
 DArray1d EY;
 DArray1d EZ;
+DArray1d E;
 DArray1d T;
 DArray1d P;
 %}
@@ -168,6 +169,7 @@ INITIALIZE
       }
       T = create_darr1d(nparticles);
       P = create_darr1d(nparticles);
+      E = create_darr1d(nparticles);
       printf("Initiating file read...\n");
       int loop;
       for (loop=0; loop < nparticles ; loop++) {
@@ -214,6 +216,7 @@ INITIALIZE
 	      T[used_photons] = particle->time*1e-3;
 	      /*weight in unspecified units:*/
 	      P[used_photons] = particle->weight;
+              E[used_neutrons] = particle->ekin;
 	      used_photons++;
 	    }
 	    read_photons++;

--- a/mcxtrace-comps/misc/MCPL_input.comp
+++ b/mcxtrace-comps/misc/MCPL_input.comp
@@ -149,6 +149,11 @@ INITIALIZE
     );
     repeating = 0;
 #ifdef OPENACC
+    preload=1;
+    printf("OpenACC, preload implicit:\n");
+#endif
+    if (preload) {
+      printf("Preload requested, loading MCPLfile in INITIALIZE\n");
       X = create_darr1d(nparticles);
       Y = create_darr1d(nparticles);
       Z = create_darr1d(nparticles);
@@ -176,38 +181,41 @@ INITIALIZE
 		     particle->polarisation[0], particle->polarisation[1], particle->polarisation[2]);
 	    }
 	    /* check energy range*/
-	    if ( particle->ekin>Emin*1e-9 || particle->ekin<Emax*1e-9 ) {
+	    if ( particle->ekin>Emin*1e-9 && particle->ekin<Emax*1e-9 ) {
 	      /* Particle energy in range */
 	      /*positions are in cm*/
-	      X[read_photons]=particle->position[0]/100;
-	      Y[read_photons]=particle->position[1]/100;
-	      Z[read_photons]=particle->position[2]/100;
+	      X[used_photons]=particle->position[0]/100;
+	      Y[used_photons]=particle->position[1]/100;
+	      Z[used_photons]=particle->position[2]/100;
 
 	      if(polarisationuse){
-		EX[read_photons]=(double)particle->polarisation[0];
-		EY[read_photons]=(double)particle->polarisation[1];
-		EZ[read_photons]=(double)particle->polarisation[2];
+		EX[used_photons]=(double)particle->polarisation[0];
+		EY[used_photons]=(double)particle->polarisation[1];
+		EZ[used_photons]=(double)particle->polarisation[2];
 	      }else{
-		EX[read_photons]=0;
-		EY[read_photons]=0;
-		EZ[read_photons]=0;
+		EX[used_photons]=0;
+		EY[used_photons]=0;
+		EZ[used_photons]=0;
 	      }
 	      double nrm;
               nrm = particle->ekin *1e3*E2K;
               nrm = sqrt(nrm);
 
-	      double d0=particle->direction[0],d1=particle->direction[1],d2=particle->direction[2];
+	      double d0=particle->direction[0];
+	      double d1=particle->direction[1];
+	      double d2=particle->direction[2];
 
-	      KX[read_photons]=d0*nrm;
-	      KY[read_photons]=d1*nrm;
-	      KZ[read_photons]=d2*nrm;
+	      KX[used_photons]=d0*nrm;
+	      KY[used_photons]=d1*nrm;
+	      KZ[used_photons]=d2*nrm;
 
 	      /*time in ms:*/
-	      T[read_photons] = particle->time*1e-3;
+	      T[used_photons] = particle->time*1e-3;
 	      /*weight in unspecified units:*/
-	      P[read_photons] = particle->weight;
-	      read_photons++;
+	      P[used_photons] = particle->weight;
+	      used_photons++;
 	    }
+	    read_photons++;
 	  }
 	}
       }
@@ -217,11 +225,13 @@ INITIALIZE
 	      (long unsigned)repeat_count,(long unsigned)read_photons,
 	      (long unsigned)repeat_count,(long unsigned)repeat_cnt*read_photons);
       fprintf(stdout, " photons total\n\n");
-      mcset_ncount(repeat_cnt*read_photons);
-
-      ncount=mcget_ncount();
-      fprintf(stdout,"Initialize ncount is %lu\n",(long unsigned)ncount);
-#endif
+    }
+    repeat_tot=repeat_cnt*mpi_cnt;
+    if (preload) {
+      mcset_ncount(repeat_tot*used_neutrons);
+    } else {
+      mcset_ncount(repeat_tot*nparticles);
+    }
 %}
 
 TRACE
@@ -231,10 +241,10 @@ TRACE
   long long ncount;
 #ifndef OPENACC
     const mcpl_particle_t *particle;// = (mcpl_particle_t *) calloc(sizeof(mcpl_particle_t),1);
+  if(!preload) {
     particle = mcpl_read(inputfile);
 
     ncount=mcget_ncount();
-    // fprintf(stdout,"Trace ncount is %ld\n",ncount);      
     if (!particle) {
       if(repeat_cnt>1) {
 	/* Trigger rewind of the file and ABSORB to get the first photon "again" */
@@ -270,44 +280,87 @@ TRACE
 	     particle->polarisation[0], particle->polarisation[1], particle->polarisation[2]);
     }
    );
-
+  }
+#endif
+  ncount = mcget_ncount();
+  //fprintf(stdout,"Trace ncount is %ld on %i\n",ncount,ismpislave);
+  unsigned long long i=(_particle->_uid);
+  if (preload) {
+    if (i>=used_photons) {
+      repeating=1;
+      i = i % used_photons;
+    }
+  }
+  if (!preload) {
     /*positions are in cm*/
+    #ifndef OPENACC
     x=particle->position[0]/100;
     y=particle->position[1]/100;
     z=particle->position[2]/100;
+    #endif
+  } else {
+    x=X[i]/100;
+    y=Y[i]/100;
+    z=Z[i]/100;
+  }
+  if (ismpislave || repeating) {
+    double tmpx,tmpy,tmpz;
+    // Position-MC:
+    randvec_target_circle(&tmpx, &tmpy, &tmpz, NULL, 0, 0, 1, 0);
+    NORM(tmpx,tmpy,tmpz);
+    tmpx *= pos_smear*rand01(); tmpy *= pos_smear*rand01(); tmpz *= pos_smear*rand01();
+    x+=tmpx; y+=tmpy; z+=tmpz;
+  }
     
-    if (ismpislave || repeating) {
-      double tmpx,tmpy,tmpz;
-      // Position-MC:
-      randvec_target_circle(&tmpx, &tmpy, &tmpz, NULL, 0, 0, 1, 0);
-      NORM(tmpx,tmpy,tmpz);
-      tmpx *= pos_smear*rand01(); tmpy *= pos_smear*rand01(); tmpz *= pos_smear*rand01();
-      x+=tmpx; y+=tmpy; z+=tmpz;
+  if(polarisationuse){
+    if(!preload) {
+      #ifndef OPENACC
+      Ex=particle->polarisation[0];
+      Ey=particle->polarisation[1];
+      Ez=particle->polarisation[2];
+      #endif
+    } else {
+      Ex=EX[i];
+      Ey=EY[i];
+      Ez=EZ[i];
     }
-    
-    if(polarisationuse){
-        Ex=particle->polarisation[0];
-        Ey=particle->polarisation[1];
-        Ez=particle->polarisation[2];
-    }else{
-        Ex=Ey=Ez=0;
-    }
+  } else {
+    Ex=Ey=Ez=0;
+  }
+
+  if (!preload) {
+    #ifndef OPENACC
     nrm = particle->ekin *1e3*E2K;
+    #endif
+  } else {
+    nrm = E[i] *1e3*E2K;
+  }
+  
     nrm = sqrt(nrm);
-    if (ismpislave || repeating) {
-      // Energy-MC:
-      double tmp=(1.0+E_smear*randpm1());
-      //printf("Adjusting energy from %g to",nrm);
-      nrm *= (1+E_smear*randpm1());
-      //printf(" to %g\n",nrm);
-    }
-    double d0=particle->direction[0],d1=particle->direction[1],d2=particle->direction[2];
-    
-    if (ismpislave || repeating) {
+  if (ismpislave || repeating) {
+    // Energy-MC:
+    double tmp=(1.0+E_smear*randpm1());
+    //printf("Adjusting energy from %g to",nrm);
+    nrm *= (1+E_smear*randpm1());
+    //printf(" to %g\n",nrm);
+  }
+  double d0,d1,d2;
+  if (!preload) {
+    #ifndef OPENACC
+    d0=particle->direction[0];
+    d1=particle->direction[1];
+    d2=particle->direction[2];
+    #endif
+  } else {
+    d0=KX[i];
+    d1=KY[i];
+    d2=KZ[i];
+  }
+  if (ismpislave || repeating) {
       // Direction-MC:
       double tmpx,tmpy,tmpz;
       // Position-MC:
-      randvec_target_circle(&d0, &d1, &d2, NULL, particle->direction[0], particle->direction[1], particle->direction[2], sin(dir_smear*DEG2RAD));
+      randvec_target_circle(&d0, &d1, &d2, NULL, d0, d1, d2, sin(dir_smear*DEG2RAD));
       NORM(d0,d1,d2);
     }
     
@@ -315,69 +368,28 @@ TRACE
     ky=d1*nrm;
     kz=d2*nrm;   
 
+  if (!preload) {
+    #ifndef OPENACC
     /*time in ms:*/
     t=particle->time*1e-3;
     /*weight in unspecified units:*/
     p=particle->weight;
-
+    #endif
+  } else {
+    t=T[i]*1e-3;
+    p=P[i];
+  }
     /* Correct for repetition, by repeat_count and/or MPI */
-    p /= repeat_cnt;
-#if defined (USE_MPI)   
-    p /= mpi_node_count;
-#endif
-#else
-  unsigned long long i=_particle->_uid;
-  if (i>=nparticles) {
-    repeating=1;
-    i = i % nparticles;
-  }
-  x=X[i];
-  y=Y[i];
-  z=Z[i];
-  kx=KX[i];
-  ky=KY[i];
-  kz=KZ[i];
-  Ex=EX[i];
-  Ey=EY[i];
-  Ez=EZ[i];
-  t=T[i];
-  /*MCPL does not store photon phase information.*/
-  phi=0;
-  p=P[i];
-  if (repeat_cnt>1) p = p /repeat_cnt;
-
-  if (repeating) {
-    /* Position smearing */
-    double tmpx,tmpy,tmpz;
-    // Position-MC:
-    randvec_target_circle(&tmpx, &tmpy, &tmpz, NULL, 0, 0, 1, 0);
-    NORM(tmpx,tmpy,tmpz);
-    tmpx *= pos_smear*rand01(); tmpy *= pos_smear*rand01(); tmpz *= pos_smear*rand01();
-    x+=tmpx; y+=tmpy; z+=tmpz;
-
-    double d0=kx,d1=ky,d2=kz;
-    /* Direction smearing: */
-    randvec_target_circle(&d0, &d1, &d2, NULL, kx, ky, kz, sin(dir_smear*DEG2RAD));
-    NORM(d0,d1,d2);
-
-    /* Energy smearing: */
-    double tmpe=(1.0+E_smear*randpm1());
-    double nrm=K2E*sqrt(kx*kx+ky*ky+kz*kz);
-    nrm *= (1.0+E_smear*randpm1());
-    nrm = K2E*nrm;
-
-    kx=nrm*d0;
-    ky=nrm*d1;
-    kz=nrm*d2;
-  }
-#endif
+  p /= (repeat_tot);
   SCATTER;
 %}
 
 SAVE
 %{
     #ifndef OPENACC
+  if (!preload) {
     mcpl_close_file(inputfile);
+  }
     #endif
 %}
 

--- a/mcxtrace-comps/misc/MCPL_input.comp
+++ b/mcxtrace-comps/misc/MCPL_input.comp
@@ -28,13 +28,13 @@
 * %Parameters
 * INPUT PARAMETERS
 *
-* filename: [str]       Name of photon mcpl file to read.
-* verbose: [ ]          Print debugging information for first 10 particles read.
-* preload: [ ]          Load particles during INITIALIZE. On GPU preload is forced.
-* polarisationuse: [ ]  If !=0 read polarisation vectors from file.
-* Emin: [keV]           Lower energy bound. Particles found in the MCPL-file below the limit are skipped.
-* Emax: [keV]           Upper energy bound. Particles found in the MCPL-file above the limit are skipped.
-* repeat_count: [1]     Repeat contents of the MCPL file this number of times. NB: When running MPI, repeating is implicit and is taken into account by integer division. Should be combined sith the _smear options!
+* filename: [str]       Name of photon mcpl file to read
+* verbose: [ ]          Print debugging information for first 10 particles read
+* preload: [ ]          Load particles during INITIALIZE. On GPU preload is forced
+* polarisationuse: [ ]  If !=0 read polarisation vectors from file
+* Emin: [keV]           Lower energy bound. Particles found in the MCPL-file below the limit are skipped
+* Emax: [keV]           Upper energy bound. Particles found in the MCPL-file above the limit are skipped
+* repeat_count: [1]     Repeat contents of the MCPL file this number of times. NB: When running MPI, repeating is implicit and is taken into account by integer division. MUST be combined sith the _smear options!
 * E_smear: [1]          When repeating events, make a Gaussian MC choice within E_smear*E around particle energy E
 * pos_smear: [m]        When repeating events, make a flat MC choice of position within pos_smear around particle starting position
 * dir_smear: [deg]      When repeating events, make a Gaussian MC choice of direction within dir_smear around particle direction
@@ -332,6 +332,7 @@ TRACE
     Ex=Ey=Ez=0;
   }
 
+  /*ekin is in MeV, in McXtrace keV*/ 
   if (!preload) {
     #ifndef OPENACC
     nrm = particle->ekin *1e3*E2K;

--- a/mcxtrace-comps/misc/MCPL_input.comp
+++ b/mcxtrace-comps/misc/MCPL_input.comp
@@ -18,7 +18,7 @@
 * Source-like component that reads photon state parameters from a binary mcpl-file.
 *
 * MCPL is short for Monte Carlo Particle List, and is a new format for sharing events
-* between e.g. MCNP(X), Geant-4 and McXtrace .
+* between e.g. MCNP(X), Geant4 and McXtrace .
 *
 * When used with MPI, the --ncount given on the commandline is overwritten by 
 * #MPI nodes x #events in the file.
@@ -30,6 +30,7 @@
 *
 * filename: [str]       Name of photon mcpl file to read.
 * verbose: [ ]          Print debugging information for first 10 particles read.
+* preload: [ ]          Load particles during INITIALIZE. On GPU preload is forced.
 * polarisationuse: [ ]  If !=0 read polarisation vectors from file.
 * Emin: [keV]           Lower energy bound. Particles found in the MCPL-file below the limit are skipped.
 * Emax: [keV]           Upper energy bound. Particles found in the MCPL-file above the limit are skipped.
@@ -43,7 +44,7 @@
 
 DEFINE COMPONENT MCPL_input
 
-SETTING PARAMETERS (string filename=0, polarisationuse=1,verbose=1, Emin=0, Emax=FLT_MAX, int repeat_count=1, E_smear=0, pos_smear=0, dir_smear=0)
+SETTING PARAMETERS (string filename=0, polarisationuse=1,verbose=1, Emin=0, Emax=FLT_MAX, int repeat_count=1, E_smear=0, pos_smear=0, dir_smear=0, int preload=0)
 
 DEPENDENCY "@MCPLFLAGS@"
 
@@ -408,7 +409,7 @@ FINALLY
                 "Please examine the recorded intensities carefully.\n",
           NAME_CURRENT_COMP,(long unsigned)ncount,(long unsigned)nparticles,(long unsigned)used_photons);
     }
-    
+
     destroy_darr1d(X);
     destroy_darr1d(Y);
     destroy_darr1d(Z);

--- a/mcxtrace-comps/misc/MCPL_output.comp
+++ b/mcxtrace-comps/misc/MCPL_output.comp
@@ -38,15 +38,15 @@
 * %Parameters
 * INPUT PARAMETERS
 *
-* filename: [str]         Name of neutron file to write. If not given, the component name will be used.
-* verbose:         [1]   If 1) Print summary information for created MCPL file. 2) Also print summary of first 10 particles information stored in the MCPL file. >2) Also print information for first 10 particles as they are being stored by McXtrace.
-* polarisationuse: [1]   Enable storing the polarization state of the photon.
-* doubleprec:      [1]   Use double precision storage.
+* filename: [str]         Name of neutron file to write. If not given, the component name will be used
+* verbose:         [1]   If 1) Print summary information for created MCPL file. 2) Also print summary of first 10 particles information stored in the MCPL file. >2) Also print information for first 10 particles as they are being stored by McXtrace
+* polarisationuse: [1]   Enable storing the polarisation state of the photon
+* doubleprec:      [1]   Use double precision storage
 * userflag:        [1]   Extra variable to attach to each photon. The value of this variable will be packed into a 32 bit integer.
 * userflagcomment: [str] String variable to describe the userflag. If this string is empty (the default) no userflags will be stored.
-* merge_mpi:       [1]   Flag to indicate if output should be merged in case of MPI.
+* merge_mpi:       [1]   Flag to indicate if output should be merged in case of MPI
 * keep_mpi_unmerged: [1] Flag to indicate if original unmerged mcpl-files should be kept (or deleted).
-* buffermax: [1]         Maximal number of events to save ( <= MAXINT), GPU/OpenACC only.
+* buffermax: [1]         Maximal number of events to save ( <= MAXINT), GPU/OpenACC only
 * %End
 *******************************************************************************/
 
@@ -61,7 +61,7 @@ SHARE
 %{
 #include <mcpl.h>
 #include <sys/stat.h>
-  int mcpl_file_exist (char *filename)
+int mcpl_file_exist (char *filename)
   {
     struct stat   buffer;
     return (stat (filename, &buffer) == 0);
@@ -331,7 +331,7 @@ SAVE
       }
 
       nrm =sqrt(KX[i]*KX[i] + KY[i]*KY[i] + KZ[i]*KZ[i]);
-      /*ekin is in MeV in McXtrace keV*/
+      /*ekin is in MeV, in McXtrace keV*/
       Particle.ekin = K2E*nrm*1e-3;
       Particle.direction[0] = KX[i]/nrm;
       Particle.direction[1] = KY[i]/nrm;


### PR DESCRIPTION
1. Fixes https://github.com/mccode-dev/McCode/issues/2003
2. Preparation for https://github.com/mccode-dev/McCode/issues/2018 by:
  * Minimising differences between `MCPL_input` in McStas vs. McXtrace (only differs by particle properties)
  * Minimising differences between `MCPL_output` in McStas vs. McXtrace (only differs by particle properties)
  * Minimising differences between `MCPL_output` and `MCPL_output_noacc` in McStas (difference is simply the `OPENACC` parts ripped out and `NOACC` raised

@g5t I agree the differences between the legacy `MCPL_input` and `MCPL_input_once` is (maybe) too big to make a hybrid, but I think we should:
a. Eventually port the `once` to McXtrace
b. Ensure identical behaviour / interface when working on https://github.com/mccode-dev/McCode/issues/2018