### PR TITLE
Add commentstring to vim editor

### DIFF
--- a/support/common/editors/mccode.vim
+++ b/support/common/editors/mccode.vim
@@ -12,7 +12,7 @@
 
 " McStas/McXtrace instruments are mostly c syntax so start with that
 :runtime! syntax/c.vim
-
+:setlocal commentstring=//\ %s
 "keywords for mcstas statements
 :syntax keyword instrStatement DECLARE DEPENDENCY DEFINE END FINALLY INITIALIZE MCDISPLAY SAVE SHARE USERVARS
 :syntax keyword instrStatement TRACE DEFINITION PARAMETERS POLARISATION SETTING STATE


### PR DESCRIPTION
Add a commentstring to the vim syntax, such that block comments are easily made using gcc

### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

A small addition of commentstring to the vim syntax file, such that commentstrings are available.

--------------
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



