### PR TITLE
Mcxtrace fluo add detector 0

### DIFF
--- a/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/Test_Fluorescence.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/Test_Fluorescence.instr
@@ -67,8 +67,10 @@ EXTEND %{
 %}
 
 // ideal detectors
-COMPONENT emon_fluo = E_monitor(restore_xray=1,nE=2001,Emin=0, Emax=1.5*E0,
-                                filename="Fluorescence.dat")
+COMPONENT emon_fluo = E_monitor(restore_xray=1,
+  xwidth=0.007, yheight=0.007,
+  nE=2001,Emin=0, Emax=1.5*E0,
+  filename="Fluorescence.dat")
 WHEN (Stype == FLUORESCENCE)
 AT(0,0,0.1) RELATIVE PREVIOUS
 
@@ -85,7 +87,7 @@ COMPONENT emon = Fluo_detector(restore_xray=1,nE=2001,Emin=0, Emax=1.5*E0,
   filename="emon.dat",xwidth=0.007, yheight=0.007)
 AT(0,0,0) RELATIVE PREVIOUS
 
-COMPONENT psd = PSD_monitor(xwidth=0.0015, yheight=0.0015, nx=100, ny=100, filename="psd.dat")
+COMPONENT psd = PSD_monitor(xwidth=0.001, yheight=0.001, nx=100, ny=100, filename="psd.dat")
 AT(0,0,0) RELATIVE PREVIOUS
 
 

--- a/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/Test_Fluorescence.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/Test_Fluorescence.instr
@@ -59,40 +59,36 @@ AT(0,0,3) RELATIVE Origin
 
 COMPONENT sample=Fluorescence(material=material,
   xwidth=0.001,yheight=0.001,zdepth=0.0001, p_interact=0.99,
-  target_index=1, focus_xw=0.0005, focus_yh=0.0005, 
-  escape_ratio=0.01, pileup_ratio=0.01)
+  target_index=1, focus_xw=0.0005, focus_yh=0.0005)
 AT (0,0,0) RELATIVE sample_mount_point
 EXTEND %{
   if (!SCATTERED) ABSORB;
   Stype=type;
 %}
 
-COMPONENT emon = E_monitor(restore_xray=1,nE=2001,Emin=0, Emax=1.5*E0, 
-  filename="emon.dat",xwidth=0.007, yheight=0.007)
-AT(0,0,0.1) RELATIVE PREVIOUS
-
-COMPONENT psd = PSD_monitor(xwidth=0.0015, yheight=0.0015, nx=100, ny=100, filename="psd.dat")
-AT(0,0,0.1) RELATIVE PREVIOUS
-
-COMPONENT emon_fluo = COPY(emon)(filename="Fluorescence.dat")
+// ideal detectors
+COMPONENT emon_fluo = E_monitor(restore_xray=1,nE=2001,Emin=0, Emax=1.5*E0,
+                                filename="Fluorescence.dat")
 WHEN (Stype == FLUORESCENCE)
 AT(0,0,0.1) RELATIVE PREVIOUS
 
-COMPONENT emon_Compton = COPY(emon)(filename="Compton.dat")
+COMPONENT emon_Compton = COPY(emon_fluo)(filename="Compton.dat")
 WHEN (Stype == COMPTON)
-AT(0,0,0.1) RELATIVE PREVIOUS
+AT(0,0,0) RELATIVE PREVIOUS
 
-COMPONENT emon_Rayleigh = COPY(emon)(filename="Rayleigh.dat")
+COMPONENT emon_Rayleigh = COPY(emon_fluo)(filename="Rayleigh.dat")
 WHEN (Stype == RAYLEIGH)
-AT(0,0,0.1) RELATIVE PREVIOUS
+AT(0,0,0) RELATIVE PREVIOUS
 
-COMPONENT emon_Escape = COPY(emon)(filename="Si_Escape.dat")
-WHEN (Stype == FLUORESCENCE_ESCAPE)
-AT(0,0,0.1) RELATIVE PREVIOUS
+// SDD model
+COMPONENT emon = Fluo_detector(restore_xray=1,nE=2001,Emin=0, Emax=1.5*E0,
+  filename="emon.dat",xwidth=0.007, yheight=0.007)
+AT(0,0,0) RELATIVE PREVIOUS
 
-COMPONENT emon_PileUp = COPY(emon)(filename="Si_PileUp.dat")
-WHEN (Stype == FLUORESCENCE_PILEUP)
-AT(0,0,0.1) RELATIVE PREVIOUS
+COMPONENT psd = PSD_monitor(xwidth=0.0015, yheight=0.0015, nx=100, ny=100, filename="psd.dat")
+AT(0,0,0) RELATIVE PREVIOUS
+
+
 
 
 END

--- a/mcxtrace-comps/examples/Tests_samples/Test_SX/Test_SX.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_SX/Test_SX.instr
@@ -21,7 +21,7 @@
 * - index=3: use Fluorescence+Single_crystal in a GROUP
 *
 * %Example: index=1 Detector: psd_Diff_I=2.29638e-13
-* %Example: index=2 Detector: psd_Diff_I=6.60276e-14
+* %Example: index=2 Detector: psd_Diff_I=3.70277e-14
 * %Example: index=3 Detector: psd_Diff_I=1.19386e-13
 *
 * %Parameters
@@ -81,6 +81,7 @@ EXTEND %{
   else Stype=type;
 %}
 
+// Fluorescence+SX in a GROUP
 COMPONENT FluoG = Fluorescence(
   radius = .5e-4, yheight = 1e-3, material=reflections, p_interact=0.5)
 WHEN (index == 3)

--- a/mcxtrace-comps/monitors/Fluo_detector.comp
+++ b/mcxtrace-comps/monitors/Fluo_detector.comp
@@ -16,16 +16,19 @@
 *
 * %Description
 * A detector that records energy spectrum from e.g. fluorescence.
-* This component also simulates the escape and time coincidence peaks, as well as the
-* detector energy resolution.
+* This component handles:
+* - fluorescence detector escape  (energy shift from detector K-alpha)
+* - fluorescence detector pile-up (sum aka time-coincidence aka pile-up within detector dead-time)
+* - energy resolution (above Fano level)
+*
 * The detector geometry can be a rectangle xwidth*yheight, or a disk of given 'radius'.
 * When the radius is given negative, a 4PI detector sphere of given radius is assumed.
 *
-* The first process corresponds with a fluorescence excitation within the detector itself
+* The detector escape corresponds with a fluorescence excitation within the detector itself
 * that subtracts the K-alpha detector level from the sample scattered energy.
 * The level of escape peaks in set as 'escape_ratio', e.g. 1-2 %.
 *
-* The second process is related to the detector dead-time, within which time coincidence
+* The detector pile-up is related to the detector dead-time, within which time coincidence
 * between two fluorescence photons are summed-up.
 * The level of pile-up is set as 'pileup_ratio', e.g. 1-2 % which can increase for high
 * count rates that saturate the detector.
@@ -78,15 +81,8 @@ SHARE %{
 #ifndef FLUO_DETECTOR
 #define FLUO_DETECTOR
 
-#ifndef FLUORESCENCE
-#define FLUORESCENCE 0
-#endif
-#ifndef FLUORESCENCE_ESCAPE
-#define FLUORESCENCE_ESCAPE 5 // Detector escape      peak fluorescence
-#endif
-#ifndef FLUORESCENCE_PILEUP
-#define FLUORESCENCE_PILEUP 6 // Detector pile-up/sum peak fluorescence
-#endif
+#define SDD_ESCAPE 5 // Detector escape      peak fluorescence
+#define SDD_PILEUP 6 // Detector pile-up/sum peak fluorescence
   /* SDD_SelectFromDistribution: select a random element from a distribution
    *   index = SDD_SelectFromDistribution(cum_sum[N], N);
    * index is returned within 0 and N-1
@@ -217,18 +213,18 @@ TRACE %{
 
     k     = sqrt(kx*kx + ky*ky + kz*kz);
     E     = k*K2E;
-    type  = FLUORESCENCE;
+    type  = 0;
 
     // handle detector escape peak: just shift energy down by detector K-alpha
     if (escape_ratio > 0 && escape_energy > 0 && E > escape_energy && rand01() < escape_ratio) {
         E   -= escape_energy; // escape
-        type = FLUORESCENCE_ESCAPE;
+        type = SDD_ESCAPE;
 
     } else if (pileup_ratio > 0 && rand01() < pileup_ratio) {
         // handle detector pile-up peak: get an other fluo line and sum it
         int i_E = SDD_SelectInteraction(E_p, nE);
         E  += Emin+i_E*(Emax-Emin)/nE;             // pile-up
-        type= FLUORESCENCE_PILEUP;
+        type= SDD_PILEUP;
     }
 
     // we add the detector resolution (broadening)
@@ -236,6 +232,8 @@ TRACE %{
       dE = sqrt(K*E+electronic_noise*electronic_noise);
     else if (resolution > 0)
       dE = resolution;
+    else if (electronic_noise > 0)
+      dE = electronic_noise;
     else dE=0;
     if (dE) {
       if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
@@ -254,7 +252,7 @@ TRACE %{
         E_p2[i] = E_p2[i] + p*p;
 
         // special storage
-        if (type == FLUORESCENCE_PILEUP) {
+        if (type == SDD_PILEUP) {
           #pragma acc atomic
           E_N_pileup[i] = E_N_pileup[i] + 1;
           #pragma acc atomic
@@ -262,7 +260,7 @@ TRACE %{
           #pragma acc atomic
           E_p2_pileup[i] = E_p2_pileup[i] + p*p;
 
-        } else if (type == FLUORESCENCE_ESCAPE) {
+        } else if (type == SDD_ESCAPE) {
           #pragma acc atomic
           E_N_escape[i] = E_N_escape[i] + 1;
           #pragma acc atomic

--- a/mcxtrace-comps/monitors/Fluo_detector.comp
+++ b/mcxtrace-comps/monitors/Fluo_detector.comp
@@ -54,7 +54,7 @@
 * escape_ratio:       [1] Detector escape peak ratio,  e.g. 0.01-0.02. Zero inactivates.
 * escape_energy:    [keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
 * pileup_ratio:       [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. This is e.g. the dead-time ratio. Zero inactivates.
-* electronic_noise: [keV] Electronic noise at E=0, in keV. Use electronic_noise=0 for Fano limit.
+* electronic_noise: [keV] Electronic noise at E=0, FWHM in keV. Use electronic_noise=0 for Fano limit.
 * resolution_energy:[keV] Energy at which resolution is given, e.g. 5.9 keV Mn K-alpha.
 * resolution:       [keV] Resolution FWHM in keV at resolution_energy.
 * flag_lorentzian:    [1] When 1, the line shapes are assumed to be Lorentzian, else Gaussian.
@@ -191,10 +191,15 @@ TRACE %{
   int    type=-1;
 
   if (shape==0)       // disk
-    intersect=(x*x + y*y < radius*radius);
+    {
+      PROP_Z0;
+      intersect=(x*x + y*y < radius*radius);
+    }
   else if (shape==1)  // rectangle
-    intersect=(-xwidth/2  < x && x < xwidth/2
-            && -yheight/2 < y && y < yheight/2);
+    { PROP_Z0;
+      intersect=(-xwidth/2  < x && x < xwidth/2
+              && -yheight/2 < y && y < yheight/2);
+    }
   else if (shape==2)  // sphere
     intersect=sphere_intersect  (&l0,&l1, x,y,z,kx,ky,kz, radius);
 
@@ -208,8 +213,6 @@ TRACE %{
       else
         PROP_DL(l1);
     }
-    else
-      PROP_Z0;
 
     k     = sqrt(kx*kx + ky*ky + kz*kz);
     E     = k*K2E;
@@ -220,8 +223,10 @@ TRACE %{
         E   -= escape_energy; // escape
         type = SDD_ESCAPE;
 
-    } else if (pileup_ratio > 0 && rand01() < pileup_ratio) {
+    }
+    if (pileup_ratio > 0 && N_sum > 1000 && rand01() < pileup_ratio) {
         // handle detector pile-up peak: get an other fluo line and sum it
+        // require some statistics in the spectrum in order to select a line
         int i_E = SDD_SelectInteraction(E_p, nE);
         E  += Emin+i_E*(Emax-Emin)/nE;             // pile-up
         type= SDD_PILEUP;
@@ -236,6 +241,7 @@ TRACE %{
       dE = electronic_noise;
     else dE=0;
     if (dE) {
+      dE /= 2;  // half-width
       if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
       else                 dE  *= randnorm();          // Gaussian distribution
       E += dE;

--- a/mcxtrace-comps/monitors/Fluo_detector.comp
+++ b/mcxtrace-comps/monitors/Fluo_detector.comp
@@ -1,0 +1,213 @@
+/*******************************************************************************
+*
+* McXtrace, x-ray tracing package
+*         Copyright, All rights reserved
+*         DTU Physics, Kgs. Lyngby, Denmark
+*         Synchrotron SOLEIL, Saint-Aubin, France
+*
+* Component: Fluo_detector
+*
+* %Identification
+* Written by: E. Farhi
+* Date:       May 2025
+* Origin:     Synchrotron SOLEIL
+*
+* Detector for fluorescence, e.g. Silicon Drift Detector (SDD) or High Purity Germanium (HPGe).
+*
+* %Description
+* A detector that records energy spectrum from e.g. fluorescence.
+* This component also simulates the escape and time coincidence peaks, as well as the
+* detector energy resolution.
+* The detector geometry can be a rectangle xwidth*yheight, or a disk of given 'radius'.
+* When the radius is given negative, a 4PI detector sphere of given radius is assumed.
+*
+* The first process corresponds with a fluorescence excitation within the detector itself
+* that subtracts the K-alpha detector level from the sample scattered energy.
+* The level of escape peaks in set as 'escape_ratio', e.g. 1-2 %.
+*
+* The second process is related to the detector dead-time, within which time coincidence
+* between two fluorescence photons are summed-up.
+* The level of pile-up is set as 'pileup_ratio', e.g. 1-2 % which can increase for high
+* count rates that saturate the detector.
+*
+* Last, the fluorescence peak shape is broadened using an electronic noise (at E=0) and
+* a nominal resolution at E=resolution_energy (in keV). You may set the electronic_noise
+* to zero for a perfect detector (Fano limit). To use a constant resolution, set the
+* resolution_energy=0.
+*
+* Example: Fluo_detector(xwidth=0.1, yheight=0.1,
+*                 Emin=1, Emax=50, nE=20, filename="Output.nrj")
+*
+* %Parameters
+* INPUT PARAMETERS:
+* radius:             [m] Radius of disk detector (in XY plane). When given as negative, a 4PI sphere is assumed.
+* xwidth:             [m] Width  of rectangle detector.
+* yheight:            [m] Height of rectangle detector.
+* escape_ratio:       [1] Detector escape peak ratio,  e.g. 0.01-0.02. Zero inactivates.
+* escape_energy:    [keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
+* pileup_ratio:       [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. This is e.g. the dead-time ratio. Zero inactivates.
+* electronic_noise: [keV] Electronic noise at E=0. Use electronic_noise=0 for Fano limit.
+* resolution_energy:[keV] Energy at which resolution is given, e.g. 5.9 keV Mn K-alpha.
+* resolution:       [keV] Resolution FWHM at resolution_energy.
+* flag_lorentzian:    [1] When 1, the line shapes are assumed to be Lorentzian, else Gaussian.
+*
+* %Link
+* Fluorescence https://en.wikipedia.org/wiki/Fluorescence
+*
+* %End
+*******************************************************************************/
+
+DEFINE COMPONENT Fluo_detector
+SETTING PARAMETERS(
+  radius=0, xwidth=0, yheight=0,
+  escape_ratio=0, escape_energy    = 1.739,
+  pileup_ratio=0, electronic_noise = 0.1,
+  resolution_energy= 6, resolution = 0.2,
+  flag_lorentzian=0)
+
+/* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
+
+SHARE %{
+#ifndef FLUO_DETECTOR
+#define FLUO_DETECTOR
+
+#ifndef FLUORESCENCE
+#define FLUORESCENCE 0
+#endif
+#ifndef FLUORESCENCE_ESCAPE
+#define FLUORESCENCE_ESCAPE 5 // Detector escape      peak fluorescence
+#endif
+#ifndef FLUORESCENCE_PILEUP
+#define FLUORESCENCE_PILEUP 6 // Detector pile-up/sum peak fluorescence
+#endif
+  /* SDD_SelectFromDistribution: select a random element from a distribution
+   *   index = SDD_SelectFromDistribution(cum_sum[N], N);
+   * index is returned within 0 and N-1
+   * The x_arr must be a continuously increasing cumulated sum, which last element is the max
+   */
+  int SDD_SelectFromDistribution(double x_arr[], int N)
+  {
+    if (x_arr == NULL || N <=0) return (0);
+    double x=rand01()*x_arr[N-1];
+    if (x<x_arr[0]) {    // x is smaller than lower limit
+      return 0;
+    }
+    if (x>=x_arr[N-1]) { // x is greater or equal to upper limit
+      return N-1;
+    }
+    int id=0, iu=N-1; // lower and upper index of the subarray to search
+    while (iu-id>1) { // search until the size of the subarray to search is >1
+      int im = (id + iu)/2; // use the midpoint for equal partition
+      // decide which subarray to search
+      if (x>=x_arr[im]) id=im; // change min index to search upper subarray
+      else iu=im; // change max index to search lower subarray
+    }
+
+    return id;
+  } // SDD_SelectFromDistribution
+#endif
+%}
+
+DECLARE %{
+  DArray1d E_N;
+  DArray1d E_p;
+  DArray1d E_p2;
+  int      shape;
+  double   K;
+%}
+
+
+INITIALIZE %{
+
+  shape=-1; /* 0:cyl, 1:box, 2:sphere  */
+
+  if (xwidth && yheight)            shape=1; /* rectangle */
+  else if (radius > 0)              shape=0; /* disk      */
+  else if (radius < 0)              shape=2; /* sphere    */
+  else
+    exit(fprintf(stderr,"Fluo_detector: %s: detector has invalid dimensions.\n"
+                        "ERROR          Please check parameter values (xwidth, yheight, zdepth, radius).\n", NAME_CURRENT_COMP));
+
+  // Use instance name for monitor output if no input was given
+  if (!strcmp(filename,"\0")) sprintf(filename,"%s",NAME_CURRENT_COMP);
+
+  // storage
+  E_N = create_darr1d(nE);
+  E_p = create_darr1d(nE);
+  E_p2= create_darr1d(nE);
+
+  // constant for resolution calculation
+  if (resolution > electronic_noise && resolution_energy > 0)
+    K = (resolution*resolution-electronic_noise*electronic_noise)/resolution_energy;
+  else K=0;
+
+%}
+
+TRACE %{
+  int    intersect=0;       /* flag to continue/stop */
+  double l0,  l1;           /* times for intersections */
+  int    type=-1;
+
+  if (shape==0)       // disk
+    intersect=(x*x + y*y < radius*radius);
+  else if (shape==1)  // rectangle
+    intersect=(-xwidth/2  < x && x < xwidth/2
+            && -yheight/2 < y && y < yheight/2);
+  else if (shape==2)  // sphere
+    intersect=sphere_intersect  (&l0,&l1, x,y,z,kx,ky,kz, radius);
+
+  if (intersect) {  /* we propagate to the detector surface */
+
+    if (shape==2) {
+      if (l0 > 0 && (l0 < l1 || l1 < 0))
+        PROP_DL(l0);
+      else
+        PROP_DL(l1);
+    }
+    else
+      PROP_Z0;
+
+    double k = sqrt(kx*kx + ky*ky + kz*kz);
+    double E = k*K2E;
+    type     = FLUORESCENCE;
+
+    // handle detector escape peak: just shift energy down by detector K-alpha
+    if (escape_ratio > 0 && escape_energy > 0 && E > escape_energy && rand01() < escape_ratio) {
+        E   -= escape_energy; // escape
+        type = FLUORESCENCE_ESCAPE;
+
+    } else if (pileup_ratio > 0 && rand01() < pileup_ratio) {
+        // handle detector pile-up peak: get an other fluo line and sum it
+        int i_E = SDD_SelectFromDistribution(E_p, nE);
+        E  += Emin+i*(Emax-Emin)/nE;             // pile-up
+        type= FLUORESCENCE_PILEUP;
+    }
+
+    // we add the detector resolution (broadening)
+    if (K)
+      dE = sqrt(K*E+electronic_noise*electronic_noise);
+    else if (resolution > 0)
+      dE = resolution;
+    if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
+    else                 dE  *= randnorm();          // Gaussian distribution
+    E += dE;
+
+    i = floor((E-Emin)*nE/(Emax-Emin));
+    if(i >= 0 && i < nE)
+    {
+        #pragma acc atomic
+        E_N[i] = E_N[i] + 1;
+        #pragma acc atomic
+        E_p[i] = E_p[i] + p;
+        #pragma acc atomic
+        E_p2[i] = E_p2[i] + p*p;
+        SCATTER;
+    }
+
+    if (restore_xray) {
+        RESTORE_XRAY(INDEX_CURRENT_COMP, x, y, z, kx, ky, kz, phi, t, Ex, Ey, Ez, p);
+    }
+  }
+
+
+%}

--- a/mcxtrace-comps/monitors/Fluo_detector.comp
+++ b/mcxtrace-comps/monitors/Fluo_detector.comp
@@ -43,12 +43,17 @@
 * radius:             [m] Radius of disk detector (in XY plane). When given as negative, a 4PI sphere is assumed.
 * xwidth:             [m] Width  of rectangle detector.
 * yheight:            [m] Height of rectangle detector.
+* Emin:             [keV] Minimum energy to detect.
+* Emax:             [keV] Maximum energy to detect.
+* nE:                 [m] Number of energy channels.
+* filename:         [str] Name of file in which to store the detector image.
+* restore_xray:     [0/1] If set, the monitor does not influence the x-ray state.
 * escape_ratio:       [1] Detector escape peak ratio,  e.g. 0.01-0.02. Zero inactivates.
 * escape_energy:    [keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
 * pileup_ratio:       [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. This is e.g. the dead-time ratio. Zero inactivates.
-* electronic_noise: [keV] Electronic noise at E=0. Use electronic_noise=0 for Fano limit.
+* electronic_noise: [keV] Electronic noise at E=0, in keV. Use electronic_noise=0 for Fano limit.
 * resolution_energy:[keV] Energy at which resolution is given, e.g. 5.9 keV Mn K-alpha.
-* resolution:       [keV] Resolution FWHM at resolution_energy.
+* resolution:       [keV] Resolution FWHM in keV at resolution_energy.
 * flag_lorentzian:    [1] When 1, the line shapes are assumed to be Lorentzian, else Gaussian.
 *
 * %Link
@@ -60,8 +65,10 @@
 DEFINE COMPONENT Fluo_detector
 SETTING PARAMETERS(
   radius=0, xwidth=0, yheight=0,
-  escape_ratio=0, escape_energy    = 1.739,
-  pileup_ratio=0, electronic_noise = 0.1,
+  Emin=1, Emax=39, nE=2000, string filename=0,
+  restore_xray=0,
+  escape_ratio=0.01, escape_energy    = 1.739,
+  pileup_ratio=0.01, electronic_noise = 0.1,
   resolution_energy= 6, resolution = 0.2,
   flag_lorentzian=0)
 
@@ -105,6 +112,30 @@ SHARE %{
 
     return id;
   } // SDD_SelectFromDistribution
+
+  /* XRMC_SelectInteraction: select interaction type Fluo/Compton/Rayleigh
+   * Return the interaction type from a random choice within cross sections 'xs'
+   *   type = XRMC_SelectInteraction(xs[3], 3);
+   * 'xs' is computed with XRMC_CrossSections.
+   * type is one of FLUORESCENCE | RAYLEIGH | COMPTON
+   */
+  int SDD_SelectInteraction(double *xs, int nb_processes)
+  {
+    double sum_xs, *cum_xs;
+    int    i;
+
+    if (xs == NULL || nb_processes < 1) return 0;
+    cum_xs = malloc((nb_processes+1)*sizeof(double));
+    if (!cum_xs)          return 0;
+    cum_xs[0]=sum_xs=0;
+    for (i=0; i< nb_processes; i++) {
+      sum_xs += xs[i];
+      cum_xs[i+1]= sum_xs;
+    }
+    i = SDD_SelectFromDistribution(cum_xs, nb_processes+1);
+    free(cum_xs);
+    return i;
+  } // SDD_SelectInteraction
 #endif
 %}
 
@@ -112,8 +143,16 @@ DECLARE %{
   DArray1d E_N;
   DArray1d E_p;
   DArray1d E_p2;
+  DArray1d E_N_pileup;
+  DArray1d E_p_pileup;
+  DArray1d E_p2_pileup;
+  DArray1d E_N_escape;
+  DArray1d E_p_escape;
+  DArray1d E_p2_escape;
   int      shape;
   double   K;
+  double   p_sum;
+  double   N_sum;
 %}
 
 
@@ -132,9 +171,16 @@ INITIALIZE %{
   if (!strcmp(filename,"\0")) sprintf(filename,"%s",NAME_CURRENT_COMP);
 
   // storage
-  E_N = create_darr1d(nE);
-  E_p = create_darr1d(nE);
-  E_p2= create_darr1d(nE);
+  E_N        = create_darr1d(nE);
+  E_p        = create_darr1d(nE);
+  E_p2       = create_darr1d(nE);
+  E_N_pileup = create_darr1d(nE);
+  E_p_pileup = create_darr1d(nE);
+  E_p2_pileup= create_darr1d(nE);
+  E_N_escape = create_darr1d(nE);
+  E_p_escape = create_darr1d(nE);
+  E_p2_escape= create_darr1d(nE);
+  p_sum=N_sum=0;
 
   // constant for resolution calculation
   if (resolution > electronic_noise && resolution_energy > 0)
@@ -157,6 +203,8 @@ TRACE %{
     intersect=sphere_intersect  (&l0,&l1, x,y,z,kx,ky,kz, radius);
 
   if (intersect) {  /* we propagate to the detector surface */
+    int i;
+    double k, E, dE;
 
     if (shape==2) {
       if (l0 > 0 && (l0 < l1 || l1 < 0))
@@ -167,9 +215,9 @@ TRACE %{
     else
       PROP_Z0;
 
-    double k = sqrt(kx*kx + ky*ky + kz*kz);
-    double E = k*K2E;
-    type     = FLUORESCENCE;
+    k     = sqrt(kx*kx + ky*ky + kz*kz);
+    E     = k*K2E;
+    type  = FLUORESCENCE;
 
     // handle detector escape peak: just shift energy down by detector K-alpha
     if (escape_ratio > 0 && escape_energy > 0 && E > escape_energy && rand01() < escape_ratio) {
@@ -178,8 +226,8 @@ TRACE %{
 
     } else if (pileup_ratio > 0 && rand01() < pileup_ratio) {
         // handle detector pile-up peak: get an other fluo line and sum it
-        int i_E = SDD_SelectFromDistribution(E_p, nE);
-        E  += Emin+i*(Emax-Emin)/nE;             // pile-up
+        int i_E = SDD_SelectInteraction(E_p, nE);
+        E  += Emin+i_E*(Emax-Emin)/nE;             // pile-up
         type= FLUORESCENCE_PILEUP;
     }
 
@@ -188,9 +236,12 @@ TRACE %{
       dE = sqrt(K*E+electronic_noise*electronic_noise);
     else if (resolution > 0)
       dE = resolution;
-    if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
-    else                 dE  *= randnorm();          // Gaussian distribution
-    E += dE;
+    else dE=0;
+    if (dE) {
+      if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
+      else                 dE  *= randnorm();          // Gaussian distribution
+      E += dE;
+    }
 
     i = floor((E-Emin)*nE/(Emax-Emin));
     if(i >= 0 && i < nE)
@@ -201,6 +252,29 @@ TRACE %{
         E_p[i] = E_p[i] + p;
         #pragma acc atomic
         E_p2[i] = E_p2[i] + p*p;
+
+        // special storage
+        if (type == FLUORESCENCE_PILEUP) {
+          #pragma acc atomic
+          E_N_pileup[i] = E_N_pileup[i] + 1;
+          #pragma acc atomic
+          E_p_pileup[i] = E_p_pileup[i] + p;
+          #pragma acc atomic
+          E_p2_pileup[i] = E_p2_pileup[i] + p*p;
+
+        } else if (type == FLUORESCENCE_ESCAPE) {
+          #pragma acc atomic
+          E_N_escape[i] = E_N_escape[i] + 1;
+          #pragma acc atomic
+          E_p_escape[i] = E_p_escape[i] + p;
+          #pragma acc atomic
+          E_p2_escape[i] = E_p2_escape[i] + p*p;
+        }
+
+        #pragma acc atomic
+        N_sum = N_sum +1;
+        #pragma acc atomic
+        p_sum = p_sum +1;
         SCATTER;
     }
 
@@ -209,5 +283,55 @@ TRACE %{
     }
   }
 
-
 %}
+
+SAVE
+%{
+  DETECTOR_OUT_1D(
+    "Energy monitor",
+    "Energy [keV]",
+    "Intensity",
+    "E", Emin, Emax, nE,
+    &E_N[0],&E_p[0],&E_p2[0],
+    filename);
+  if (escape_ratio)
+    {
+      char f_escape[1024];
+      snprintf(f_escape, 1024, "Escape_%s",filename);
+      DETECTOR_OUT_1D(
+      "Energy monitor (escape)",
+      "Energy [keV]",
+      "Intensity (escape)",
+      "E", Emin, Emax, nE,
+      &E_N_escape[0],&E_p_escape[0],&E_p2_escape[0],
+      f_escape);
+    }
+  if (pileup_ratio)
+    {
+      char f_pileup[1024];
+      snprintf(f_pileup, 1024, "PileUp_%s",filename);
+      DETECTOR_OUT_1D(
+      "Energy monitor (pile-up)",
+      "Energy [keV]",
+      "Intensity (pile-up)",
+      "E", Emin, Emax, nE,
+      &E_N_pileup[0],&E_p_pileup[0],&E_p2_pileup[0],
+      f_pileup);
+    }
+%}
+
+DISPLAY %{
+  if (shape ==0) {          // disk
+    circle("xy",0,0,0,radius);
+
+  } else if (shape == 1) {  // rectangle
+    rectangle("xy",0,0,0,xwidth,yheight);
+
+  } else if (shape == 2) {  // sphere
+    circle("xy",0,0,0,fabs(radius));
+    circle("xz",0,0,0,fabs(radius));
+    circle("yz",0,0,0,fabs(radius));
+  }
+%}
+
+END

--- a/mcxtrace-comps/samples/FluoCrystal.comp
+++ b/mcxtrace-comps/samples/FluoCrystal.comp
@@ -1044,8 +1044,9 @@ do { /* while (intersect) Loop over multiple scattering events */
       case FLUORESCENCE: /* 0 Fluo: choose line */
         n_fluo++;
         p_fluo += p;
-        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);      // dE in keV
+        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel); // dE full-width in keV
         if (dE) {
+          dE /= 2;  // half-width
           if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
           else                 dE  *= randnorm();          // Gaussian distribution
           Ef = Ef + dE;

--- a/mcxtrace-comps/samples/FluoCrystal.comp
+++ b/mcxtrace-comps/samples/FluoCrystal.comp
@@ -22,8 +22,6 @@
 * - Compton scattering  (inelastic, incoherent)
 * - Rayleigh scattering (elastic,   coherent)
 * - crystal diffraction (elastic,   coherent)
-* - fluorescence detector escape  (energy shift from detector K-alpha)
-* - fluorescence detector pile-up (sum aka time coincidence aka pile-up in detector)
 *
 * The 'material' specification is given as a chemical formulae, e.g. "LaB6". It
 * may also be given as a file name (CIF/LAU/LAZ/FullProf format) in which case
@@ -96,32 +94,6 @@
 * If you get strange results, check the crystal mosaicity and delta(d)/d parameters,
 * as this component is not suited for ideal/perfect mosaic crystals.
 *
-* <b>Detector artifacts:</b>
-* This component also simulates the escape and time coincidence peaks in a close-by
-* detector (e.g. SDD). The first process corresponds with a fluorescence excitation within
-* the detector that subtracts the K-alpha detector level from the sample scattered energy.
-* The second process is related to the detector dead-time, within which time coincidence
-* between two fluorescence photons are summed-up.
-* If you activate these features, with e.g. 'escape_ratio=0.01' and 'pileup_ratio=0.01', you
-* should further remove these contributions for the rest of the simulation beyond the
-* fluorescence detector, with an ABSORB keyword:
-*
-* USERVARS %{
-*   int fluo_type;
-* %}
-* COMPONENT F = FluoCrystal(material="Al", escape_ratio=0.01, pileup_ratio=0.01) AT ...
-* EXTEND %{
-*   if (SCATTERED) fluo_type=type;              // record type of interaction
-* %}
-*
-* COMPONENT E_mon = Monitor_nD(options="energy", ...) AT ...
-* EXTEND %{
-*   if (fluo_type>=FLUORESCENCE_ESCAPE) ABSORB; // remove detector artifacts further
-* %}
-*
-* (...)
-*
-*
 * The fluorescence is computed via the XRayLib (apt install libxrl-dev) https://github.com/tschoonj/xraylib.
 *
 * %Parameters
@@ -150,10 +122,7 @@
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
 * flag_sx:        [1] When 0, the crystal diffraction is ignored.
 * flag_lorentzian:[1] When 1, the fluorescence line shapes are assumed to be Lorentzian, else Gaussian.
-* flag_kissel:    [1] When 1, to handle M-lines XRF from Kissel (else only K and L-lines, but faster).
-* escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. Zero inactivates.
-* escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
-* pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. This is e.g. the dead-time ratio. Zero inactivates.
+* flag_kissel:    [1] When 1 (slower), handle M-lines XRF from Kissel for Z>=52 Te (else only K and L-lines).
 * order:          [1] Limit multiple fluorescence up to given order. Last iteration is absorption only.
 * sx_refl:      [str] A CIF/LAZ/LAU reflection file as for PowderN. When not given, 'material' is used. Specify it when 'material' is a chemical formula.
 * barns:          [1] Flag to indicate if |F|^2 from 'material' is in barns or fm^2, (barns=1 for laz/cif, barns=0 for lau type files).
@@ -175,7 +144,7 @@
 * cz:   [AA or AA^-1]   c on z axis
 *
 * CALCULATED PARAMETERS:
-* type: scattering event type 0=fluorescence, 1=Rayleigh, 2=Compton, 3=transmit (absorbsion), 4=diffraction, 5=detector escape peak, 6=detector pile-up/sum/coincidence peak
+* type: scattering event type 0=fluorescence, 1=Rayleigh, 2=Compton, 3=transmit (absorbsion), 4=diffraction
 *
 * %Link
 * The XRayLib https://github.com/tschoonj/xraylib http://dx.doi.org/10.1016/j.sab.2011.09.011
@@ -216,8 +185,6 @@ SETTING PARAMETERS(
   aa=0,   bb=0,   cc=0,
   vector mosaic_AB={0,0, 0,0,0, 0,0,0},
   mosaic = 3, mosaic_a = -1, mosaic_b = -1, mosaic_c = -1,
-  escape_ratio=0, escape_energy=1.739,
-  pileup_ratio=0,
   int order=1)
 
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
@@ -237,8 +204,6 @@ EXTEND %{
   #define COMPTON      2  // Incoherent
   #define DIFFRACTION  3  // diffraction
   #define TRANSMISSION 4
-  #define FLUORESCENCE_ESCAPE 5 // Detector escape      peak fluorescence
-  #define FLUORESCENCE_PILEUP 6 // Detector pile-up/sum peak fluorescence
 
   #include <xraylib/xraylib.h>
 
@@ -1132,20 +1097,6 @@ do { /* while (intersect) Loop over multiple scattering events */
 
       default:  // should never happen
         ABSORB;
-    }
-
-    // handle detector escape peak: just shift energy down by detector K-alpha
-    if (escape_ratio > 0 && escape_energy > 0 && kf > escape_energy*E2K && rand01() < escape_ratio) {
-      kf  -= escape_energy*E2K;
-      type = FLUORESCENCE_ESCAPE;
-
-    } else if (type == FLUORESCENCE && pileup_ratio > 0 && rand01() < pileup_ratio) {
-      // handle detector pile-up peak: get an other fluo line and sum it
-      i_Z = XRMC_SelectFromDistribution(cum_xs_fluo,     compound->nElements+1);
-      Z   = compound->Elements[i_Z];
-      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);
-      kf += Ef*E2K;
-      type= FLUORESCENCE_PILEUP;
     }
 
     kx = kf*kf_x;

--- a/mcxtrace-comps/samples/FluoPowder.comp
+++ b/mcxtrace-comps/samples/FluoPowder.comp
@@ -829,8 +829,9 @@ do { /* while (intersect) Loop over multiple scattering events */
       case FLUORESCENCE: /* 0 Fluo: choose line */
         n_fluo++;
         p_fluo += p;
-        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);      // dE in keV
+        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel); // dE full-width in keV
         if (dE) {
+          dE /= 2;  // half-width
           if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
           else                 dE  *= randnorm();          // Gaussian distribution
           Ef = Ef + dE;

--- a/mcxtrace-comps/samples/FluoPowder.comp
+++ b/mcxtrace-comps/samples/FluoPowder.comp
@@ -22,8 +22,6 @@
 * - Compton scattering  (inelastic, incoherent)
 * - Rayleigh scattering (elastic,   coherent)
 * - powder diffraction  (elastic,   coherent)
-* - fluorescence detector escape  (energy shift from detector K-alpha)
-* - fluorescence detector pile-up (sum aka time coincidence aka pile-up in detector)
 *
 * The 'material' specification is given as a chemical formulae, e.g. "LaB6". It
 * may also be given as a file name (CIF/LAU/LAZ/FullProf format) in which case
@@ -94,32 +92,6 @@
 * This sample component can advantageously benefit from the SPLIT feature, e.g.
 * SPLIT COMPONENT sample = FluoPowder(...)
 *
-* <b>Detector artifacts:</b>
-* This component also simulates the escape and time coincidence peaks in a close-by
-* detector (e.g. SDD). The first process corresponds with a fluorescence excitation within
-* the detector that subtracts the K-alpha detector level from the sample scattered energy.
-* The second process is related to the detector dead-time, within which time coincidence
-* between two fluorescence photons are summed-up.
-* If you activate these features, with e.g. 'escape_ratio=0.01' and 'pileup_ratio=0.01', you
-* should further remove these contributions for the rest of the simulation beyond the
-* fluorescence detector, with an ABSORB keyword:
-*
-* USERVARS %{
-*   int fluo_type;
-* %}
-* COMPONENT F = FluoPowder(material="Al", escape_ratio=0.01, pileup_ratio=0.01) AT ...
-* EXTEND %{
-*   if (SCATTERED) fluo_type=type;              // record type of interaction
-* %}
-*
-* COMPONENT E_mon = Monitor_nD(options="energy", ...) AT ...
-* EXTEND %{
-*   if (fluo_type>=FLUORESCENCE_ESCAPE) ABSORB; // remove detector artifacts further
-* %}
-*
-* (...)
-*
-*
 * The fluorescence is computed via the XRayLib (apt install libxrl-dev) https://github.com/tschoonj/xraylib.
 *
 * %Parameters
@@ -148,10 +120,7 @@
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
 * flag_powder:    [1] When 0, the powder diffraction is ignored.
 * flag_lorentzian:[1] When 1, the fluorescence line shapes are assumed to be Lorentzian, else Gaussian.
-* flag_kissel:    [1] When 1, to handle M-lines XRF from Kissel (else only K and L-lines, but faster).
-* escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. Zero inactivates.
-* escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
-* pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. This is e.g. the dead-time ratio. Zero inactivates.
+* flag_kissel:    [1] When 1 (slower), handle M-lines XRF from Kissel for Z>=52 Te (else only K and L-lines).
 * order:          [1] Limit multiple fluorescence up to given order. Last iteration is absorption only.
 * barns:          [1] Flag to indicate if |F|^2 from 'material' is in barns or fm^2, (barns=1 for laz/cif, barns=0 for lau type files).
 * d_phi:        [deg] Angle corresponding to the difraction vertical angular range to focus to, e.g. detector height. 0 for no focusing. You may as well define focus_ah or focus_yh and target.
@@ -164,7 +133,7 @@
 * Vc:          [AA^3] Volume of unit cell=nb atoms per cell/density of atoms.
 *
 * CALCULATED PARAMETERS:
-* type: scattering event type 0=FLUORESCENCE fluorescence, 1=RAYLEIGH Rayleigh, 2=COMPTON Compton, 3=TRANSMISSION Transmit (absorbsion), 4=DIFFRACTION Diffraction, 5=FLUORESCENCE_ESCAPE Detector escape peak, 6=FLUORESCENCE_PILEUP Detector pile-up/sum/coincidence peak
+* type: scattering event type 0=FLUORESCENCE fluorescence, 1=RAYLEIGH Rayleigh, 2=COMPTON Compton, 3=TRANSMISSION Transmit (absorbsion), 4=DIFFRACTION Diffraction
 *
 * %Link
 * The XRayLib https://github.com/tschoonj/xraylib http://dx.doi.org/10.1016/j.sab.2011.09.011
@@ -199,8 +168,6 @@ SETTING PARAMETERS(
   string powder_refl="",
   vector powder_format={0,0,0,0,0,0,0,0}, Vc=0, delta_d_d=0, DW=0,
   d_phi=0, int nb_atoms=1, int barns=1, int tth_sign=0,
-  escape_ratio=0, escape_energy=1.739,
-  pileup_ratio=0,
   int order=1)
 
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
@@ -917,20 +884,6 @@ do { /* while (intersect) Loop over multiple scattering events */
 
       default:  // should never happen
         ABSORB;
-    }
-
-    // handle detector escape peak: just shift energy down by detector K-alpha
-    if (escape_ratio > 0 && escape_energy > 0 && kf > escape_energy*E2K && rand01() < escape_ratio) {
-      kf  -= escape_energy*E2K; // escape
-      type = FLUORESCENCE_ESCAPE;
-
-    } else if (type == FLUORESCENCE && pileup_ratio > 0 && rand01() < pileup_ratio) {
-      // handle detector pile-up peak: get an other fluo line and sum it
-      i_Z = XRMC_SelectFromDistribution(cum_xs_fluo,     compound->nElements+1);
-      Z   = compound->Elements[i_Z];
-      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);
-      kf += Ef*E2K;             // pile-up
-      type= FLUORESCENCE_PILEUP;
     }
 
     kx = kf*kf_x;

--- a/mcxtrace-comps/samples/Fluorescence.comp
+++ b/mcxtrace-comps/samples/Fluorescence.comp
@@ -284,7 +284,7 @@ SHARE %{
     // select randomly one of these lines
     i_line = XRMC_SelectFromDistribution(cum_xs_lines, XRAYLIB_LINES_MAX); // extract a line
     // get the K shell line width as approximation of fluorescence line width
-    if (dE) *dE = AtomicLevelWidth(Z, K_SHELL, NULL); // keV
+    if (dE) *dE = AtomicLevelWidth(Z, K_SHELL, NULL); // keV, full-width in keV
 
     return LineEnergy(Z, -i_line, NULL); // fluorescent line energy
   } // XRMC_SelectFluorescenceEnergy
@@ -870,8 +870,9 @@ do { /* while (intersect) Loop over multiple scattering events */
       case FLUORESCENCE: /* 0 Fluo: choose line */
         n_fluo++;
         p_fluo += p;
-        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);      // dE in keV
+        Ef      = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel); // dE full-width in keV
         if (dE) {
+          dE /= 2;  // half-width
           if (flag_lorentzian) dE  *= tan(PI/2*randpm1()); // Lorentzian distribution
           else                 dE  *= randnorm();          // Gaussian distribution
           Ef = Ef + dE;

--- a/mcxtrace-comps/samples/Fluorescence.comp
+++ b/mcxtrace-comps/samples/Fluorescence.comp
@@ -20,8 +20,6 @@
 * - fluorescence        (excited electrons emit light while falling into lower states)
 * - Compton scattering  (inelastic, transfer some energy to an electron,    incoherent)
 * - Rayleigh scattering (elastic,   dipolar radiation of excitated electrons, coherent)
-* - fluorescence detector escape  (energy shift from detector K-alpha)
-* - fluorescence detector pile-up (sum aka time coincidence aka pile-up in detector)
 *
 * Use the <b>FluoPowder</b> sample component to properly handle powder diffraction with fluorescence.
 *
@@ -90,32 +88,6 @@
 * This sample component can advantageously benefit from the SPLIT feature, e.g.
 * SPLIT COMPONENT sample = Fluorescence(...)
 *
-* <b>Detector artifacts:</b>
-* This component also simulates the escape and time coincidence peaks in a close-by
-* detector (e.g. SDD). The first process corresponds with a fluorescence excitation within
-* the detector that subtracts the K-alpha detector level from the sample scattered energy.
-* The second process is related to the detector dead-time, within which time coincidence
-* between two fluorescence photons are summed-up.
-* If you activate these features, with e.g. 'escape_ratio=0.01' and 'pileup_ratio=0.01', you
-* should further remove these contributions for the rest of the simulation beyond the
-* fluorescence detector, with an ABSORB keyword:
-*
-* USERVARS %{
-*   int fluo_type;
-* %}
-* COMPONENT F = Fluorescence(material="Al", escape_ratio=0.01, pileup_ratio=0.01) AT ...
-* EXTEND %{
-*   if (SCATTERED) fluo_type=type;              // record type of interaction
-* %}
-*
-* COMPONENT E_mon = Monitor_nD(options="energy", ...) AT ...
-* EXTEND %{
-*   if (fluo_type>=FLUORESCENCE_ESCAPE) ABSORB; // remove detector artifacts further
-* %}
-*
-* (...)
-*
-*
 * The computation is made via the XRayLib (apt install libxrl-dev) https://github.com/tschoonj/xraylib.
 *
 * %Parameters
@@ -144,14 +116,11 @@
 * flag_compton:   [1] When 0, the Compton  scattering is ignored.
 * flag_rayleigh:  [1] When 0, the Rayleigh scattering is ignored.
 * flag_lorentzian:[1] When 1, the line shapes are assumed to be Lorentzian, else Gaussian.
-* flag_kissel:    [1] When 1, to handle M-lines XRF from Kissel (else only K and L-lines, but faster).
-* escape_ratio:   [1] Detector escape peak ratio,  e.g. 0.01-0.02. Zero inactivates.
-* escape_energy:[keV] Detector escape peak energy, e.g. 1.739 for Si, 9.886 for Ge.
-* pileup_ratio:   [1] Sum aka time coincidence aka pile-up detector peak ratio, e.g. 0.01-0.02. This is e.g. the dead-time ratio. Zero inactivates.
+* flag_kissel:    [1] When 1 (slower), handle M-lines XRF from Kissel for Z>=52 Te (else only K and L-lines).
 * order:          [1] Limit multiple fluorescence up to given order. Last iteration is absorption only.
 *
 * CALCULATED PARAMETERS:
-* type: scattering event type 0=FLUORESCENCE fluorescence, 1=RAYLEIGH Rayleigh, 2=COMPTON Compton, 3=TRANSMISSION Transmit (absorbsion), 4=DIFFRACTION Diffraction (not handled here), 5=FLUORESCENCE_ESCAPE Detector escape peak, 6=FLUORESCENCE_PILEUP Detector pile-up/sum/coincidence peak
+* type: scattering event type 0=FLUORESCENCE fluorescence, 1=RAYLEIGH Rayleigh, 2=COMPTON Compton, 3=TRANSMISSION Transmit (absorbsion), 4=DIFFRACTION Diffraction (not handled here)
 *
 * %Link
 * The XRayLib https://github.com/tschoonj/xraylib http://dx.doi.org/10.1016/j.sab.2011.09.011
@@ -183,8 +152,6 @@ SETTING PARAMETERS(
   focus_xw=0, focus_yh=0, focus_aw=0, focus_ah=0, int target_index=0,
   int flag_compton=1, int flag_rayleigh=1, int flag_lorentzian=0,
   int flag_kissel=0,
-  escape_ratio=0, escape_energy=1.739,
-  pileup_ratio=0,
   int order=1)
 
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
@@ -206,8 +173,6 @@ SHARE %{
   #define COMPTON      2  // Incoherent
   #define DIFFRACTION  3  // diffraction
   #define TRANSMISSION 4
-  #define FLUORESCENCE_ESCAPE 5 // Detector escape      peak fluorescence
-  #define FLUORESCENCE_PILEUP 6 // Detector pile-up/sum peak fluorescence
 
   #include <xraylib/xraylib.h>
   
@@ -234,7 +199,7 @@ SHARE %{
     // loop on possible fluorescence lines
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) { 
       // cumulative sum of the line cross sections
-      xs[FLUORESCENCE] += kissel ?
+      xs[FLUORESCENCE] += kissel && Z >= 50 ?
         CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
       : CSb_FluorLine(Z, -i_line, E0, NULL);
     }
@@ -309,7 +274,7 @@ SHARE %{
     // compute cumulated XS for all fluo lines
     cum_xs_lines[0] = sum_xs = 0;
     for (i_line=0; i_line<XRAYLIB_LINES_MAX; i_line++) { // loop on fluorescent lines
-      double xs = kissel ?
+      double xs = kissel && Z >= 50 ?
         CSb_FluorLine_Kissel(Z, -i_line, E0, NULL) /* XRayLib lines are negative integers */
       : CSb_FluorLine(Z, -i_line, E0, NULL);
       // when a line is inactive: E=xs=0
@@ -940,22 +905,6 @@ do { /* while (intersect) Loop over multiple scattering events */
         kf         = ComptonEnergy(E, theta, NULL)*E2K; /* XRayLib, fraction of emc2=511 keV */
         p         *= 4*PI*dsigma/xs[COMPTON];
         break;
-    }
-    
-    
-
-    // handle detector escape peak: just shift energy down by detector K-alpha
-    if (escape_ratio > 0 && escape_energy > 0 && kf > escape_energy*E2K && rand01() < escape_ratio) {
-      kf  -= escape_energy*E2K; // escape
-      type = FLUORESCENCE_ESCAPE;
-
-    } else if (type == FLUORESCENCE && pileup_ratio > 0 && rand01() < pileup_ratio) {
-      // handle detector pile-up peak: get an other fluo line and sum it
-      i_Z = XRMC_SelectFromDistribution(cum_xs_fluo,     compound->nElements+1);
-      Z   = compound->Elements[i_Z];
-      Ef  = XRMC_SelectFluorescenceEnergy(Z, E, &dE, flag_kissel);
-      kf += Ef*E2K;             // pile-up
-      type= FLUORESCENCE_PILEUP;
     }
     
     kx = kf*kf_x;


### PR DESCRIPTION
Move escape + pile-up stuff from Fluo samples to a new monitor `Fluo_detector`. 
This latter is tested within the `Test_Fluorescence`.
Indeed, these feature' are bound to a detector, not a sample scattering process.
