### PR TITLE
LaTeX math (formulae etc) for mcdoc %Description headers

### DIFF
--- a/tools/Python/mcdoc/mcdoc.py
+++ b/tools/Python/mcdoc/mcdoc.py
@@ -491,6 +491,14 @@ class InstrDocWriter:
 
 <BODY>
 
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+<script src="http://dreasgrech.com/upload/jslatex/jquery.jslatex.packed.js"></script>
+<script>
+$(function () {
+    $(".latex").latex();
+});
+</script>
+
 <P ALIGN=CENTER>
  [ <A href="#id">Identification</A>
  | <A href="#desc">Description</A>

--- a/tools/Python/mcdoc/mcdoc.py
+++ b/tools/Python/mcdoc/mcdoc.py
@@ -491,8 +491,8 @@ class InstrDocWriter:
 
 <BODY>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-<script src="http://dreasgrech.com/upload/jslatex/jquery.jslatex.packed.js"></script>
+<script src="https://tex.mccode.org/jquery/latest/jquery.min.js"></script>
+<script src="https://tex.mccode.org/jquery/latex/jquery.jslatex.packed.js"></script>
 <script>
 $(function () {
     $(".latex").latex();
@@ -770,6 +770,13 @@ function comp() {
 }
 </script>
 
+<script src="https://tex.mccode.org/jquery/latest/jquery.min.js"></script>
+<script src="https://tex.mccode.org/jquery/latex/jquery.jslatex.packed.js"></script>
+<script>
+$(function () {
+    $(".latex").latex();
+});
+</script>
 
 <BODY>
 


### PR DESCRIPTION
This PR adds a little js code (residing on mccode.org) to allow redering formulae in mcdoc pages. Use in the `%Description` part of of instr/comp headers like this:

```
* %D
* An arm does not actually do anything, it is just there to set
* up a new coordinate system.
*
* <div class="latex">
* $\frac{\alpha}{\beta}$
* </div>
```
**Important: Currently all of these lines need a `* ` at the start**. Renders like this:
![Screenshot 2025-06-03 at 14 08 42](https://github.com/user-attachments/assets/d9a6027c-62d1-42f6-8be6-a1c285f6f025)




