### PR TITLE
Fix FluoPowder compilation error from nightlies

### DIFF
--- a/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
+++ b/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/Test_FluoPowder.instr
@@ -98,7 +98,7 @@ EXTEND %{
 
 COMPONENT FL_pow = FluoPowder(
     radius=0.5e-6, material=material,
-    escape_ratio=0.01, pileup_ratio=0.01, delta_d_d=delta_d_d)
+    delta_d_d=delta_d_d)
 WHEN (index == 3)
 AT (0, 0, 0) RELATIVE sample_cradle
 EXTEND %{


### PR DESCRIPTION
@farhi just spotted this one on https://new-nightly.mcxtrace.org/todays-datafiles/2025-05-20_output.html - upstream changes from comp(s) simply missing.