### PR TITLE
Fix for ppc64 Linux (via conda)

### DIFF
--- a/cmake/Modules/PlatformDefaults.cmake
+++ b/cmake/Modules/PlatformDefaults.cmake
@@ -249,7 +249,7 @@ function( detect_platform_variables resultvarname )
     set( MCCODE_CFLAGS "${MCCODE_CFLAGS} -I\$\{CONDA_PREFIX\}/include -Wl,-rpath,\$\{CONDA_PREFIX\}/lib -L\$\{CONDA_PREFIX\}/lib" )
   endif()
 
-  foreach( flag "-fno-PIC" "-fPIE" "-flto" "-O3" "-mtune=native" "-march=native" "-fno-math-errno" "-ftree-vectorize" "-g" "-DNDEBUG" "-D_POSIX_SOURCE" "-std=c99" "-lm" )
+  foreach( flag "-fno-PIC" "-fPIE" "-flto" "-O3" "-march=native" "-fno-math-errno" "-ftree-vectorize" "-g" "-DNDEBUG" "-D_POSIX_SOURCE" "-std=c99" "-lm" )
     #NB: plethora of "unset(tmp_test_c_flag_result ...)" statements below is
     #added for safety, to prevent CMake's CACHE system to give unpredictable
     #results.


### PR DESCRIPTION
Remove -mtune=native as (e.g. conda) usually has sets a reasonable local default (e.g. -mtune=haswell)

Should eventually rectify #2084 