### PR TITLE
Adding script for flexible+convenient creation of .yml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 3rdparty/
 Mambaforge-Linux-x86_64.sh
 
+#Python venv:
+/venv/

--- a/devel/bin/mccode-create-conda-yml
+++ b/devel/bin/mccode-create-conda-yml
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+import sys
+import pathlib
+import os
+
+def create_deplist( cfg ):
+    #Should in general reflect the dependencies listed in pkgs in the meta.yaml
+    #at conda-forge, although with minor differences (e.g. stdlib("c") is left
+    #out, and we might for simplicity not always use the exact same version
+    #constraints if it doesn't really matter in practice).
+    deps = []
+
+    #First build-time deps:
+    if cfg.include_buildtime_deps:
+        deps += ['cmake','c-compiler']
+        if cfg.is_unix:
+            deps += ['make','flex','bison']
+        if cfg.is_win:
+            deps += ['winflexbison','dirent']
+    if not cfg.include_runtime_deps:
+        return deps
+
+    #The rest are run-time deps:
+    deps += ['python','c-compiler','pyaml','numpy']
+    if cfg.is_unix:
+        deps += ['bash']
+    if cfg.is_win:
+        deps += ['mslex']
+    if cfg.include_mcgui:
+        deps += ['pyqt','qscintilla2']
+    if cfg.include_vis:
+        deps += ['matplotlib',
+                 'tornado >=5',
+                 'scipy','pillow','pyqtgraph','pyqt >=5.10','qtpy',
+                 'nodejs','ply','jinja2',
+                 'mcstasscript','jupytext','jupyterlab' ]
+        if cfg.is_unix:
+            deps += ['rsync']
+        if cfg.is_win:
+            deps += ['m2-which','m2-sed','m2-gzip']
+    if cfg.include_toplevel_extras:
+        deps += ['gsl','libnexus','nexpy','cif2hkl','mcpl','mcpl-extra']
+        if cfg.is_mcstas:
+            deps += ['ncrystal']
+        if cfg.is_mcxtrace:
+            deps += ['xraylib']
+        if cfg.is_linux:
+            deps += ['ucx']
+    if cfg.include_mpi:
+        if cfg.is_unix:
+            deps += ['openmpi =4']
+        if cfg.is_win:
+            deps += ['msmpi']
+    return deps
+
+def parse_args( argv ):
+    from argparse import ArgumentParser as AP
+    parser = AP( prog = os.path.basename(argv[0]),
+                 description=('Create conda environment (.yml) file for'
+                              ' McStas or McXtrace.') )
+    parser.add_argument('-m','--mode', choices=['mcstas', 'mcxtrace'],
+                        default='mcstas',
+                        help='Choose McStas or McXtrace mode (default: mcstas)')
+    parser.add_argument('-p','--platform', choices=['win', 'linux', 'mac'],
+                        default=None,
+                        help=('Generate dependencies for specific platform'
+                              ' (default: current platform)'))
+    parser.add_argument('-o','--outfile',type=str,metavar='FILE',
+                        default='stdout',
+                        help='Output destination (defaults to stdout)')
+    parser.add_argument('-f','--force', action='store_true',
+                        help='Allow overwriting existing output file')
+    default_envname = 'myenv'
+    parser.add_argument('-n','--name',type=str,metavar='NAME',
+                        default=default_envname,
+                        help=('Conda environment name in produced YAML'
+                              f' (default: "{default_envname}")'))
+    parser.add_argument('--nompi', action='store_true',
+                        help='Never include dependencies only needed for MPI')
+    parser.add_argument('--novis', action='store_true',
+                        help='Never include dependencies only needed for visualisation')
+    parser.add_argument('--nomcgui', action='store_true',
+                        help='Never include dependencies only needed for mcgui')
+    parser.add_argument('--nographics', action='store_true',
+                        help='Implies both --novis and --nomcgui')
+    parser.add_argument('--buildonly', action='store_true',
+                        help=('Only include dependencies needed to build'
+                              ' McStas/McXtrace itself'))
+    parser.add_argument('--runonly', action='store_true',
+                        help=('Only include dependencies needed when'
+                              ' using McStas/McXtrace'))
+    parser.add_argument('--noextras', action='store_true',
+                        help=('Do not include optional dependencies needed'
+                              ' only for certain instruments.'))
+
+    args = parser.parse_args(argv[1:])
+
+    if args.buildonly and args.runonly:
+        parser.error('Do not specify both --buildonly and --runonly')
+    if not args.platform:
+        args.platform = autodetect_platform()
+
+    if args.nographics:
+        args.novis = True
+        args.nomcgui = True
+    if args.outfile!='stdout':
+        p = pathlib.Path(args.outfile)
+        if not args.force and p.exists():
+            parser.error(f'File already exists (use --force to overwrite): {p}')
+        elif not p.parent.is_dir():
+            parser.error(f'Directory not found: {p.parent}')
+        args.outfile=p.resolve().absolute()
+    else:
+        args.outfile = None
+    return args
+
+def autodetect_platform():
+    import platform
+    return {'Windows':'win',
+            'Darwin':'mac',
+            'Linux':'linux'}[platform.system()]
+
+def create_cfg( args ):
+    class Cfg:
+        is_mcstas = ( args.mode=='mcstas' )
+        is_mcxtrace = not is_mcstas
+        is_win   = ( args.platform=='win' )
+        is_linux = ( args.platform=='linux' )
+        is_mac   = ( args.platform=='mac' )
+        is_unix  = ( is_linux or is_mac )
+        include_mpi   = not args.nompi
+        include_mcgui = not args.nomcgui
+        include_vis   = not args.novis
+        include_buildtime_deps = not args.runonly
+        include_runtime_deps = not args.buildonly
+        include_toplevel_extras = not args.noextras
+    return Cfg()
+
+def generate_output( env_name, deplist ):
+    out=f'''name: {env_name}
+channels:
+  - nodefaults
+  - conda-forge
+dependencies:
+'''
+    seen = set()#prevent duplicates
+    for d in deplist:
+        if d not in seen:
+            seen.add(d)
+            out += f'  - {d}\n'
+    return out
+
+def main():
+    args = parse_args( sys.argv )
+    cfg = create_cfg( args )
+    deplist = create_deplist( cfg )
+    o = generate_output(
+        env_name = args.name,
+        deplist = deplist
+    )
+    if not args.outfile:
+        print(o,end='')
+    else:
+        args.outfile.write_text(o)
+
+if __name__=='__main__':
+    main()


### PR DESCRIPTION
Adding a script for creation conda .yml files that might be needed by developers or in various workflows. 

This started with a discussion with a @willend yesterday, in order to reduce code duplication in various workflows.

Example usage:

```
$> ./devel/bin/mccode-create-conda-yml -h
usage: mccode-create-conda-yml [-h] [-m {mcstas,mcxtrace}] [-p {win,linux,mac}] [-o FILE] [-f] [-n NAME] [--nompi] [--novis] [--nomcgui] [--nographics] [--buildonly] [--runonly]
                               [--noextras]

Create conda environment (.yml) file for McStas or McXtrace.

options:
  -h, --help            show this help message and exit
  -m {mcstas,mcxtrace}, --mode {mcstas,mcxtrace}
                        Choose McStas or McXtrace mode (default: mcstas)
  -p {win,linux,mac}, --platform {win,linux,mac}
                        Generate dependencies for specific platform (default: current platform)
  -o FILE, --outfile FILE
                        Output destination (defaults to stdout)
  -f, --force           Allow overwriting existing output file
  -n NAME, --name NAME  Conda environment name in produced YAML (default: "myenv")
  --nompi               Never include dependencies only needed for MPI
  --novis               Never include dependencies only needed for visualisation
  --nomcgui             Never include dependencies only needed for mcgui
  --nographics          Implies both --novis and --nomcgui
  --buildonly           Only include dependencies needed to build McStas/McXtrace itself
  --runonly             Only include dependencies needed when using McStas/McXtrace
  --noextras            Do not include optional dependencies needed only for certain instruments.
```
```
$> ./devel/bin/mccode-create-conda-yml 
name: myenv
channels:
  - nodefaults
  - conda-forge
dependencies:
  - cmake
  - c-compiler
  - make
  - flex
  - bison
  - python
  - pyaml
  - numpy
  - bash
  - pyqt
  - qscintilla2
  - matplotlib
  - tornado >=5
  - scipy
  - pillow
  - pyqtgraph
  - pyqt >=5.10
  - qtpy
  - nodejs
  - ply
  - jinja2
  - mcstasscript
  - jupytext
  - jupyterlab
  - rsync
  - gsl
  - libnexus
  - nexpy
  - cif2hkl
  - mcpl
  - mcpl-extra
  - ncrystal
  - ucx
  - openmpi =4
```
```
$> ./devel/bin/mccode-create-conda-yml  --nographics -p win
name: myenv
channels:
  - nodefaults
  - conda-forge
dependencies:
  - cmake
  - c-compiler
  - winflexbison
  - dirent
  - python
  - pyaml
  - numpy
  - mslex
  - gsl
  - libnexus
  - nexpy
  - cif2hkl
  - mcpl
  - mcpl-extra
  - ncrystal
  - msmpi
```
Going forward, dependency changes in the conda-forge meta.yaml files should be kept synchronised with the functionality of this script. It is all done in a single function at the top of the script:
```py
def create_deplist( cfg ):
    #Should in general reflect the dependencies listed in pkgs in the meta.yaml
    #at conda-forge, although with minor differences (e.g. stdlib("c") is left
    #out, and we might for simplicity not always use the exact same version
    #constraints if it doesn't really matter in practice).
    deps = []

    #First build-time deps:
    if cfg.include_buildtime_deps:
        deps += ['cmake','c-compiler']
        if cfg.is_unix:
            deps += ['make','flex','bison']
        if cfg.is_win:
            deps += ['winflexbison','dirent']
    if not cfg.include_runtime_deps:
        return deps

    #The rest are run-time deps:
    deps += ['python','c-compiler','pyaml','numpy']
    if cfg.is_unix:
        deps += ['bash']
    if cfg.is_win:
        deps += ['mslex']
    if cfg.include_mcgui:
        deps += ['pyqt','qscintilla2']
    if cfg.include_vis:
        deps += ['matplotlib',
                 'tornado >=5',
                 'scipy','pillow','pyqtgraph','pyqt >=5.10','qtpy',
                 'nodejs','ply','jinja2',
                 'mcstasscript','jupytext','jupyterlab' ]
        if cfg.is_unix:
            deps += ['rsync']
        if cfg.is_win:
            deps += ['m2-which','m2-sed','m2-gzip']
    if cfg.include_toplevel_extras:
        deps += ['gsl','libnexus','nexpy','cif2hkl','mcpl','mcpl-extra']
        if cfg.is_mcstas:
            deps += ['ncrystal']
        if cfg.is_mcxtrace:
            deps += ['xraylib']
        if cfg.is_linux:
            deps += ['ucx']
    if cfg.include_mpi:
        if cfg.is_unix:
            deps += ['openmpi =4']
        if cfg.is_win:
            deps += ['msmpi']
    return deps
```

