### PR TITLE
Bring back old hooks for matlab/octave tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,3 +3,4 @@ cmake_policy(VERSION 3.17.0)
 
 #add_subdirectory(Legacy-Perl-cmdline)
 add_subdirectory(Python)
+add_subdirectory(matlab)

--- a/tools/matlab/mcdisplay/CMakeLists.txt
+++ b/tools/matlab/mcdisplay/CMakeLists.txt
@@ -69,16 +69,16 @@ set(WORK "${PROJECT_BINARY_DIR}/work")
 
 
 # Configure fallback script
-configure_file("${CMAKE_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display" @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.in" "${WORK}/${P}display" @ONLY)
 
 # Configure doc
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay-matlab.md.in" "${WORK}/${P}display-matlab.md" @ONLY)
 
 if(WINDOWS)
-  set(BINS "${PROJECT_SOURCE_DIR}/mcdisplay.m")
+  set(BINS "${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.m")
 else()
   set(BINS "${WORK}/${P}display")
-  set(BINS "${PROJECT_SOURCE_DIR}/mcdisplay.m")
+  set(BINS "${CMAKE_CURRENT_SOURCE_DIR}/mcdisplay.m")
 endif()
 
 
@@ -110,10 +110,6 @@ if(NOT WINDOWS)
     COMMAND "${CMAKE_COMMAND}" -E remove "${WORK}/${P}display-matlab"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink
     "${TOOLS_LIB}/mcdisplay" "${WORK}/${P}display"
-    )
-
-  add_custom_target(
-    "CREATE_SYMLINK" ALL DEPENDS "${WORK}/${P}display"
     )
 
   install(


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

By popular demand, bring back old hooks for matlab/octave tools
(Lifting dependencies on a given system rely on user actions - much like mcdisplay-cad)

--------------

* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



