### PR TITLE
Add ADR doc folder for proposed, accepted, rejected, deprecated, superseded changes of McCode GRAMMAR

### DIFF
--- a/doc/GRAMMAR-ADR-records/README.md
+++ b/doc/GRAMMAR-ADR-records/README.md
@@ -5,3 +5,5 @@ Please document any (proposed, accepted, rejected, deprecated, superseded) chang
 
 1. `cp template.md ADR_20250612_INHERIT_COMP.md`
 2. Edit the resulting file documenting the (proposed, accepted, rejected, deprecated, superseded) change
+3. Please link to associated PR's, issues etc.
+4. Update status along with edited files

--- a/doc/GRAMMAR-ADR-records/README.md
+++ b/doc/GRAMMAR-ADR-records/README.md
@@ -1,0 +1,7 @@
+# ADR records for McCode grammar changes
+This folder contains *Architectural Design Records*, associated with changes in the McCode GRAMMAR (i.e. accepted syntax, keywords and behaviour of the McCode comp/instrument grammar).
+
+Please document any (proposed, accepted, rejected, deprecated, superseded) change of the grammar by use of the template, adding relevant date and descriptive label
+
+1. `cp template.md ADR_20250612_INHERIT_COMP.md`
+2. Edit the resulting file documenting the (proposed, accepted, rejected, deprecated, superseded) change

--- a/doc/GRAMMAR-ADR-records/template.md
+++ b/doc/GRAMMAR-ADR-records/template.md
@@ -1,0 +1,24 @@
+# Decision record template by Michael Nygard
+
+This is the template in [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+You can use [adr-tools](https://github.com/npryce/adr-tools) for managing the ADR files.
+
+In each ADR file, write these sections:
+
+# Title
+
+## Status
+
+What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.?
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION
As discussed in zoom meeting on June 11th by @farhi, @g5t, @mads-bertelsen, @willend - hereby the introduction of a folder to hold ADR (*Architectural Design Records*) documents relating to the McCode GRAMMAR.

There are tools available for the editing of such records, but for now I think we can make do with simple file edits.