### PR TITLE
Fixes relating to recent Monochromator_bent updates from @Lomholy

### DIFF
--- a/mcstas-comps/contrib/Monochromator_bent.comp
+++ b/mcstas-comps/contrib/Monochromator_bent.comp
@@ -5,7 +5,7 @@
 *         Risoe National Laboratory, Roskilde, Denmark
 *         Institut Laue Langevin, Grenoble, France
 *
-* Component: Monochromator
+* Component: Monochromator_bent
 *
 * %I
 * Written by: Daniel Lomholt Christensen <dlc@math.ku.dk> 
@@ -37,51 +37,52 @@
 * %P
 * INPUT PARAMETERS:
 *
-* zwidth: [m]               			Width of each crystal without bending.
-* yheight: [m]              			Height of each crystal without bending.
-* xthickness: [m]           			Thickness of each crystal without bending.
-* radius_x: [m]             			Radius of the circle the monochromator bends on in the plane.
-* plane_of_reflection: ["Si400"] 		The plane of reflection from the material. The list of possible reflections can 
-* 										can be seen in the source code.
-* angle_to_cut_horizontal [degrees]  	Angle between cut and normal of crystal slab, horizontally
-* angle_to_cut_vertical [degrees] 		Angle between cut and normal of crystal slab, vertically ! NOTE: This may not work as intended.
-* mosaicity[arc minutes]                Gaussian mosaicity of the crystal. Always the horizontal mosaicity
-* mosaic_anisotropy                     Anisotropy of the mosaicity, changes vertical mosaicity to be mosaic_anisotropy*mosaicity
-* domainthickness [micro meter]			Thickness of the crystal domains.
-* temperature: [K]          			Temperature of the monochromator in Kelvin.
-* optimize: []							Flag to tell if the component should optimize for reflections or not. NOTE: May not work perfectly
-* vector x_pos = NULL					x-Position of each crystal
-* vector y_pos = NULL					y-Position of each crystal
-* vector z_pos = NULL					z-Position of each crystal
-* vector x_rot = NULL 					Rotation around x-axis for each crystal
-* vector y_rot = NULL 					Rotation around y-axis for each crystal
-* vector z_rot = NULL					Rotation around z-axis for each crystal
-*										NOTE: Rotations happen around x, then y, then z.
-* verbose: [0]							Verbosity of the monochromator. Used for debugging. 
+* zwidth:                  [m]      Width of each crystal without bending.
+* yheight:                 [m]      Height of each crystal without bending.
+* xthickness:              [m]      Thickness of each crystal without bending.
+* radius_x:                [m]      Radius of the circle the monochromator bends on in the plane.
+* plane_of_reflection:     [str]    The plane of reflection from the material, e.g. "Si400". The list of possible reflections can can be seen in the source code.
+* angle_to_cut_horizontal: [deg]    Angle between cut and normal of crystal slab, horizontally
+* angle_to_cut_vertical:   [deg]    Angle between cut and normal of crystal slab, vertically ! NOTE: This may not work as intended.
+* mosaicity:               [arcmin] Gaussian mosaicity of the crystal. Always the horizontal mosaicity
+* mosaic_anisotropy:       [1]      Anisotropy of the mosaicity, changes vertical mosaicity to be mosaic_anisotropy*mosaicity
+* domainthickness:         [1e-6m]  Thickness of the crystal domains.
+* temperature:             [K]      Temperature of the monochromator in Kelvin.
+* optimize:                [1]	    Flag to tell if the component should optimize for reflections or not. NOTE: May not work perfectly
+* x_pos:                   [vector] x-Position of each crystal
+* y_pos:                   [vector] y-Position of each crystal
+* z_pos:                   [vector] z-Position of each crystal
+* x_rot:                   [vector] Rotation around x-axis for each crystal (NOTE: Rotations happen around x, then y, then z.)
+* y_rot:                   [vector] Rotation around y-axis for each crystal
+* z_rot:                   [vector] Rotation around z-axis for each crystal										
+* verbose:                 [1]      Verbosity of the monochromator. Used for debugging. 
+* n_crystals:              [1]      Number of mono crystals
+* draw_as_rectangles:      [1]      Flag to visualise component as individual rectangles pr. mono crystal
+* 
 *
 * %E
 *******************************************************************************/
 DEFINE COMPONENT Monochromator_bent
-SETTING PARAMETERS (zwidth = 0.2,
-					yheight = 0.1,
-					xthickness = 0.0005,
-					radius_x = 2,
-					string plane_of_reflection = "Si400",
-					angle_to_cut_horizontal = 0,
-					angle_to_cut_vertical = 0,
-					mosaicity = 30,
-					int n_crystals = 1,
-					mosaic_anisotropy = 1,
-					domainthickness = 10,
-					temperature = 300,
-					int optimize = 1,
-					vector x_pos = NULL,// x-Position of each lamella
-					vector y_pos = NULL,// y-Position of each lamella
-					vector z_pos = NULL,// z-Position of each lamella
-					vector x_rot = NULL, // Rotation around x-axis
-					vector y_rot = NULL, // Rotation around y-axis
-					vector z_rot = NULL, // Rotation around z-axis
-					int verbose = 0,
+SETTING PARAMETERS (zwidth=0.2,
+					yheight=0.1,
+					xthickness=0.0005,
+					radius_x=2,
+					string plane_of_reflection="Si400",
+					angle_to_cut_horizontal=0,
+					angle_to_cut_vertical=0,
+					mosaicity=30,
+					int n_crystals=1,
+					mosaic_anisotropy=1,
+					domainthickness=10,
+					temperature=300,
+					int optimize=1,
+					vector x_pos=NULL,
+					vector y_pos=NULL,
+					vector z_pos=NULL,
+					vector x_rot=NULL,
+					vector y_rot=NULL,
+					vector z_rot=NULL,
+					int verbose=0,
 					int draw_as_rectangles=0)
 // Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) 
 NOACC

--- a/mcstas-comps/examples/ILL/ILL_SALSA/ILL_SALSA.instr
+++ b/mcstas-comps/examples/ILL/ILL_SALSA/ILL_SALSA.instr
@@ -2293,7 +2293,7 @@ ROTATED (0,0,-2.5334840861792602) RELATIVE arm_mono
 COMPONENT Monochromator_0 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_0
 GROUP monochromator_array
@@ -2301,7 +2301,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_1 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_1
 GROUP monochromator_array
@@ -2309,7 +2309,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_2 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_2
 GROUP monochromator_array
@@ -2317,7 +2317,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_3 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_3
 GROUP monochromator_array
@@ -2325,7 +2325,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_4 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_4
 GROUP monochromator_array
@@ -2333,7 +2333,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_5 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_5
 GROUP monochromator_array
@@ -2341,7 +2341,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_6 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_6
 GROUP monochromator_array
@@ -2349,7 +2349,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_7 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_7
 GROUP monochromator_array
@@ -2357,7 +2357,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_8 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_8
 GROUP monochromator_array
@@ -2365,7 +2365,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_9 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_9
 GROUP monochromator_array
@@ -2373,7 +2373,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_10 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_10
 GROUP monochromator_array
@@ -2381,7 +2381,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_11 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_11
 GROUP monochromator_array
@@ -2389,7 +2389,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_12 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_12
 GROUP monochromator_array
@@ -2397,7 +2397,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_13 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_13
 GROUP monochromator_array
@@ -2405,7 +2405,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_14 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_14
 GROUP monochromator_array
@@ -2413,7 +2413,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_15 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_15
 GROUP monochromator_array
@@ -2421,7 +2421,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_16 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_16
 GROUP monochromator_array
@@ -2429,7 +2429,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_17 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_17
 GROUP monochromator_array
@@ -2437,7 +2437,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_18 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_18
 GROUP monochromator_array
@@ -2445,7 +2445,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_19 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_19
 GROUP monochromator_array
@@ -2453,7 +2453,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_20 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_20
 GROUP monochromator_array
@@ -2461,7 +2461,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_21 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_21
 GROUP monochromator_array
@@ -2469,7 +2469,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_22 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_22
 GROUP monochromator_array
@@ -2477,7 +2477,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_23 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_23
 GROUP monochromator_array
@@ -2485,7 +2485,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_24 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_24
 GROUP monochromator_array
@@ -2493,7 +2493,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_25 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_25
 GROUP monochromator_array
@@ -2501,7 +2501,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_26 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_26
 GROUP monochromator_array
@@ -2509,7 +2509,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_27 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_27
 GROUP monochromator_array
@@ -2517,7 +2517,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_28 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_28
 GROUP monochromator_array
@@ -2525,7 +2525,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_29 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_29
 GROUP monochromator_array
@@ -2533,7 +2533,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_30 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_30
 GROUP monochromator_array
@@ -2541,7 +2541,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_31 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_31
 GROUP monochromator_array
@@ -2549,7 +2549,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_32 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_32
 GROUP monochromator_array
@@ -2557,7 +2557,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_33 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_33
 GROUP monochromator_array
@@ -2565,7 +2565,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_34 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_34
 GROUP monochromator_array
@@ -2573,7 +2573,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_35 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_35
 GROUP monochromator_array
@@ -2581,7 +2581,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_36 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_36
 GROUP monochromator_array
@@ -2589,7 +2589,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_37 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_37
 GROUP monochromator_array
@@ -2597,7 +2597,7 @@ GROUP monochromator_array
 COMPONENT Monochromator_38 = Monochromator_bent(
  mosaicity=0, zwidth = 0.178, yheight = 0.005,
  xthickness = 0.0005, radius_x = monochromator_horizontal_radius,
- lamella_slabs = 16, lamella_gap_size = 0.00025,
+ n_crystals = 16,
  plane_of_reflection = "Si400")
 AT (-2.2,0,0) RELATIVE arm_mono_38
 GROUP monochromator_array

--- a/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent/Test_Monochromator_bent.instr
+++ b/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent/Test_Monochromator_bent.instr
@@ -72,7 +72,7 @@ ROTATED (0,mono_rotation,0) RELATIVE Source
 COMPONENT Monochromator = Monochromator_bent(
  zwidth = 0.07, yheight = 0.012,
  xthickness = 0.008, radius_x = 10,
- lamella_slabs = 1, lamella_gap_size = 0.0001,
+ n_crystals = 1,
  plane_of_reflection = "Ge511", angle_to_cut_horizontal = -19.47,
  angle_to_cut_vertical = 0, mosaicity=mono_mos)
 AT (0,0,0) RELATIVE monochromator_arm


### PR DESCRIPTION
@Lomholy I've rectified the component header and parameter this two allow producing a working mcdoc page:

(Steps to produce yourself: Copy component in place in `$MCSTAS/contrib`; run `mcdoc -i` to build the html pages; `mcdoc bent` and follow the right link in your browser.)

![Screenshot 2025-06-10 at 10 42 49](https://github.com/user-attachments/assets/8bb5c6ac-cc62-45cd-bd90-9db940282553)

Please also ensure that the changes I did on the two related instrument files are right: lamella_slabs -> n_crystals and lamella_gap_size no longer used