### PR TITLE
Fix for rare crash of ILL_IN4 / MPI

### DIFF
--- a/mcstas-comps/examples/ILL/ILL_IN4/ILL_IN4.instr
+++ b/mcstas-comps/examples/ILL/ILL_IN4/ILL_IN4.instr
@@ -329,6 +329,10 @@ INITIALIZE %{
 
   #pragma acc update device( environment_thickness )
 
+  #ifdef USE_MPI
+  /* In case of MPI mode, add an MPI_Barrier to ensure no node runs on an uncompleted/non-existentt Dirac2D.sqw */
+  MPI_Barrier(MPI_COMM_WORLD);
+  #endif
 %}
 
 


### PR DESCRIPTION


### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Fix for rare crash of ILL_IN4 / MPI. As can be seen in e.g. https://new-nightly.mcstas.org/2026-01-06_output.html (no access to underlying sim data, sorry) ILL_IN4 crashes at times. 

The underlying reason seems in principle simple:
Master is meant to write the file `Dirac2D.sqw`, but naturally other nodes may ‘overtake’ and attempt to load a non-existent or non-completed file…

The addition of an MPI_Barrier at the end if init seems to help - we should consider if this should be added at code-generation level instead….

--------------
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



