### PR TITLE
Fixed typo in Phonon_simple and reverted test to earlier value

### DIFF
--- a/mcstas-comps/examples/Tests_samples/Samples_Phonon/Samples_Phonon.instr
+++ b/mcstas-comps/examples/Tests_samples/Samples_Phonon/Samples_Phonon.instr
@@ -17,7 +17,7 @@
 * Simple test instrument for the Phonon_simple component.
 * Refer to the component documentation for further instructions.
 *
-* %Example: E=10 -n 1e5 Detector: mon1_I=4.9e-25
+* %Example: E=10 -n 1e5 Detector: mon1_I=2.86265e-25
 *
 * %Parameters
 * E:    [meV] Mean energy at source   

--- a/mcstas-comps/samples/Phonon_simple.comp
+++ b/mcstas-comps/samples/Phonon_simple.comp
@@ -319,9 +319,9 @@ double zridd_gpu(double x1, double x2, struct neutron_params *neutron, struct ph
 
     // Then in energy gain for the neutron
     for (int i=0; i<phonon->e_steps_high_; i++){
-      root = zridd(f, brack_low+range_high*i/ phonon->e_steps_high_,
-		   brack_low+range_high*(i+1)/ phonon->e_steps_high_,
-		   neutron, phonon, ROOTACC);
+      root = zridd(f, brack_mid+range_high*i/ phonon->e_steps_high_,
+		           brack_mid+range_high*(i+1)/ phonon->e_steps_high_,
+		           neutron, phonon, ROOTACC);
       if (root != UNUSED){
 	list[(*index)++]=root;
       }
@@ -348,9 +348,9 @@ double zridd_gpu(double x1, double x2, struct neutron_params *neutron, struct ph
 
     // Then in energy gain for the neutron
     for (int i=0; i<phonon->e_steps_high_; i++){
-      root = zridd_gpu(brack_low+range_high*i/ phonon->e_steps_high_,
-		       brack_low+range_high*(i+1)/ phonon->e_steps_high_,
-		       neutron, phonon, ROOTACC);
+      root = zridd_gpu(brack_mid+range_high*i/ phonon->e_steps_high_,
+		               brack_mid+range_high*(i+1)/ phonon->e_steps_high_,
+		               neutron, phonon, ROOTACC);
       if (root != UNUSED){
 	list[(*index)++]=root;
       }


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Discovered that the Union version of Phonon simple no longer validate against the original component. Found that updates had been made to improve the structure, which does make the code easier to read. There was however a small typo in the findroots function that resulted in an increased intensity. 

The first search should be starting at low and end at mid, the second starting and mid and go to high. The second search started at low instead.

This pull request fixes the typo and reverts the test to the earlier value (reverting commit 5bf165a).

With this fix the Union version and original component validates well.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [X] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [X] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [X] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [X] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [X] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [X] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [X] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [ ] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [ ] Explanation is added in free form text above or below the checklist

--------------



