### PR TITLE
OPENACC: Fix for compilation errors 

### DIFF
--- a/common/lib/share/interoff-lib.c
+++ b/common/lib/share/interoff-lib.c
@@ -38,6 +38,10 @@
 #ifndef INTEROFF_LIB_C
 #define INTEROFF_LIB_C "$Revision$"
 
+#ifdef OPENACC // If on GPU map fprintf to printf
+#define fprintf(stderr,...) printf(__VA_ARGS__)
+#endif
+
 #pragma acc routine
 double off_F(double x, double y,double z,double A,double B,double C,double D) {
   return ( A*x + B*y + C*z + D );
@@ -370,9 +374,7 @@ int off_clip_3D_mod(intersection* t, Coords a, Coords b,
 #ifdef OFF_LEGACY
         if (t_size>OFF_INTERSECT_MAX)
         {
-#ifndef OPENACC
           fprintf(stderr, "Warning: number of intersection exceeded (%d) (interoff-lib/off_clip_3D_mod)\n", OFF_INTERSECT_MAX);
-#endif
             return (t_size);
         }
 #endif
@@ -454,9 +456,7 @@ int off_clip_3D_mod_grav(intersection* t, Coords pos, Coords vel, Coords acc,
     
     if (t_size>CHAR_BUF_LENGTH)
       {
-#ifndef OPENACC
 	fprintf(stderr, "Warning: number of intersection exceeded (%d) (interoff-lib/off_clip_3D_mod)\n", CHAR_BUF_LENGTH);
-#endif
 	return (t_size);
       }
     //both planes intersect the polygon, let's find the intersection point

--- a/common/lib/share/r-interoff-lib.c
+++ b/common/lib/share/r-interoff-lib.c
@@ -43,6 +43,10 @@
 #include "r-interoff-lib.h"
 #endif
 
+#ifdef OPENACC // If on GPU map fprintf to printf
+#define fprintf(stderr,...) printf(__VA_ARGS__)
+#endif
+
 #pragma acc routine
 double r_off_F(double x, double y,double z,double A,double B,double C,double D) {
   return ( A*x + B*y + C*z + D );
@@ -366,9 +370,7 @@ int r_off_clip_3D_mod(r_intersection* t, Coords a, Coords b,
 #ifdef OFF_LEGACY
         if (t_size>OFF_INTERSECT_MAX)
         {
-#ifndef OPENACC
           fprintf(stderr, "Warning: number of intersection exceeded (%d) (interoff-lib/off_clip_3D_mod)\n", OFF_INTERSECT_MAX);
-#endif
             return (t_size);
         }
 #endif
@@ -450,9 +452,7 @@ int r_off_clip_3D_mod_grav(r_intersection* t, Coords pos, Coords vel, Coords acc
     
     if (t_size>CHAR_BUF_LENGTH)
       {
-#ifndef OPENACC
 	fprintf(stderr, "Warning: number of intersection exceeded (%d) (interoff-lib/off_clip_3D_mod)\n", CHAR_BUF_LENGTH);
-#endif
 	return (t_size);
       }
     //both planes intersect the polygon, let's find the intersection point
@@ -891,6 +891,10 @@ int n2 =  r - m;
 r_intersection *L, *R;
  L = (r_intersection *)malloc(sizeof(r_intersection) * n1);
  R = (r_intersection *)malloc(sizeof(r_intersection) * n2);
+  if (!L||!R) {
+   fprintf(stderr,"Error allocating intersection arrays\n");
+   exit(-1);
+ }
 /* Copy data to temp arrays L[] and R[] */
  #pragma acc loop independent
 for (i = 0; i < n1; i++)


### PR DESCRIPTION
Recent modifications to interoff-lib (error message in case of failed malloc) lead to compilation errors when using OPENACC.

Patch is verified to restore compilation in e.g. McStas ESS_BEER_MCPL, but error logs indicate that most OPENACC non-compiles should be resorted.

(Full list of McStas instruments with related error message:
```
Conditional_test
cryostat_example
Demonstration
Demo_shape_primitives
Demo_shape_primitives_simple
ESS_BEER_MCPL
ESS_butterfly_Guide_curved_test
ESS_butterfly_MCPL_test
ESS_butterfly_test
ESS_butterfly_tfocus_NOFOCUS_test
ESS_butterfly_tfocus_test
ESS_mcpl2hist
ESS_Testbeamline_HZB_V20
External_component
External_component_test
FZJ_BenchmarkSfin2
Geometry_test
He3_spin_filter
Histogrammer
HZB_NEAT
ILL_BRISP
ILL_D2B
ILL_D2B_noenv
ILL_D4
ILL_H10_IN8
ILL_H113
ILL_H13_IN20
ILL_H142
ILL_H142_D33
ILL_H142_IN12
ILL_H143_LADI
ILL_H15
ILL_H15_D11
ILL_H15_IN6
ILL_H16
ILL_H16_IN5
ILL_H16_IN5_Mantid
ILL_H16_Mantid
ILL_H22
ILL_H22_D1A
ILL_H22_D1A_noenv
ILL_H22_D1B
ILL_H22_D1B_noenv
ILL_H22_VIVALDI
ILL_H24
ILL_H25
ILL_H25_IN22
ILL_H5
ILL_H512_D22
ILL_H53
ILL_H53_D16
ILL_H53_IN14
ILL_H5_new
ILL_H8_IN1
ILL_IN13
ILL_IN4
ILL_IN5
ILL_IN5_Mantid
ILL_IN5_Spots
ILL_IN6
ILL_Lagrange
ILL_SALSA
IncoherentPhonon_test
Incoherent_validation
ISIS_GEM
ISIS_HET
ISIS_IMAT
ISIS_MERLIN
ISIS_OSIRIS
ISIS_Prisma2
ISIS_SANS2d_Mantid
ISIS_test
ISIS_TOSCA_preupgrade
ISIS_TOSCA_preupgrade_Mantid
Laue_camera
linup-4
linup-6
LLB_6T2
Logger_test
Manual_example
MCPL2hist
MCPL2Mantid_flat
MCPL_filter_energy
MCPL_filter_radius
MCPL_filter_wavelength
McStas_Isotropic_Sqw
McStas_PowderN
McStas_Single_crystal
Powder_validation
PSI_DMC
PSI_DMC_simple
PSI_Focus
Radiography_absorbing_edge
rallelepiped: 5159)
Reflectometer
RITA-II
RTP_DIF
RTP_Laue
RTP_NeutronRadiography
RTP_SANS
SAFARI_MPISI
SAFARI_PITSI
Sample_picture_replica
Samples_Incoherent
Samples_Incoherent_off
Samples_Isotropic_Sqw
Samples_vanadium
SE_usage_example
SimplePowderDiffractometer
Single_crystal_validation
SNS_analytic_test
SNS_ARCS
SNS_ARCS_Mantid
SNS_BASIS
SNS_test
Tagging_demo
templateDIFF
templateLaue
templateNMX
templateNMX_TOF
templateSANS2_Mantid
templateSANS_Mantid
templateTAS
templateTOF
templateVanadiumMultipleScat_Mantid
Test_absorption_image
Test_Collimator_Radial
Test_Cyl_monitors
Test_DiskChoppers2
Test_Fermi
Test_focus
Test_Guides
Test_Guides_Curved
Test_Incoherent
Test_Jump_Iterate
Test_Lens
Test_Magnon_bcc_2D
Test_MCPL_input
Test_MCPL_input_once
Test_MCPL_output
Test_Monitor_nD
Test_Monochromators
Test_Pol_Set
Test_powder
Test_PowderN
Test_PowderN_concentric
Test_PowderN_Res
Test_Powders
Test_PreMonitor_nD
Test_Selectors
Test_Single_crystal_inelastic
Test_single_magnetic_crystal
Test_Source_pulsed
Test_Sources
Test_Sqw
Test_Sqw_monitor
Test_StatisticalChopper
Test_SX
Time_of_flight
Tomography
Tools_ONION
Union_NCrystal_example
Union_NCrystal_mix_example
Unit_test_abs_logger_1D_space
Unit_test_abs_logger_1D_space_event
Unit_test_abs_logger_1D_space_tof
Unit_test_abs_logger_1D_space_tof_to_lambda
Unit_test_abs_logger_2D_space
Unit_test_abs_logger_event
Unit_test_conditional_PSD
Unit_test_conditional_standard
Unit_test_logger_1D
Unit_test_logger_2D_kf
Unit_test_logger_2D_kf_time
Unit_test_logger_2DQ
Unit_test_logger_2D_space
Unit_test_logger_2D_space_time
Unit_test_logger_3D_space
Unit_test_loggers_base
Unittest_SPLIT_sample
ViewModISIStest
WOFSANS
```
)