### PR TITLE
Removing debug prints from Sphere and 3D logger in Union.

### DIFF
--- a/mcstas-comps/examples/Tests_union/Geometry_test/Geometry_test.instr
+++ b/mcstas-comps/examples/Tests_union/Geometry_test/Geometry_test.instr
@@ -86,10 +86,12 @@ COMPONENT cryostat_wall_vacuum = Union_cylinder(
 AT (0,0,0) RELATIVE sample_pos
 ROTATED (0,0,0) RELATIVE sample_pos
 
+/*
 COMPONENT sample_sphere = Union_sphere(
  radius=0.031,priority=20,material_string="Cu")
 AT (0.01,0,0) RELATIVE sample_pos
 ROTATED (0,0,0) RELATIVE sample_pos
+*/
 
 COMPONENT sample_box = Union_box(
  xwidth=0.021, yheight=0.018, zdepth=0.1, priority=21, material_string="Vanadium")

--- a/mcstas-comps/examples/Tests_union/Geometry_test/Geometry_test.instr
+++ b/mcstas-comps/examples/Tests_union/Geometry_test/Geometry_test.instr
@@ -86,12 +86,10 @@ COMPONENT cryostat_wall_vacuum = Union_cylinder(
 AT (0,0,0) RELATIVE sample_pos
 ROTATED (0,0,0) RELATIVE sample_pos
 
-/*
 COMPONENT sample_sphere = Union_sphere(
  radius=0.031,priority=20,material_string="Cu")
 AT (0.01,0,0) RELATIVE sample_pos
 ROTATED (0,0,0) RELATIVE sample_pos
-*/
 
 COMPONENT sample_box = Union_box(
  xwidth=0.021, yheight=0.018, zdepth=0.1, priority=21, material_string="Vanadium")

--- a/mcstas-comps/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/union/Union_logger_3D_space.comp
@@ -583,8 +583,6 @@ INITIALIZE
   
   //printf("past input sanitation \n");
   
-  
-  printf("Allocating 3D arrays \n");
   // Remember to take special care when deallocating this array, use free3Ddouble
   
   /*

--- a/mcstas-comps/union/Union_sphere.comp
+++ b/mcstas-comps/union/Union_sphere.comp
@@ -318,28 +318,15 @@ if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(
 }
 
 this_sphere_volume.geometry.number_of_faces = 1;
-printf("Reached malloc\n");
 this_sphere_volume.geometry.surface_stack_for_each_face = malloc(this_sphere_volume.geometry.number_of_faces*sizeof(struct surface_stack_struct*));
-printf("malloced\n");
 
-printf("Reached assign to face\n");
 // This could be inserted into the fill_surface_stack function
 this_sphere_volume.geometry.surface_stack_for_each_face[0] = &surface_stack;
-
-printf("assigned to face\n");
-
-printf("Reached assign cut\n");
 this_sphere_volume.geometry.internal_cut_surface_stack = &cut_surface_stack; // This surface is used if the volume is cut by overlapping of higher priority volume
-printf("assigned cut\n");
 
-
-printf("Reached grab\n");
 struct pointer_to_global_surface_list *global_surface_list = COMP_GETPAR3(Union_init, init, global_surface_list);
-printf("Reached fill surface\n");
 fill_surface_stack(surface, global_surface_list, NAME_CURRENT_COMP, &surface_stack);
-printf("Reached fill cut_surface\n");
 fill_surface_stack(cut_surface, global_surface_list, NAME_CURRENT_COMP, &cut_surface_stack);
-printf("did all surface initialize\n");
 
 sprintf(this_sphere_volume.name,"%s",NAME_CURRENT_COMP);
 sprintf(this_sphere_volume.geometry.shape,"sphere");
@@ -371,10 +358,8 @@ this_sphere_volume.abs_loggers.num_elements = 0;
 sprintf(global_geometry_element.name,"%s",NAME_CURRENT_COMP);
 global_geometry_element.activation_counter = number_of_activations;
 global_geometry_element.component_index = INDEX_CURRENT_COMP;
-global_geometry_element.Volume = &this_sphere_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
+global_geometry_element.Volume = &this_sphere_volume;
 add_element_to_geometry_list(global_geometry_list, global_geometry_element);
-
-
 
 // TEST Union sphere has been initialized, test shell point function by writing to file.
 /*


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Tiny pull request to remove some debug print that was accidentally left in place.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_
OS X

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [ ] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [ ] Explanation is added in free form text above or below the checklist

--------------



