### PR TITLE
Minor fixes for recent contributions from Daniel Lomholt

### DIFF
--- a/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent_complex/Test_Monochromator_bent_complex.instr
+++ b/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent_complex/Test_Monochromator_bent_complex.instr
@@ -18,14 +18,14 @@
 * %D
 * Used as a test instrument to highlight Monochromator Bent complex's capabilities
 *
-* %Example: Test_Mono_bent_complex.instr mos=60 Detector: E_PSD_mon_end_I=0.000215194
+* %Example: Test_Monochromator_bent_complexx.instr mos=60 Detector: E_PSD_mon_end_I=0.000215194
 *
 * %P
 * Par1: [unit] Parameter1 description
 *
 * %E
 *******************************************************************************/
-DEFINE INSTRUMENT template_simple(
+DEFINE INSTRUMENT Test_Monochromator_bent_complex(
     double sample_x=0.005, 
     double sample_y=0.015, 
     double L0 = 1.38000,

--- a/mcstas-comps/examples/Tests_samples/Test_Incoherent_MS/Test_Incoherent_MS.instr
+++ b/mcstas-comps/examples/Tests_samples/Test_Incoherent_MS/Test_Incoherent_MS.instr
@@ -73,6 +73,7 @@ DECLARE
   double focus_w;
   double focus_h;
   int sample_case=0; // 0 = none, 1 = thin, 2 = thick
+  #pragma acc declare create(sample_case)
 %}
 
 /* The INITIALIZE section is executed when the simulation starts     */
@@ -99,7 +100,8 @@ INITIALIZE
     total_scattering=1;
   } else {
     fprintf(stderr,"ERROR: Sample case %s is not supported!\n",sample);
-  } 
+  }
+  #pragma acc update device(sample_case)
   
   if (total_scattering){
     focus_w = 0;


### PR DESCRIPTION
1. GPU-oriented fix to instrument file Test_Incoherent_MS.instr, all instrument-vars used in e.g. WHEN statements need to become global vars on the GPU (via #pragma acc statements)
2. Example instruments should preferably sit in their own example folder and have matching internal instrument name to the filename