### PR TITLE
Use multiple # Data entries in output files if -USR2 is used for intermediate saves

### DIFF
--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -74,15 +74,17 @@ jobs:
 
     - name: Setup (macOS)
       id: setup-macos
-      # Temporary workaround for failing build of brew / xraylib on macos-15
       if: runner.os == 'macOS'
+      # Temporarily disable xraylib runs on macOS, upstream seems to
+      # cause build-issues. Will soon port basictest scripts to conda
+      # for Windows/Linux
       run: |
            brew install bison flex gfortran gsl
-           if [ "${{ matrix.os }}" != "macos-15" ];
-           then
-             brew tap tschoonj/tap
-             brew install xraylib
-           fi
+           #if [ "${{ matrix.os }}" != "macos-15" ];
+           #then
+           #  brew tap tschoonj/tap
+           #  brew install xraylib
+           #fi
 
     - name: Setup (Windows)
       id: setup-Windows

--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -1471,8 +1471,9 @@ MCDETECTOR mcdetector_out_2D_ascii(MCDETECTOR detector)
 
         mcruninfo_out( "# ", outfile);
         mcdatainfo_out("# ", outfile,   detector);
-        fprintf(outfile, "# Data [%s/%s] %s:\n", detector.component, detector.filename, detector.zvar);
       }
+      /* Add # Data entry for any write to the file (e.g. via -USR2, see GitHub issue #2174 ) */
+      fprintf(outfile, "# Data [%s/%s] %s:\n", detector.component, detector.filename, detector.zvar);
       mcdetector_out_array_ascii(detector.m, detector.n*detector.p, detector.p1,
         outfile, detector.istransposed);
       if (detector.p2) {


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Adding patch from @jkruger1 to fix https://github.com/mccode-dev/McCode/issues/2174

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [ ] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



