### PR TITLE
Prepare to release 3.5.32

### DIFF
--- a/CHANGES_McStas
+++ b/CHANGES_McStas
@@ -91,6 +91,7 @@ Changes in McStas/McXtrace 3.5.32, June 17th, 2025
     * Edits by @farhi and @willend in https://github.com/mccode-dev/McCode/pull/2062
     * Add ADR (Architectural Design Record) doc folder for proposed, accepted, rejected, deprecated, superseded changes of McCode GRAMMAR by @willend in https://github.com/mccode-dev/McCode/pull/2064
     * Put in place folder for grammar documentation by @willend in https://github.com/mccode-dev/McCode/pull/2070
+  * The McStas/McXtrace code generators have a new commandline switch --version-num to print the version number only.
 
 * New CLI default for mcstas / mcxtrace: --trace is on
   * This allows any compiled instrument to run with --trace=0 by @willend in https://github.com/mccode-dev/McCode/pull/2010 and https://github.com/mccode-dev/McCode/pull/2023

--- a/CHANGES_McStas
+++ b/CHANGES_McStas
@@ -57,13 +57,13 @@
 * Modified by: PW February 2025: version 3.5.24
 * Modified by: PW February 2025: version 3.5.24
 * Modified by: PW April 2025: version 3.5.27
-* Modified by: PW June 2025: version 3.5.31
+* Modified by: PW June 2025: version 3.5.32
 *
-* This file is part of McStas 3.5.31, released April 29th 2025.
+* This file is part of McStas 3.5.32, released April 29th 2025.
 * It gives a 'changes' list from the beginning of the project
 *
 *******************************************************************************/
-Changes in McStas/McXtrace 3.5.31, June 16th, 2025
+Changes in McStas/McXtrace 3.5.32, June 17th, 2025
 ## What's Changed
 ### Common changes to McStas and McXtrace
 * Deployment, platforms and CI
@@ -136,7 +136,7 @@ Changes in McStas/McXtrace 3.5.31, June 16th, 2025
 * cif2hkl: update to solve F^2 for Xrays using latest CrysFML by @farhi in https://github.com/mccode-dev/McCode/pull/2021
 * McXtrace: add SWING BL at SOLEIL by @farhi in https://github.com/mccode-dev/McCode/pull/2036
 
-**Full Changelog**: https://github.com/mccode-dev/McCode/compare/v3.5.27...v3.5.31
+**Full Changelog**: https://github.com/mccode-dev/McCode/compare/v3.5.27...v3.5.32
 
 
 Changes in McStas/McXtrace 3.5.27, April 29th, 2025

--- a/CHANGES_McXtrace
+++ b/CHANGES_McXtrace
@@ -43,6 +43,7 @@ Changes in McStas/McXtrace 3.5.31, June 17th, 2025
     * Edits by @farhi and @willend in https://github.com/mccode-dev/McCode/pull/2062
     * Add ADR (Architectural Design Record) doc folder for proposed, accepted, rejected, deprecated, superseded changes of McCode GRAMMAR by @willend in https://github.com/mccode-dev/McCode/pull/2064
     * Put in place folder for grammar documentation by @willend in https://github.com/mccode-dev/McCode/pull/2070
+  * The McStas/McXtrace code generators have a new commandline switch --version-num to print the version number only.
 
 * New CLI default for mcstas / mcxtrace: --trace is on
   * This allows any compiled instrument to run with --trace=0 by @willend in https://github.com/mccode-dev/McCode/pull/2010 and https://github.com/mccode-dev/McCode/pull/2023

--- a/CHANGES_McXtrace
+++ b/CHANGES_McXtrace
@@ -15,7 +15,7 @@
 *
 * Documentation: CHANGES_McXtrace
 *************************************************************************/
-Changes in McStas/McXtrace 3.5.31, June 16th, 2025
+Changes in McStas/McXtrace 3.5.31, June 17th, 2025
 ## What's Changed
 ### Common changes to McStas and McXtrace
 * Deployment, platforms and CI
@@ -88,7 +88,7 @@ Changes in McStas/McXtrace 3.5.31, June 16th, 2025
 * cif2hkl: update to solve F^2 for Xrays using latest CrysFML by @farhi in https://github.com/mccode-dev/McCode/pull/2021
 * McXtrace: add SWING BL at SOLEIL by @farhi in https://github.com/mccode-dev/McCode/pull/2036
 
-**Full Changelog**: https://github.com/mccode-dev/McCode/compare/v3.5.27...v3.5.31
+**Full Changelog**: https://github.com/mccode-dev/McCode/compare/v3.5.27...v3.5.32
 
 
 Changes in McStas/McXtrace 3.5.27, April 29th, 2025

--- a/INSTALL-McStas/Docker/README.md
+++ b/INSTALL-McStas/Docker/README.md
@@ -1,4 +1,4 @@
-# Running McStas and McXtrace 3.5.31 in Docker / podman etc.
+# Running McStas and McXtrace 3.5.32 in Docker / podman etc.
 
 The container definition is available at [here](https://github.com/willend/jupyter-remote-desktop-proxy/tree/mcstas-mcxtrace-3.5) and is further on dockerhub under docker.io/mccode/mcstas-mcxtrace
 

--- a/INSTALL-McStas/Linux/README.md
+++ b/INSTALL-McStas/Linux/README.md
@@ -1,4 +1,4 @@
-# Install McStas 3.5.31 on Linux and Unix.
+# Install McStas 3.5.32 on Linux and Unix.
 
 * We provide Debian packages, RedHat packages, and tar.gz's of "preconfigured" source code.
 

--- a/INSTALL-McStas/Linux/debian/README.md
+++ b/INSTALL-McStas/Linux/debian/README.md
@@ -1,4 +1,4 @@
-## Install McStas 3.5.31 On Debian class systems (including Ubuntu, mint etc.):
+## Install McStas 3.5.32 On Debian class systems (including Ubuntu, mint etc.):
 The packages have been tested to work correctly on Ubuntu 24.04.
 
 # Add the McCode repository
@@ -29,7 +29,7 @@ mcstas-tools-python-mcplot-pyqtgraph - python-tools-mcplot-pyqtgraph built using
 mcstas-tools-python-mcrun - python-tools-mcrun built using CMake
 ```
 The meta-package mcstas-suite-python (or mcstas-suite-python-ng)
-allows you to install mcstas 3.5.31 with tools (mcrun/mcplot etc.) by
+allows you to install mcstas 3.5.32 with tools (mcrun/mcplot etc.) by
 the simple apt-get command
 ```bash
 sudo apt-get install mcstas-suite-python

--- a/INSTALL-McStas/README.md
+++ b/INSTALL-McStas/README.md
@@ -1,4 +1,4 @@
-# Installation instructions for McStas 3.5.31
+# Installation instructions for McStas 3.5.32
 
 Please consult the individual platform instructions:
 

--- a/INSTALL-McStas/Windows/README.md
+++ b/INSTALL-McStas/Windows/README.md
@@ -1,4 +1,4 @@
-# Installation of McStas 3.5.31 on Windows 64 bit Intel systems (some support for arm64)
+# Installation of McStas 3.5.32 on Windows 64 bit Intel systems (some support for arm64)
 ## *IMPORTANT: active internet connection required during installation*
 
 * Please use either of:
@@ -8,7 +8,7 @@
     * Once install has completed, please use the `mcstas-shell` shortcut on the desktop - issue terminal command `mcgui` to start the McStas GUI. 
     * Option 1 *may* function `arm64` Windows, but will require installation of Visual Studio including both arm64 and x64_64 build tools for c++.
   2. **Legacy:**
-    * install the legacy-style MinGW based [McStas 3.5.31 metapackage](https://download.mcstas.org/mcstas-3.5.31/Windows/McStas-Metapackage-3.5.31-win64.exe) - now includes MCPL. 
+    * install the legacy-style MinGW based [McStas 3.5.32 metapackage](https://download.mcstas.org/mcstas-3.5.32/Windows/McStas-Metapackage-3.5.32-win64.exe) - now includes MCPL. 
     * Option 2 should be fully functional on `arm64` processors.
   3. **WSL:**
     * Use the directions available in [WSL](WSL/README.md) to install the "Windows subsystem for Linux" and run the Linux Debian binaries there. 

--- a/INSTALL-McStas/Windows/WSL/README.md
+++ b/INSTALL-McStas/Windows/WSL/README.md
@@ -1,4 +1,4 @@
-# Installation of McStas 3.5.31 on Windows 64 bit systems - using WSL
+# Installation of McStas 3.5.32 on Windows 64 bit systems - using WSL
 *(WSL is the Windows Subsystem for Linux, aka. bash on Ubuntu on Windows)*
 
 
@@ -11,7 +11,7 @@ available, but we recommend Ubuntu)
 * To open it again later, simply issue bash in a terminal or through
 the start menu
 
-## Install the McStas 3.5.31 Debian packages
+## Install the McStas 3.5.32 Debian packages
 * Follow the
   [normal Debian installation instructions](../../Linux/debian/README.md)
   - essentially a matter of sudo apt-get install mcstas-suite-python

--- a/INSTALL-McStas/conda/README.md
+++ b/INSTALL-McStas/conda/README.md
@@ -1,6 +1,6 @@
-# Install McStas 3.5.31 through conda-forge (macOS, Linux or Windows host)
+# Install McStas 3.5.32 through conda-forge (macOS, Linux or Windows host)
 
-* We a set of conda-packages for installing McStas 3.5.31.x through conda
+* We a set of conda-packages for installing McStas 3.5.32.x through conda
 
 ## Get yourself a conda / mamba
 Due to the complex [licensing situation](https://discuss.scientific-python.org/t/response-to-anaconda-switch-to-paid-plans/1395) with the commercial Anaconda ecosystem, we clearly recommend McStas users to start from an open-source entry-point such as

--- a/INSTALL-McStas/macOS/README.md
+++ b/INSTALL-McStas/macOS/README.md
@@ -1,4 +1,4 @@
-# Installation of McStas 3.5.31 on macOS 
+# Installation of McStas 3.5.32 on macOS 
 
 ## Supported macOS releases
 * macOS 11-15 (Big Sur and later, fully supported python tool set. Supported on both Intel and Apple Silicon,
@@ -7,16 +7,16 @@
 ## Steps to perform
 
 * Download the package:
-  [McStas 3.5.31 for macOS](https://download.mcstas.org/mcstas-3.5.31/macOS/mcstas-3.5.31-macOS-conda.tar.gz)
+  [McStas 3.5.32 for macOS](https://download.mcstas.org/mcstas-3.5.32/macOS/mcstas-3.5.32-macOS-conda.tar.gz)
  and unpack it (e.g. double-clicking should work).
 
 * Open the relevant folder for your local processor
 
-* Drag the McStas-3.5.31.app to /Applications and right-click + open to start the app:<br/>
+* Drag the McStas-3.5.32.app to /Applications and right-click + open to start the app:<br/>
 ![](screenshots/1_open-mcstas-from-Applications.png?raw=true)
 
 * Depending on your macOS version, security settings may initially prevent the app from opening, example from macOS 15 Sequoia:
-  - Initial warning that "McStas-3.5.31" was not opened<br/>
+  - Initial warning that "McStas-3.5.32" was not opened<br/>
   ![](screenshots/2_mcstas-not-opened.png?raw=true)
   - Next, go to System Preferences, Privacy and Security and select to
   "Open Anyway"<br/>
@@ -26,9 +26,9 @@
   - And finally give your password for installation to proceed<br/>
   ![](screenshots/5_admin-password.png?raw=true)
 
-* :warning: In case the last warning still does not allow to open the application, you may issue the following command in a Terminal: `sudo xattr -dr com.apple.quarantine /Applications/McStas-3.5.31.app`
+* :warning: In case the last warning still does not allow to open the application, you may issue the following command in a Terminal: `sudo xattr -dr com.apple.quarantine /Applications/McStas-3.5.32.app`
 
-* McStas 3.5.31 macOS app bundless are fully based on conda-forge and will "self-inject" all dependencies on first launch. Please follow any on-screen instructions given.
+* McStas 3.5.32 macOS app bundless are fully based on conda-forge and will "self-inject" all dependencies on first launch. Please follow any on-screen instructions given.
   
 * In case you have trouble accessing instrument files in certain areas
   of your disk, please give the McStas bundle "Full Disk Access"

--- a/INSTALL-McXtrace/Docker/README.md
+++ b/INSTALL-McXtrace/Docker/README.md
@@ -1,4 +1,4 @@
-# Running McStas and McXtrace 3.5.31 in Docker / podman etc.
+# Running McStas and McXtrace 3.5.32 in Docker / podman etc.
 
 The container definition is available at [here](https://github.com/willend/jupyter-remote-desktop-proxy/tree/mcstas-mcxtrace-3.5) and is further on dockerhub under docker.io/mccode/mcstas-mcxtrace
 

--- a/INSTALL-McXtrace/Linux/README.md
+++ b/INSTALL-McXtrace/Linux/README.md
@@ -1,4 +1,4 @@
-# Install McXtrace 3.5.31 on Linux and Unix.
+# Install McXtrace 3.5.32 on Linux and Unix.
 
 * We provide Debian packages, RedHat packages, and tar.gz's of "preconfigured" source code.
 

--- a/INSTALL-McXtrace/Linux/debian/README.md
+++ b/INSTALL-McXtrace/Linux/debian/README.md
@@ -1,4 +1,4 @@
-## Install McXtrace 3.5.31 On Debian class systems (including Ubuntu, mint etc.):
+## Install McXtrace 3.5.32 On Debian class systems (including Ubuntu, mint etc.):
 The packages have been tested to work correctly on Ubuntu 24.04.
 
 # Add the McCode repository
@@ -28,7 +28,7 @@ mcxtrace-tools-python-mxplot-pyqtgraph - python-tools-mxplot-pyqtgraph built usi
 mcxtrace-tools-python-mxrun - python-tools-mxrun built using CMake
 ```
 The meta-package mcxtrace-suite-python (or mcxtrace-suite-python-ng)
-allows you to install mcxtrace 3.5.31 with tools (mcrun/mcplot etc.) by
+allows you to install mcxtrace 3.5.32 with tools (mcrun/mcplot etc.) by
 the simple apt-get command
 ```bash
 sudo apt-get install mcxtrace-suite-python

--- a/INSTALL-McXtrace/README.md
+++ b/INSTALL-McXtrace/README.md
@@ -1,4 +1,4 @@
-# Installation instructions for McXtrace 3.5.31
+# Installation instructions for McXtrace 3.5.32
 
 Please consult the individual platform instructions:
 

--- a/INSTALL-McXtrace/Windows/README.md
+++ b/INSTALL-McXtrace/Windows/README.md
@@ -1,4 +1,4 @@
-# Installation of McXtrace 3.5.31 on Windows 64 bit Intel systems (some support for arm64)
+# Installation of McXtrace 3.5.32 on Windows 64 bit Intel systems (some support for arm64)
 ## *IMPORTANT: active internet connection required during installation*
 
 * Please use either of:
@@ -8,7 +8,7 @@
     * Once install has completed, please use the `mcxtrace-shell` shortcut on the desktop - issue terminal command `mxgui` to start the McXtrace GUI. 
     * Option 1 *may* function `arm64` Windows, but will require installation of Visual Studio including both arm64 and x64_64 build tools for c++.
   2. **Legacy:**
-    * install the legacy-style MinGW based [McXtrace 3.5.31 metapackage](https://download.mcxtrace.org/mcxtrace-3.5.31/Windows/McXtrace-Metapackage-3.5.31-win64.exe) - now includes MCPL. 
+    * install the legacy-style MinGW based [McXtrace 3.5.32 metapackage](https://download.mcxtrace.org/mcxtrace-3.5.32/Windows/McXtrace-Metapackage-3.5.32-win64.exe) - now includes MCPL. 
     * Option 2 should be fully functional on `arm64` processors.
   3. **WSL:**
     * Use the directions available in [WSL](WSL/README.md) to install the "Windows subsystem for Linux" and run the Linux Debian binaries there.  

--- a/INSTALL-McXtrace/Windows/WSL/README.md
+++ b/INSTALL-McXtrace/Windows/WSL/README.md
@@ -1,4 +1,4 @@
-# Installation of McXtrace 3.5.31 on Windows 64 bit systems - using WSL
+# Installation of McXtrace 3.5.32 on Windows 64 bit systems - using WSL
 *(WSL is the Windows Subsystem for Linux, aka. bash on Ubuntu on Windows)*
 
 
@@ -11,7 +11,7 @@ available, but we recommend Ubuntu)
 * To open it again later, simply issue bash in a terminal or through
 the start menu
 
-## Install the McXtrace 3.5.31 Debian packages
+## Install the McXtrace 3.5.32 Debian packages
 * Follow the
   [normal Debian installation instructions](../../Linux/debian/README.md)
   - essentially a matter of sudo apt-get install mcxtrace-suite-python

--- a/INSTALL-McXtrace/conda/README.md
+++ b/INSTALL-McXtrace/conda/README.md
@@ -1,6 +1,6 @@
-# Install McXtrace 3.5.31 through conda-forge (macOS, Linux or Windows host)
+# Install McXtrace 3.5.32 through conda-forge (macOS, Linux or Windows host)
 
-* We a set of conda-packages for installing McXtrace 3.5.31.x through conda
+* We a set of conda-packages for installing McXtrace 3.5.32.x through conda
 
 ## Get yourself a conda / mamba
 Due to the complex [licensing situation](https://discuss.scientific-python.org/t/response-to-anaconda-switch-to-paid-plans/1395) with the commercial Anaconda ecosystem, we clearly recommend McXtrace users to start from an open-source entry-point such as

--- a/INSTALL-McXtrace/macOS/README.md
+++ b/INSTALL-McXtrace/macOS/README.md
@@ -1,4 +1,4 @@
-# Installation of McXtrace 3.5.31 on macOS 
+# Installation of McXtrace 3.5.32 on macOS 
 
 ## Supported macOS releases
 * macOS 11-15 (Big Sur and later, fully supported python tool set. Supported on both Intel and Apple Silicon,
@@ -7,16 +7,16 @@
 ## Steps to perform
 
 * Download the package:
-  [McXtrace 3.5.31 for macOS](https://download.mcxtrace.org/mcxtrace-3.5.31/macOS/mcxtrace-3.5.31-macOS-conda.tar.gz)
+  [McXtrace 3.5.32 for macOS](https://download.mcxtrace.org/mcxtrace-3.5.32/macOS/mcxtrace-3.5.32-macOS-conda.tar.gz)
  and unpack it (e.g. double-clicking should work).
 
 * Open the relevant folder for your local processor
 
-* Drag the McXtrace-3.5.31.app to /Applications and right-click + open to start the app:<br/>
+* Drag the McXtrace-3.5.32.app to /Applications and right-click + open to start the app:<br/>
 ![](screenshots/1_open-mcxtrace-from-Applications.png?raw=true)
 
 * Depending on your macOS version, security settings may initially prevent the app from opening, example from macOS 15 Sequoia:
-  - Initial warning that "McXtrace-3.5.31" was not opened<br/>
+  - Initial warning that "McXtrace-3.5.32" was not opened<br/>
   ![](screenshots/2_mcxtrace-not-opened.png?raw=true)
   - Next, go to System Preferences, Privacy and Security and select to
   "Open Anyway"<br/>
@@ -26,9 +26,9 @@
   - And finally give your password for installation to proceed<br/>
   ![](screenshots/5_admin-password.png?raw=true)
 
-* :warning: In case the last warning still does not allow to open the application, you may issue the following command in a Terminal: `sudo xattr -dr com.apple.quarantine /Applications/McXtrace-3.5.31.app`
+* :warning: In case the last warning still does not allow to open the application, you may issue the following command in a Terminal: `sudo xattr -dr com.apple.quarantine /Applications/McXtrace-3.5.32.app`
 
-* McXtrace 3.5.31 macOS app bundles are fully based on conda-forge and will "self-inject" all dependencies on first launch. Please follow any on-screen instructions given.
+* McXtrace 3.5.32 macOS app bundles are fully based on conda-forge and will "self-inject" all dependencies on first launch. Please follow any on-screen instructions given.
   
 * In case you have trouble accessing instrument files in certain areas
   of your disk, please give the McXtrace bundle "Full Disk Access"

--- a/mccode/src/instrument.y
+++ b/mccode/src/instrument.y
@@ -2149,7 +2149,8 @@ print_usage(void)
     "  %s [-o file] [-I dir1 ...] [-t] [-p] [-v] "
     "[--no-main] [--no-runtime] [--verbose] file\n", executable_name);
   fprintf(stderr, "      -o FILE --output-file=FILE Place " GENERATE_LANG " output in file FILE.\n");
-  fprintf(stderr, "      -v      --version          Prints " MCCODE_NAME " version.\n");
+  fprintf(stderr, "      -v      --version          Prints " MCCODE_NAME " full version header.\n");
+  fprintf(stderr, "              --version-num      Prints " MCCODE_NAME " version number only.\n");
   fprintf(stderr, "      --verbose                  Display compilation process steps.\n");
 #if defined(GENERATE_C)
   fprintf(stderr, "      -I DIR  --search-dir=DIR   Append DIR to the component search list. \n");
@@ -2191,9 +2192,12 @@ print_usage_error(void)
 
 /* Print McCode version and copyright. */
 static void
-print_version(void)
+print_version(char shrt)
 {
-  printf(MCCODE_NAME " code generator version " MCCODE_VERSION " (" MCCODE_DATE ")\n"
+  if (shrt)
+    printf(MCCODE_VERSION "\n");
+  else
+    printf(MCCODE_NAME " code generator version " MCCODE_VERSION " (" MCCODE_DATE ")\n"
     "Copyright (C) DTU Physics and Risoe National Laboratory, 1997-" MCCODE_YEAR "\n"
     "Additions (C) Institut Laue Langevin, 2003-2019\n"
     "All rights reserved\n\nComponents are (C) their authors, see component headers.\n");
@@ -2293,9 +2297,11 @@ parse_command_line(int argc, char *argv[])
       lint = 1;
 #endif
     else if(!strcmp("-v", argv[i]))
-      print_version();
+      print_version(0);
     else if(!strcmp("--version", argv[i]))
-      print_version();
+      print_version(0);
+    else if(!strcmp("--version-num", argv[i]))
+      print_version(1);
     else if(!strcmp("-h", argv[i]))
       { print_usage(); exit(0); }
     else if(!strcmp("--help", argv[i]))

--- a/mcstas-comps/misc/MCPL_output.comp
+++ b/mcstas-comps/misc/MCPL_output.comp
@@ -159,7 +159,7 @@ INITIALIZE
       fprintf(stderr,"\nWarning (%s): weight_mode unspecified so defaulting to 2"
               " (classic mode) which will soon become unavailable and tooling"
               " might need updating. Please consult"
-              " https://github.com/mccode-dev/McCode/discussions/9999 for more"
+              " https://github.com/mccode-dev/McCode/discussions/2076 for more"
               " information.\n",NAME_CURRENT_COMP);
     );
     weight_mode = 2;
@@ -167,7 +167,7 @@ INITIALIZE
     MPI_MASTER(
       fprintf(stderr,"\nWarning (%s): weight_mode=2 selected. This mode will"
               " soon become unavailable. Please consult"
-              " https://github.com/mccode-dev/McCode/discussions/9999 for more"
+              " https://github.com/mccode-dev/McCode/discussions/2076 for more"
               " information.\n",NAME_CURRENT_COMP);
     );
   }

--- a/mcxtrace-comps/misc/MCPL_output.comp
+++ b/mcxtrace-comps/misc/MCPL_output.comp
@@ -162,7 +162,7 @@ INITIALIZE
       fprintf(stderr,"\nWarning (%s): weight_mode unspecified so defaulting to 2"
               " (classic mode) which will soon become unavailable and tooling"
               " might need updating. Please consult"
-              " https://github.com/mccode-dev/McCode/discussions/9999 for more"
+              " https://github.com/mccode-dev/McCode/discussions/2076 for more"
               " information.\n",NAME_CURRENT_COMP);
     );
     weight_mode = 2;
@@ -170,7 +170,7 @@ INITIALIZE
     MPI_MASTER(
       fprintf(stderr,"\nWarning (%s): weight_mode=2 selected. This mode will"
               " soon become unavailable. Please consult"
-              " https://github.com/mccode-dev/McCode/discussions/9999 for more"
+              " https://github.com/mccode-dev/McCode/discussions/2076 for more"
               " information.\n",NAME_CURRENT_COMP);
     );
   }


### PR DESCRIPTION
* Fixes https://github.com/mccode-dev/McCode/issues/2075
* Adds new CLI parameter `--version-num` to `mcstas`/`mcxtrace` binary, prints the bare version number