### PR TITLE
Swap default trace behaviour to 'enabled'

### DIFF
--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -342,7 +342,7 @@ jobs:
            #if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            if [ "x$(uname)" == "xLinux" ]; then
              ../install_mcstas/bin/${MCRUN_EXECUTABLE} --format=NeXus --IDF templateSANS_Mantid.instr lambda=6
-             ../install_mcstas/bin/${MCRUN_EXECUTABLE} -c --verbose --mpi=2 --format=NeXus --IDF templateSANS_Mantid.instr lambda=6 -d MPIoutput
+             ../install_mcstas/bin/${MCRUN_EXECUTABLE} -c --verbose --mpi=2 --format=NeXus --IDF templateSANS_Mantid.instr lambda=6
            fi
 
     - name: 'Tar output files'

--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -342,7 +342,7 @@ jobs:
            #if [ "x$(uname)" == "xDarwin" ]; then export MCSTAS_CC_OVERRIDE=/usr/bin/clang; fi
            if [ "x$(uname)" == "xLinux" ]; then
              ../install_mcstas/bin/${MCRUN_EXECUTABLE} --format=NeXus --IDF templateSANS_Mantid.instr lambda=6
-             ../install_mcstas/bin/${MCRUN_EXECUTABLE} -c --verbose --mpi=2 --format=NeXus --IDF templateSANS_Mantid.instr lambda=6
+             ../install_mcstas/bin/${MCRUN_EXECUTABLE} -c --verbose --mpi=2 --format=NeXus --IDF templateSANS_Mantid.instr lambda=6 -d MPIoutput
            fi
 
     - name: 'Tar output files'

--- a/mccode/mccode.md.in
+++ b/mccode/mccode.md.in
@@ -8,7 +8,7 @@
 
 # SYNOPSIS
 
-**@FLAVOR@** [-o file] [-I dir1 ...] [-t] [-p] [-v] [--no-main] [--no-runtime] [--verbose] file
+**@FLAVOR@** [-o file] [-I dir1 ...] [-t] [--no-trace] [-p] [-v] [--no-main] [--no-runtime] [--verbose] file
 
 # DESCRIPTION
 
@@ -63,7 +63,10 @@ END
 :   Append DIR to the component search list.
 
 **-t --trace**
-:   Enable 'trace' mode for instrument display.
+:   Enable 'trace' mode for instrument display (enabled by default).
+
+**-no--trace**
+:   Disable 'trace' mode for instrument display.
 
 **-v --version**
 :   Prints @MCCODE_NAME@ version.

--- a/mccode/src/instrument.y
+++ b/mccode/src/instrument.y
@@ -2130,7 +2130,8 @@ print_usage(void)
   fprintf(stderr, "      --verbose                  Display compilation process steps.\n");
 #if defined(GENERATE_C)
   fprintf(stderr, "      -I DIR  --search-dir=DIR   Append DIR to the component search list. \n");
-  fprintf(stderr, "      -t      --trace            Enable 'trace' mode for instrument display.\n");
+  fprintf(stderr, "      -t      --trace            Enable 'trace' mode for instrument display. (Enabled by default)\n");
+  fprintf(stderr, "              --no-trace         Disable 'trace' mode for instrument display.\n");
   fprintf(stderr, "      --no-main                  Do not create main(), for external embedding.\n");
   fprintf(stderr, "      --no-runtime               Do not embed run-time libraries.\n");
   fprintf(stderr, "      --source                   Embed the instrument source code in executable.\n");
@@ -2225,7 +2226,7 @@ parse_command_line(int argc, char *argv[])
   instr_current_filename                 = NULL;
   instrument_definition->use_default_main= 1;
   instrument_definition->include_runtime = 1;
-  instrument_definition->enable_trace    = 0;
+  instrument_definition->enable_trace    = 1;
   instrument_definition->portable        = 0;
   strcmp(instrument_definition->dependency, "-lm");
   executable_name                        = argv[0];
@@ -2252,6 +2253,8 @@ parse_command_line(int argc, char *argv[])
       instrument_definition->enable_trace = 1;
     else if(!strcmp("--trace", argv[i]))
       instrument_definition->enable_trace = 1;
+    else if(!strcmp("--no-trace", argv[i]))
+      instrument_definition->enable_trace = 0;
     else if(!strcmp("-p", argv[i]))
       instrument_definition->portable = 1;
     else if(!strcmp("--portable", argv[i]))

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -126,9 +126,6 @@ class McStas:
             options.force_compile = True
             # options.mccode_bin already contains cogen value
 
-        if self.options.no_trace is not None:
-            options.force_compile = True
-
         if self.options.D1 is not None:
             options.force_compile = True
 

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -126,6 +126,9 @@ class McStas:
             options.force_compile = True
             # options.mccode_bin already contains cogen value
 
+        if self.options.no_trace is not None:
+            options.force_compile = True
+
         if self.options.D1 is not None:
             options.force_compile = True
 
@@ -142,7 +145,7 @@ class McStas:
             LOG.info('Using existing c-file: %s', existingC)
             self.cpath = existingC
         else:
-            # Generate C-code (implicit: prepare for --trace mode if not no_main / Vitess)
+            # Generate C-code (implicit: prepare for --trace or --no-trace mode if not no_main / Vitess)
             LOG.info('Regenerating c-file: %s', basename(self.cpath))
             mccode_bin_abspath = str( pathlib.Path(mccode_config.directories['bindir']) / options.mccode_bin )
             if not os.path.exists(mccode_bin_abspath):
@@ -151,10 +154,13 @@ class McStas:
                 LOG.warning('Attempting replacement by "%s"', mccode_bin_abspath)
 
             if not options.no_main:
+                trace='-t'
+                if options.no_trace:
+                   trace='--no-trace'
                 if self.options.I is not None:
-                    Process(mccode_bin_abspath).run(['-t', '-o', self.cpath, self.path, '-I', self.options.I])
+                    Process(mccode_bin_abspath).run([trace, '-o', self.cpath, self.path, '-I', self.options.I])
                 else:
-                    Process(mccode_bin_abspath).run(['-t', '-o', self.cpath, self.path])
+                    Process(mccode_bin_abspath).run([trace, '-o', self.cpath, self.path])
             else:
                 if self.options.I is not None:
                     Process(mccode_bin_abspath).run(['--no-main', '-o', self.cpath, self.path, '-I', self.options.I])

--- a/tools/Python/mcrun/mcrun.md.in
+++ b/tools/Python/mcrun/mcrun.md.in
@@ -147,10 +147,13 @@ series of `param=value` pairs. The `-h` option will list valid options.
 :   Set random seed (must be: SEED != 0)
 
 **-n COUNT, --ncount=COUNT**
-:   Set number of @MCCODE_PARTICLE@ to simulate
+:   Set number of @MCCODE_PARTICLE@s to simulate
 
 **-t trace, --trace=trace**
-:   Enable trace of @MCCODE_PARTICLE@ through instrument
+:   Enable trace of @MCCODE_PARTICLE@s through instrument
+
+**--no-trace**
+:   Disable trace of @MCCODE_PARTICLE@s in instrument (implies -c!)
 
 **-d DIR, --dir=DIR**
 :   Put all data files in directory DIR. Additionally, the directory will have

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -266,7 +266,7 @@ def add_mcstas_options(parser):
         help='Enable trace of %ss through instrument' % (mccode_config.configuration["PARTICLE"]))
 
     add('--no-trace',
-        action='store_true', metavar='notrace', default=False,
+        action='store_true', metavar='notrace', default=None,
         help='Disable trace of %ss in instrument (implies -c!)' % (mccode_config.configuration["PARTICLE"]))
 
     add('-y', '--yes',

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -267,7 +267,7 @@ def add_mcstas_options(parser):
 
     add('--no-trace',
         action='store_true', metavar='notrace', default=None,
-        help='Disable trace of %ss in instrument (implies -c!)' % (mccode_config.configuration["PARTICLE"]))
+        help='Disable trace of %ss in instrument (combine with -c)' % (mccode_config.configuration["PARTICLE"]))
 
     add('-y', '--yes',
         action='store_true', default=False,

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -259,11 +259,15 @@ def add_mcstas_options(parser):
 
     add('-n', '--ncount',
         metavar='COUNT', type=float, default=1000000,
-        help='Set number of %s to simulate' % (mccode_config.configuration["PARTICLE"]))
+        help='Set number of %ss to simulate' % (mccode_config.configuration["PARTICLE"]))
 
     add('-t', '--trace',
         metavar='trace', type=int, default=0,
-        help='Enable trace of %s through instrument' % (mccode_config.configuration["PARTICLE"]))
+        help='Enable trace of %ss through instrument' % (mccode_config.configuration["PARTICLE"]))
+
+    add('--no-trace',
+        action='store_true', metavar='notrace', default=False,
+        help='Disable trace of %ss in instrument (implies -c!)' % (mccode_config.configuration["PARTICLE"]))
 
     add('-y', '--yes',
         action='store_true', default=False,


### PR DESCRIPTION
PR to swap default trace behaviour:
1) Enable --trace by default
2) Add --no-trace to explicitly disable trace
(No need for changes in runtime or tools)

I would like the 0.02$ of you on https://github.com/mccode-dev/McCode/discussions/2011 before any merging
@farhi @g5t @mads-bertelsen @tweber-ill and maybe even @ebknudsen or @tkittel have a point of view? :-)

No direct implications for the "standard end-user" as `mcrun` / `mcgui` / `McStasscript` all use this default already. It only affects the default of the actual code generator that historically needed an explicit `mcstas -t` / `mcxtrace -t`. The `-t` becomes implicit with this PR and a handle to disable (`--no-trace`) has been added.

(For those worrying about added performance penalty - it is kind of artificial to talk about since anyone using the "high level tools" did not use this for years already... But a recent measurement says one may gain maximum 5% in a simulation by explicitly disabling via `--no-trace`.)