### PR TITLE
Suppress loading/plotting of event lists

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -1046,7 +1046,11 @@ MCDETECTOR detector_import(
   switch (detector.rank) {
     case 0:  strcpy(detector.type,  "array_0d"); m=n=p=1; break;
     case 1:  snprintf(detector.type, CHAR_BUF_LENGTH, "array_1d(%ld)", m*n*p); m *= n*p; n=p=1; break;
-    case 2:  snprintf(detector.type, CHAR_BUF_LENGTH, "array_2d(%ld, %ld)", m, n*p); n *= p; p=1; break;
+    case 2:  if(!strcasestr(detector.format,"list")) {
+               snprintf(detector.type, CHAR_BUF_LENGTH, "array_2d(%ld, %ld)", m, n*p); n *= p; p=1;
+             } else {
+               snprintf(detector.type, CHAR_BUF_LENGTH, "list(%ld, %ld)", m, n*p); n *= p; p=1;
+             } break;
     case 3:  snprintf(detector.type, CHAR_BUF_LENGTH, "array_3d(%ld, %ld, %ld)", m, n, p); break;
     default: m=0; strcpy(detector.type, ""); strcpy(detector.filename, "");/* invalid */
   }

--- a/tools/Python/mccodelib/mcplotloader.py
+++ b/tools/Python/mccodelib/mcplotloader.py
@@ -29,7 +29,12 @@ class DataMcCode(object):
 class Data0D(DataMcCode):
     # Bring back empty 'component' field, courtesy
     # of the scan plotter (otherwise we fail abrubtly)
-    DataMcCode.component=''
+    def __init__(self):
+        super(Data0D, self).__init__()
+        self.component=''
+        self.filename = ''
+        self.xlabel = ''
+        self.ylabel = ''
     pass
 
 
@@ -329,13 +334,19 @@ def _load_monitor(monitorfile):
             if typ == 'array_0d':
                 print("load_monitor: Not loading 0d dataset %s" % monitorfile)
                 data = Data0D()
+                data.title='zero-dim monitor'
             elif typ == 'array_1d':
                 data = _parse_1D_monitor(text)
             elif typ == 'array_2d':
                 data = _parse_2D_monitor(text)
+            elif typ == 'list':
+                print('load_monitor: %s is an event list. loading suppressed' % f)
+                data = Data0D()
+                data.title='event list'
             else:
                 print('load_monitor: unknown data format %s' % typ)
-                data = None
+                data = Data0D()
+                data.title='Unknown format'
             data.filepath = f
             return data
         else:

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -74,7 +74,7 @@ class ModLegend(pg.LegendItem):
 
 def plot_Data0D(data, plt, log=False, legend=True, icolormap=0, verbose=True, fontsize=10):
     ''' creates an empty plot '''
-    plt.setTitle("zero-dim monitor")
+    plt.setTitle(data.title)
     return plt.getViewBox()
 
 


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Suppress loading/plotting of event lists
(fixes #292 / #1150 / #1245)

McStas 3.6.15 plot with event data:
<img width="1170" height="827" alt="Screenshot 2026-04-23 at 19 15 48" src="https://github.com/user-attachments/assets/0815b702-bf43-44f6-ba26-439ce5bc32de" />

This PR with suppressed event data:
<img width="1170" height="827" alt="Screenshot 2026-04-23 at 19 11 34" src="https://github.com/user-attachments/assets/a3a68769-74d1-4fa9-8df6-336e7839818c" />


As a bonus, failure to load an uncompleted / broken file will lead to an empty plot with the text 'Unknown format'

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My PR is meant to fix a specific, existing issue
  * [x] I have indicated the issue number here: #292 / #1150 / #1245
  * [x] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



