### PR TITLE
Platform-independent reflection list sort in Single_crystal

### DIFF
--- a/mcstas-comps/samples/Single_crystal.comp
+++ b/mcstas-comps/samples/Single_crystal.comp
@@ -396,77 +396,10 @@ struct hkl_data
     if (pa->tau_z < pb->tau_z) return -1;
     if (pa->tau_z > pb->tau_z) return 1;
 
-    /* In case of tie, sort by h also */
-    if (pa->h < pb->h) return -1;
-    if (pa->h > pb->h) return 1;
-
-    /* In case of tie, sort by k also */
-    if (pa->k < pb->k) return -1;
-    if (pa->k > pb->k) return 1;
-
-    /* In case of tie, sort by l also */
-    if (pa->l < pb->l) return -1;
-    if (pa->l > pb->l) return 1;
-
     /* In case of tie, sort by F2 also */
     if (pa->F2 < pb->F2) return -1;
     if (pa->F2 > pb->F2) return 1;
 
-    /* In case of tie, sort by cutoff also */
-    if (pa->cutoff < pb->cutoff) return -1;
-    if (pa->cutoff > pb->cutoff) return 1;
-
-    /* In case of tie, sort by sig123 also */
-    if (pa->sig123 < pb->sig123) return -1;
-    if (pa->sig123 > pb->sig123) return 1;
-
-     /* In case of tie, sort by m1 also */
-    if (pa->m1 < pb->m1) return -1;
-    if (pa->m1 > pb->m1) return 1;
-
-    /* In case of tie, sort by sig123 also */
-    if (pa->m2 < pb->m2) return -1;
-    if (pa->m2 > pb->m2) return 1;
-
-     /* In case of tie, sort by m3 also */
-    if (pa->m3 < pb->m3) return -1;
-    if (pa->m3 > pb->m3) return 1;
-
-    /* In case of tie, sort by u1x also */
-    if (pa->u1x < pb->u1x) return -1;
-    if (pa->u1x > pb->u1x) return 1;
-
-    /* In case of tie, sort by u1y also */
-    if (pa->u1y < pb->u1y) return -1;
-    if (pa->u1y > pb->u1y) return 1;
-
-     /* In case of tie, sort by u1z also */
-    if (pa->u1z < pb->u1z) return -1;
-    if (pa->u1z > pb->u1z) return 1;
-
-    /* In case of tie, sort by u2x also */
-    if (pa->u2x < pb->u2x) return -1;
-    if (pa->u2x > pb->u2x) return 1;
-
-    /* In case of tie, sort by u2y also */
-    if (pa->u2y < pb->u2y) return -1;
-    if (pa->u2y > pb->u2y) return 1;
-
-     /* In case of tie, sort by u2z also */
-    if (pa->u2z < pb->u2z) return -1;
-    if (pa->u2z > pb->u2z) return 1;
-
-    /* In case of tie, sort by u3x also */
-    if (pa->u3x < pb->u3x) return -1;
-    if (pa->u3x > pb->u3x) return 1;
-
-    /* In case of tie, sort by u3y also */
-    if (pa->u3y < pb->u3y) return -1;
-    if (pa->u3y > pb->u3y) return 1;
-
-     /* In case of tie, sort by u3z also */
-    if (pa->u3z < pb->u3z) return -1;
-    if (pa->u3z > pb->u3z) return 1;
 
     return 0;
   } /* SX_list_compare */

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -184,77 +184,10 @@ SHARE
     if (pa->tau_z < pb->tau_z) return -1;
     if (pa->tau_z > pb->tau_z) return 1;
 
-    /* In case of tie, sort by h also */
-    if (pa->h < pb->h) return -1;
-    if (pa->h > pb->h) return 1;
-
-    /* In case of tie, sort by k also */
-    if (pa->k < pb->k) return -1;
-    if (pa->k > pb->k) return 1;
-
-    /* In case of tie, sort by l also */
-    if (pa->l < pb->l) return -1;
-    if (pa->l > pb->l) return 1;
-
     /* In case of tie, sort by F2 also */
     if (pa->F2 < pb->F2) return -1;
     if (pa->F2 > pb->F2) return 1;
 
-    /* In case of tie, sort by cutoff also */
-    if (pa->cutoff < pb->cutoff) return -1;
-    if (pa->cutoff > pb->cutoff) return 1;
-
-    /* In case of tie, sort by sig123 also */
-    if (pa->sig123 < pb->sig123) return -1;
-    if (pa->sig123 > pb->sig123) return 1;
-
-     /* In case of tie, sort by m1 also */
-    if (pa->m1 < pb->m1) return -1;
-    if (pa->m1 > pb->m1) return 1;
-
-    /* In case of tie, sort by sig123 also */
-    if (pa->m2 < pb->m2) return -1;
-    if (pa->m2 > pb->m2) return 1;
-
-     /* In case of tie, sort by m3 also */
-    if (pa->m3 < pb->m3) return -1;
-    if (pa->m3 > pb->m3) return 1;
-
-    /* In case of tie, sort by u1x also */
-    if (pa->u1x < pb->u1x) return -1;
-    if (pa->u1x > pb->u1x) return 1;
-
-    /* In case of tie, sort by u1y also */
-    if (pa->u1y < pb->u1y) return -1;
-    if (pa->u1y > pb->u1y) return 1;
-
-     /* In case of tie, sort by u1z also */
-    if (pa->u1z < pb->u1z) return -1;
-    if (pa->u1z > pb->u1z) return 1;
-
-    /* In case of tie, sort by u2x also */
-    if (pa->u2x < pb->u2x) return -1;
-    if (pa->u2x > pb->u2x) return 1;
-
-    /* In case of tie, sort by u2y also */
-    if (pa->u2y < pb->u2y) return -1;
-    if (pa->u2y > pb->u2y) return 1;
-
-     /* In case of tie, sort by u2z also */
-    if (pa->u2z < pb->u2z) return -1;
-    if (pa->u2z > pb->u2z) return 1;
-
-    /* In case of tie, sort by u3x also */
-    if (pa->u3x < pb->u3x) return -1;
-    if (pa->u3x > pb->u3x) return 1;
-
-    /* In case of tie, sort by u3y also */
-    if (pa->u3y < pb->u3y) return -1;
-    if (pa->u3y > pb->u3y) return 1;
-
-     /* In case of tie, sort by u3z also */
-    if (pa->u3z < pb->u3z) return -1;
-    if (pa->u3z > pb->u3z) return 1;
 
     return 0;
   } /* SX_list_compare */

--- a/mcxtrace-comps/samples/Single_crystal.comp
+++ b/mcxtrace-comps/samples/Single_crystal.comp
@@ -413,77 +413,10 @@ SHARE
     if (pa->tau_z < pb->tau_z) return -1;
     if (pa->tau_z > pb->tau_z) return 1;
 
-    /* In case of tie, sort by h also */
-    if (pa->h < pb->h) return -1;
-    if (pa->h > pb->h) return 1;
-
-    /* In case of tie, sort by k also */
-    if (pa->k < pb->k) return -1;
-    if (pa->k > pb->k) return 1;
-
-    /* In case of tie, sort by l also */
-    if (pa->l < pb->l) return -1;
-    if (pa->l > pb->l) return 1;
-
     /* In case of tie, sort by F2 also */
     if (pa->F2 < pb->F2) return -1;
     if (pa->F2 > pb->F2) return 1;
 
-    /* In case of tie, sort by cutoff also */
-    if (pa->cutoff < pb->cutoff) return -1;
-    if (pa->cutoff > pb->cutoff) return 1;
-
-    /* In case of tie, sort by sig123 also */
-    if (pa->sig123 < pb->sig123) return -1;
-    if (pa->sig123 > pb->sig123) return 1;
-
-     /* In case of tie, sort by m1 also */
-    if (pa->m1 < pb->m1) return -1;
-    if (pa->m1 > pb->m1) return 1;
-
-    /* In case of tie, sort by sig123 also */
-    if (pa->m2 < pb->m2) return -1;
-    if (pa->m2 > pb->m2) return 1;
-
-     /* In case of tie, sort by m3 also */
-    if (pa->m3 < pb->m3) return -1;
-    if (pa->m3 > pb->m3) return 1;
-
-    /* In case of tie, sort by u1x also */
-    if (pa->u1x < pb->u1x) return -1;
-    if (pa->u1x > pb->u1x) return 1;
-
-    /* In case of tie, sort by u1y also */
-    if (pa->u1y < pb->u1y) return -1;
-    if (pa->u1y > pb->u1y) return 1;
-
-     /* In case of tie, sort by u1z also */
-    if (pa->u1z < pb->u1z) return -1;
-    if (pa->u1z > pb->u1z) return 1;
-
-    /* In case of tie, sort by u2x also */
-    if (pa->u2x < pb->u2x) return -1;
-    if (pa->u2x > pb->u2x) return 1;
-
-    /* In case of tie, sort by u2y also */
-    if (pa->u2y < pb->u2y) return -1;
-    if (pa->u2y > pb->u2y) return 1;
-
-     /* In case of tie, sort by u2z also */
-    if (pa->u2z < pb->u2z) return -1;
-    if (pa->u2z > pb->u2z) return 1;
-
-    /* In case of tie, sort by u3x also */
-    if (pa->u3x < pb->u3x) return -1;
-    if (pa->u3x > pb->u3x) return 1;
-
-    /* In case of tie, sort by u3y also */
-    if (pa->u3y < pb->u3y) return -1;
-    if (pa->u3y > pb->u3y) return 1;
-
-     /* In case of tie, sort by u3z also */
-    if (pa->u3z < pb->u3z) return -1;
-    if (pa->u3z > pb->u3z) return 1;
 
     return 0;
   } /* SX_list_compare */


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

In the same line of thinking as https://github.com/mccode-dev/McCode/pull/2272, this PR is meant to bring identical algorithmic behaviour across Unix/Windows, based on sorting Single_crystal reflection lists.

(Thinking is again that across operating systems, qsort() behaviour for 'equal' elements is not well-defined.)

I have run a few test-cases e.g. with templateLaue (which is a relatively 'clean' Single_crystal system) - here the output still differs for ~ 20 in 1e6 particles when comparing between macOS Arm and Windows Intel...

More investigations of where the differences lie may come later.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [x] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [x] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist
--------------



