### PR TITLE
Ensure to fill all BINS-oriented detector struct members

### DIFF
--- a/mcstas-comps/share/monitor_nd-lib.c
+++ b/mcstas-comps/share/monitor_nd-lib.c
@@ -945,7 +945,7 @@ void Monitor_nD_Init(MonitornD_Defines_type *DEFS,
 	  sprintf(detector.zvar,"%s","");
 	  sprintf(detector.statistics,"%s","None");
 	  sprintf(detector.variables,"%s","None");
-	  sprintf(detector.signal,"%s","None");
+	  sprintf(detector.signal,"%s","Pixel index");
 	  sprintf(detector.filename,"BINS");
 	  sprintf(detector.component,"%s",Vars->compcurname);
 	  sprintf(detector.nexuscomp,"%s%d_%s",pref,Vars->compcurindex-1,detector.component);

--- a/mcstas-comps/share/monitor_nd-lib.c
+++ b/mcstas-comps/share/monitor_nd-lib.c
@@ -936,7 +936,16 @@ void Monitor_nD_Init(MonitornD_Defines_type *DEFS,
 	  detector.p0 = NULL;
 	  detector.p1 = NULL;
 	  detector.p2 = NULL;
-	  
+	  sprintf(detector.ncount,"%s","");
+	  sprintf(detector.xvar,"%s","");
+	  sprintf(detector.xlabel,"%s","");
+	  sprintf(detector.yvar,"%s","");
+	  sprintf(detector.ylabel,"%s","");
+	  sprintf(detector.zvar,"%s","");
+	  sprintf(detector.zvar,"%s","");
+	  sprintf(detector.statistics,"%s","None");
+	  sprintf(detector.variables,"%s","None");
+	  sprintf(detector.signal,"%s","None");
 	  sprintf(detector.filename,"BINS");
 	  sprintf(detector.component,"%s",Vars->compcurname);
 	  sprintf(detector.nexuscomp,"%s%d_%s",pref,Vars->compcurindex-1,detector.component);

--- a/mcstas-comps/share/monitor_nd_noacc-lib.c
+++ b/mcstas-comps/share/monitor_nd_noacc-lib.c
@@ -953,7 +953,7 @@ void Monitor_nd_noaccInit(Monitornd_noaccDefines_type *DEFS,
 	  sprintf(detector.zvar,"%s","");
 	  sprintf(detector.statistics,"%s","None");
 	  sprintf(detector.variables,"%s","None");
-	  sprintf(detector.signal,"%s","None");
+	  sprintf(detector.signal,"%s","Pixel index");
 	  sprintf(detector.filename,"BINS");
 	  sprintf(detector.component,"%s",Vars->compcurname);
 	  sprintf(detector.nexuscomp,"%s%d_%s",pref,Vars->compcurindex-1,detector.component);

--- a/mcstas-comps/share/monitor_nd_noacc-lib.c
+++ b/mcstas-comps/share/monitor_nd_noacc-lib.c
@@ -944,7 +944,16 @@ void Monitor_nd_noaccInit(Monitornd_noaccDefines_type *DEFS,
 	  detector.p0 = NULL;
 	  detector.p1 = NULL;
 	  detector.p2 = NULL;
-	  
+	  sprintf(detector.ncount,"%s","");
+	  sprintf(detector.xvar,"%s","");
+	  sprintf(detector.xlabel,"%s","");
+	  sprintf(detector.yvar,"%s","");
+	  sprintf(detector.ylabel,"%s","");
+	  sprintf(detector.zvar,"%s","");
+	  sprintf(detector.zvar,"%s","");
+	  sprintf(detector.statistics,"%s","None");
+	  sprintf(detector.variables,"%s","None");
+	  sprintf(detector.signal,"%s","None");
 	  sprintf(detector.filename,"BINS");
 	  sprintf(detector.component,"%s",Vars->compcurname);
 	  sprintf(detector.nexuscomp,"%s%d_%s",pref,Vars->compcurindex-1,detector.component);


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Should fix issues reported by separately by both Milan Klausz and Céline Durniak:
* Presented garbage data in the NeXus `BINS` structure
* Lead to mcstastox crash on import

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



