### PR TITLE
Remove workaround for NVHPC issue, now fixed by NVIDIA

### DIFF
--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -52,11 +52,6 @@
 #include <inttypes.h>
 #include <stdint.h>
 #ifdef OPENACC
-/* Temporary workaround for issue with cabs() in newer NVHPC, see
-https://forums.developer.nvidia.com/t/compilation-issue-with-nvc-version-24-09-and-newer-openacc/331987
- */
-#include <complex.h>
-#define cabs(z) hypot(creal(z), cimag(z))
 #include <openacc.h>
 #ifndef GCCOFFLOAD
 #include <accelmath.h>

--- a/tools/Python/mctest/mcstas-test/McStas_8GPU/mccode_config.json
+++ b/tools/Python/mctest/mcstas-test/McStas_8GPU/mccode_config.json
@@ -20,7 +20,7 @@
   "compilation": {
     "CFLAGS": "-g -lm -O2 -std=c99",
     "NEXUSFLAGS": "-Wl,-rpath,GETPATH(miniconda3/lib) -LGETPATH(miniconda3/lib) -DUSE_NEXUS -lNeXus -IGETPATH(miniconda3/include/nexus)",
-    "MPIFLAGS": "-DUSE_MPI -lmpi -Wl,-rpath,/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -L,/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -I/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/include",
+    "MPIFLAGS": "-DUSE_MPI -lmpi -Wl,-rpath,/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -L,/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -I/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/include",
     "OACCFLAGS": "-fast -Minfo=accel -acc=gpu -gpu=mem:managed -DOPENACC",
     "GSLFLAGS": "-Wl,-rpath,GETPATH(miniconda3/lib) -LGETPATH(miniconda3/lib) -lgsl -lgslcblas -IGETPATH(miniconda3/include)",
     "NCRYSTALFLAGS": "CMD(ncrystal-config --show buildflags)",
@@ -28,8 +28,8 @@
     "XRLFLAGS": "",
     "CC": "gcc",
     "OACC": "nvc",
-    "MPICC": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpicc",
-    "MPIRUN": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpirun",
+    "MPICC": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpicc",
+    "MPIRUN": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpirun",
     "MPINODES": "8"
   },
   "platform": {

--- a/tools/Python/mctest/mcxtrace-test/McXtrace_8GPU/mccode_config.json
+++ b/tools/Python/mctest/mcxtrace-test/McXtrace_8GPU/mccode_config.json
@@ -20,7 +20,7 @@
   "compilation": {
     "CFLAGS": "-g -lm -O2 -std=c99",
     "NEXUSFLAGS": "-Wl,-rpath,GETPATH(miniconda3/lib) -LGETPATH(miniconda3/lib) -DUSE_NEXUS -lNeXus -IGETPATH(miniconda3/include/nexus)",
-    "MPIFLAGS": "-DUSE_MPI -lmpi -Wl,-rpath,/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -L,/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -I/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/include",
+    "MPIFLAGS": "-DUSE_MPI -lmpi -Wl,-rpath,/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -L,/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/lib -I/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/include",
     "OACCFLAGS": "-fast -Minfo=accel -acc=gpu -gpu=mem:managed -DOPENACC",
     "GSLFLAGS": "-Wl,-rpath,GETPATH(miniconda3/lib) -LGETPATH(miniconda3/lib) -lgsl -lgslcblas -IGETPATH(miniconda3/include)",
     "NCRYSTALFLAGS": "",
@@ -28,8 +28,8 @@
     "XRLFLAGS": "-Wl,-rpath,GETPATH(miniconda3/lib) -LGETPATH(miniconda3/lib) -lxrl -IGETPATH(miniconda3/include)",
     "CC": "gcc",
     "OACC": "nvc",
-    "MPICC": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpicc",
-    "MPIRUN": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpirun",
+    "MPICC": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpicc",
+    "MPIRUN": "/opt/nvidia/hpc_sdk/Linux_x86_64/25.7/comm_libs/12.9/openmpi4/openmpi-4.1.5/bin/mpirun",
     "MPINODES": "8"
   },
   "platform": {


### PR DESCRIPTION
Fixed since v25.7 of NVHPC, see https://forums.developer.nvidia.com/t/compilation-issue-with-nvc-version-24-09-and-newer-openacc/331987/3

(PR includes update of in-repo config files for DTU 8xGPU box)