### PR TITLE
Openacc minor rectifications

### DIFF
--- a/mcstas-comps/misc/MCPL_input.comp
+++ b/mcstas-comps/misc/MCPL_input.comp
@@ -160,11 +160,9 @@ INITIALIZE
       VX = create_darr1d(nparticles);
       VY = create_darr1d(nparticles);
       VZ = create_darr1d(nparticles);
-      if(polarisationuse){
-        SX = create_darr1d(nparticles);
-        SY = create_darr1d(nparticles);
-        SZ = create_darr1d(nparticles);
-      }
+      SX = create_darr1d(nparticles);
+      SY = create_darr1d(nparticles);
+      SZ = create_darr1d(nparticles);
       T = create_darr1d(nparticles);
       P = create_darr1d(nparticles);
       E = create_darr1d(nparticles);
@@ -410,11 +408,9 @@ FINALLY
     destroy_darr1d(VX);
     destroy_darr1d(VY);
     destroy_darr1d(VZ);
-    if(polarisationuse){
-      destroy_darr1d(SX);
-      destroy_darr1d(SY);
-      destroy_darr1d(SZ);
-    }
+    destroy_darr1d(SX);
+    destroy_darr1d(SY);
+    destroy_darr1d(SZ);
     destroy_darr1d(T);
     destroy_darr1d(P);
 %}

--- a/mcstas-comps/misc/MCPL_output.comp
+++ b/mcstas-comps/misc/MCPL_output.comp
@@ -433,6 +433,17 @@ FINALLY
       }
     );
   }
+  destroy_darr1d(X);
+  destroy_darr1d(Y);
+  destroy_darr1d(Z);
+  destroy_darr1d(VX);
+  destroy_darr1d(VY);
+  destroy_darr1d(VZ);
+  destroy_darr1d(SX);
+  destroy_darr1d(SY);
+  destroy_darr1d(SZ);
+  destroy_darr1d(T);
+  destroy_darr1d(P);
 %}
 
 MCDISPLAY

--- a/mcxtrace-comps/misc/MCPL_input.comp
+++ b/mcxtrace-comps/misc/MCPL_input.comp
@@ -162,11 +162,9 @@ INITIALIZE
       KX = create_darr1d(nparticles);
       KY = create_darr1d(nparticles);
       KZ = create_darr1d(nparticles);
-      if(polarisationuse){
-	EX = create_darr1d(nparticles);
-      	EY = create_darr1d(nparticles);
-      	EZ = create_darr1d(nparticles);
-      }
+      EX = create_darr1d(nparticles);
+      EY = create_darr1d(nparticles);
+      EZ = create_darr1d(nparticles);
       T = create_darr1d(nparticles);
       P = create_darr1d(nparticles);
       E = create_darr1d(nparticles);
@@ -420,11 +418,9 @@ FINALLY
     destroy_darr1d(KX);
     destroy_darr1d(KY);
     destroy_darr1d(KZ);
-    if(polarisationuse){
-      destroy_darr1d(EX);
-      destroy_darr1d(EY);
-      destroy_darr1d(EZ);
-    }
+    destroy_darr1d(EX);
+    destroy_darr1d(EY);
+    destroy_darr1d(EZ);
     destroy_darr1d(T);
     destroy_darr1d(P);
 %}

--- a/mcxtrace-comps/misc/MCPL_output.comp
+++ b/mcxtrace-comps/misc/MCPL_output.comp
@@ -437,6 +437,17 @@ FINALLY
       }
     );
   }
+  destroy_darr1d(X);
+  destroy_darr1d(Y);
+  destroy_darr1d(Z);
+  destroy_darr1d(KX);
+  destroy_darr1d(KY);
+  destroy_darr1d(KZ);
+  destroy_darr1d(EX);
+  destroy_darr1d(EY);
+  destroy_darr1d(EZ);
+  destroy_darr1d(T);
+  destroy_darr1d(P);
 %}
 
 MCDISPLAY


### PR DESCRIPTION
* Since SX/SY/SZ or EX/EY/EZ arrays are touched also when not "polarisation", better create and destroy in all cases. (Spotted from sudden failure of ESS_BEER_MCPL on OpenACC)
* Also ensure cleanup of arrays in MCPL_output case