### PR TITLE
Make ./devel/bin/mccode-build-conda script work with no args or bld dir

### DIFF
--- a/devel/bin/mccode-build-conda
+++ b/devel/bin/mccode-build-conda
@@ -3,102 +3,134 @@ import sys
 import pathlib
 import os
 import subprocess
+import tempfile
+if not os.name == 'nt':
+    import shlex as lexer
+else:
+    import mslex as lexer
 
-def syscall( command ):
-    result = subprocess.run(
-        command,
-        stdout = subprocess.PIPE,
-        stderr = subprocess.PIPE,
-        universal_newlines = True,
-        shell=True)
-    return result
+def runcmd( cmd, capture_output = False ):
+    print()
+    print('LAUNCHING>>> %s'%lexer.join([str(e) for e in cmd]))
+    print()
+    rp = subprocess.run( cmd,
+                         capture_output = capture_output,
+                         check = True )
+    if not capture_output:
+        return
+    if rp.stderr:
+        print(rp.stderr)
+        raise SystemExit(1)
+    return rp.stdout
+
+def detect_reporoot():
+    reporoot = pathlib.Path(__file__).parent.parent.parent
+    if not reporoot.joinpath('CHANGES_McStas').is_file():
+        return None
+    return reporoot.absolute()
+
+def detect_condaprefix():
+    cp = os.environ.get('CONDA_PREFIX')
+    if cp:
+        cp = pathlib.Path(cp)
+    if not cp or not cp.joinpath('conda-meta').is_dir():
+        raise SystemExit('ERROR: Could not detect valid '
+                         'conda environment via $CONDA_PREFIX.')
+    return cp.absolute()
 
 def mccode_build_conda ( cfg ):
-    
+
     if ( cfg.is_mac ):
-        res=syscall("xcrun --sdk macosx --show-sdk-path")
-        os.environ["SDKROOT"] = res.stdout
+        os.environ["SDKROOT"] = runcmd(['xcrun','--sdk','macosx',
+                                        '--show-sdk-path'],
+                                       capture_output = True)
 
-    pathlib.Path(cfg.build_dir).mkdir(parents=True, exist_ok=True)
-    os.chdir(cfg.build_dir)
+    conda_prefix = detect_condaprefix()
 
-    CONDAPREFIX = str(pathlib.PurePosixPath(os.getenv('CONDA_PREFIX')))
-    
+    extra_args = []
     if ( cfg.is_unix ):
-        EXTRAARGS = '-DNEXUSLIB=' + CONDAPREFIX + '/lib  -DNEXUSINCLUDE=' + CONDAPREFIX + '/include/nexus'
+        nexus_incdir = conda_prefix.joinpath('include/nexus')
+        nexus_libdir = conda_prefix.joinpath('lib')
+        if nexus_libdir.is_dir():
+            extra_args.append( f'-DNEXUSLIB={nexus_libdir}' )
+        if nexus_incdir.is_dir():
+            extra_args.append( f'-DNEXUSINCLUDE={nexus_incdir}' )
         GENERATOR = 'Unix Makefiles'
 
     if ( cfg.is_win ):
-        EXTRAARGS = '-DMPILIB=msmpi.lib'
+        extra_args = ['-DMPILIB=msmpi.lib']
         GENERATOR = 'NMake Makefiles'
 
-    cmd = 'cmake '
-    cmd += '-DCMAKE_INSTALL_PREFIX=' + CONDAPREFIX + ' '
-    cmd += '-S '+ cfg.src_dir +' '
-    cmd += '-DMCVERSION="'+ cfg.version +'" '
-    cmd += '-DMCCODE_BUILD_CONDA_PKG=ON '
-    cmd += '-DBUILD_SHARED_LIBS=ON '
-    cmd += '-DCMAKE_INSTALL_LIBDIR=lib '
-    cmd += '-DCMAKE_BUILD_TYPE=Release '
-    if ( cfg.is_mcstas ):
-        cmd += '-DBUILD_MCSTAS=ON '
+    cmd = ['cmake',
+           f'-DCMAKE_INSTALL_PREFIX={conda_prefix}',
+           '-S', cfg.src_dir,
+           f'-DMCVERSION={cfg.version}',
+           #'-DCMAKE_BUILD_PARALLEL_LEVEL=4',
+           '-DMCCODE_BUILD_CONDA_PKG=ON',
+           '-DBUILD_SHARED_LIBS=ON',
+           '-DCMAKE_INSTALL_LIBDIR=lib',
+           '-DCMAKE_BUILD_TYPE=Release',
+           '-DBUILD_MCSTAS=ON' if cfg.is_mcstas else '-DBUILD_MCXTRACE=ON',
+           '-DMCCODE_USE_LEGACY_DESTINATIONS=OFF',
+           '-DBUILD_TOOLS=ON',
+           '-DENABLE_COMPONENTS=ON',
+           '-DENSURE_MCPL=OFF',
+           '-DENSURE_NCRYSTAL=OFF',
+           '-DENABLE_CIF2HKL=OFF',
+           '-DENABLE_NEUTRONICS=OFF',
+           '-G',GENERATOR]
+    cmd += extra_args
+
+    #configure, build, install:
+
+    def doit(blddir):
+        runcmd( cmd + ['-B', blddir] )
+        runcmd(['cmake','--build',  blddir,'--config','Release'])
+        runcmd(['cmake','--install',blddir,'--config','Release'])
+
+    if cfg.build_dir:
+        doit(cfg.build_dir)
     else:
-        cmd += '-DBUILD_MCXTRACE=ON '
-    cmd += '-DMCCODE_USE_LEGACY_DESTINATIONS=OFF '
-    cmd += '-DBUILD_TOOLS=ON '
-    cmd += '-DENABLE_COMPONENTS=ON '
-    cmd += '-DENSURE_MCPL=OFF '
-    cmd += '-DENSURE_NCRYSTAL=OFF '
-    cmd += '-DENABLE_CIF2HKL=OFF '
-    cmd += '-DENABLE_NEUTRONICS=OFF '
-    cmd += '-G "' + GENERATOR + '" '
-    cmd += EXTRAARGS
-
-    res=syscall(cmd)
-    print(res.stdout)
-    print(res.stderr)
-    
-    
-    cmd = 'cmake --build . --config Release\n\n'
-    res=syscall(cmd)
-    print(res.stdout)
-    print(res.stderr)
-
-    cmd = 'cmake --build . --target install --config Release\n\n'
-    res=syscall(cmd)
-    print(res.stdout)
-    print(res.stderr)
+        with tempfile.TemporaryDirectory() as tmp_bld_dir:
+            try:
+                doit(tmp_bld_dir)
+            except Exception:
+                print()
+                print('ERROR: Something went wrong. Try again with a specific'
+                      ' build directory if you need to investigate further.')
+                print()
+                raise
 
 def parse_args( argv ):
     from argparse import ArgumentParser as AP
     parser = AP( prog = os.path.basename(argv[0]),
-                 description=('Build and install McStas or McXtrace trace witin conda environment'))
+                 description=('Build and install McStas or McXtrace trace within conda environment'))
     parser.add_argument('-m','--mode', choices=['mcstas', 'mcxtrace'],
                         default='mcstas',
                         help='Choose McStas or McXtrace mode (default: mcstas)')
-    parser.add_argument('-p','--platform', choices=['win', 'linux', 'mac'],
-                        default=None,
-                        help=('Generate settings for specific platform'
-                              ' (default: current platform)'))
-    parser.add_argument('-f','--force', action='store_true',
-                        help='Allow overwriting existing output file')
     parser.add_argument('-v','--version',
-                            default='3.99.99',
-                            help='Set build version (default: 3.99.99)')
+                        default='3.99.99',
+                        help='Set build version (default: 3.99.99)')
+    reporoot = detect_reporoot()
     parser.add_argument('-s','--srcdir',
-                            default='src',
-                            help='Source dir (default: src)')
+                        required = (not reporoot),
+                        default = reporoot,
+                        help=( 'Source dir (required since reporoot not found)'
+                               if not reporoot
+                               else 'Source dir (default: McCode repo root)' ) )
     parser.add_argument('-b','--builddir',
-                            default=None,
-                            help='Build dir (default: build_mcstas | build_mcxtrace)')
+                        default=None,
+                        help='Build dir (default: use temporary directory)')
 
     args = parser.parse_args(argv[1:])
 
-    if not args.platform:
-        args.platform = autodetect_platform()
+    #if not args.platform:
+    args.platform = autodetect_platform()
 
-    if not args.builddir:
-        args.builddir = 'build_' + args.mode
+    sd = pathlib.Path(args.srcdir)
+    if not sd.is_dir():
+        parser.error(f'Missing source dir: {sd}')
+    args.srcdir = sd.absolute()
 
     return args
 


### PR DESCRIPTION
Update the ./devel/bin/mccode-build-conda script so it finds the src dir automatically, and by default uses a temporary build dir. Also changed the code a bit to avoid shell=True, etc.


--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun -c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun -c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun -c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [ ] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



