### PR TITLE
Fixes for parameter quoting issues

### DIFF
--- a/tools/Python/mccodelib/mcdisplayutils.py
+++ b/tools/Python/mccodelib/mcdisplayutils.py
@@ -11,6 +11,11 @@ from .particleparser import ParticleBundleRayFactory, ParticleTraceParser
 from .fcparticleparser import FlowChartParticleTraceParser
 from . import mccode_config
 
+if not os.name == 'nt':
+    import shlex as lexer
+else:
+    import mslex as lexer
+
 class McDisplayReader(object):
     ''' High-level trace manager '''
     def __init__(self, instr=None, inspect=None, default=False, n=300, dir=None, debug=False, options=None, trace=1, **kwds):
@@ -26,10 +31,9 @@ class McDisplayReader(object):
         cmd = f"{mcruncmd} {instr} --no-output-files --trace={trace} --ncount={n}"
 
         if dir:
-            cmd = cmd + ' --dir=' + dir
-        if options is not None:
-            for option in options:
-                cmd = f"{cmd} {option}"
+            cmd = cmd + ' --dir=' + lexer.quote(dir)
+        if options:
+            cmd += ' ' + lexer.join(options)
         
         self.debug = debug
         self.count = n

--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -13,6 +13,12 @@ import time
 import re
 import pathlib
 import shutil
+
+if not os.name == 'nt':
+    import shlex as lexer
+else:
+    import mslex as lexer
+
 try:
     from PyQt6 import QtWidgets, QtCore
     from PyQt6.QtWidgets import QApplication, QWidget
@@ -421,9 +427,7 @@ class McGuiState(QtCore.QObject):
             runstr = runstr + ' --bufsiz=' + Bufsiz
 
         # parse instrument params
-        for p in params:
-            runstr = runstr + ' ' + p[0] + '=' + p[1]
-        
+        runstr += ' ' + lexer.join('%s=%s'%(p[0],p[1]) for p in params)
         print('Running: ' + runstr)
         
         # Add & for backgrounding on Unix systems

--- a/tools/Python/mcgui/viewclasses.py
+++ b/tools/Python/mcgui/viewclasses.py
@@ -804,7 +804,7 @@ class McStartSimDialog(QtWidgets.QDialog):
         params = []
         for w in self._wParams:
             p = []
-            p.append(str(w[0].text()).rstrip(':'))
+            p.append(str(w[0].text()).rstrip(':').strip())
             p.append(str(w[1].text()))
             params.append(p)
         

--- a/tools/Python/mcrun/mccode.py
+++ b/tools/Python/mcrun/mccode.py
@@ -67,7 +67,7 @@ class Process:
             args = []
         # Run executable as shell
         # command = [self.executable, *args]
-        command = self.executable + " " + " ".join(args)
+        command = self.executable + " " + lexer.join(args)
         LOG.debug(f'CMD: {command}')
         try:
             proc = run(command, shell=True, check=True, text=True, capture_output=pipe)


### PR DESCRIPTION
Fixes for parameter quoting, in particular to allow semicolons in NCrystal cfgstrings.

Fixes #1685.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun -c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun -c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun -c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [ ] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



