### PR TITLE
[Add] repository dispatch action to notify tag changes in registries

### DIFF
--- a/.github/workflows/mccode-pooch-registries-dispatch.yml
+++ b/.github/workflows/mccode-pooch-registries-dispatch.yml
@@ -1,0 +1,34 @@
+name: McCode Pooch Registries Dispatch
+on:
+  create:
+  delete:
+
+jobs:
+  dispatch:
+    if: github.event.ref_type == 'tag'
+    name: Dispatch tag
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['mccode-dev/mccode-pooch-registries']
+    timeout-minutes: 5
+    steps:
+      - name: Construct creation payload
+        shell: bash
+        run: |
+          echo "${GITHUB_EVENT_NAME}"
+          REMOVE=$([ "${GITHUB_EVENT_NAME}" == "delete" ] && echo "1" || echo "0" )
+          echo "REMOVE=${REMOVE}" >> "${GITHUB_ENV}"
+          echo "TAG=${{ github.event.ref }}" >> "${GITHUB_ENV}"
+        
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RECEIVER_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: update_tag
+          client-payload: |-
+            {
+              "remove": "${{ env.REMOVE }}",
+              "tag": "${{ env.TAG }}"
+            }


### PR DESCRIPTION
The added workflow will only run on creation or deletion of branches and tags, and will be skipped for branches.
If a tag is pushed or deleted a message is sent to [mccode-pooch-registries](https://github.com/mccode-dev/mccode-pooch-registries) which causes a workflow action there to update its tagged registry files.

This should allow for closer synchronization between `McCode` releases and `mccode-antlr`.