### PR TITLE
Follow-up to #2402, should complete #2305

### DIFF
--- a/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
+++ b/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
@@ -180,7 +180,7 @@ COMPONENT box_sample = Incoherent(
     zdepth=thick,
     sigma_inc = 5.08,
     sigma_abs = 5.08
-) WHEN (!strcmp((const char*)"thin", (const char*)sample))
+) WHEN (!str_comp((const char*)"thin", (const char*)sample))
 AT (0, 0, 0) RELATIVE arm_sample
 ROTATED (0, 0, 0) RELATIVE arm_sample
 

--- a/mcstas-comps/share/tinyexpr.c
+++ b/mcstas-comps/share/tinyexpr.c
@@ -164,7 +164,9 @@ static const te_variable functions[] = {
     {"abs", fabs,     TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"acos", acos,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"asin", asin,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    #ifndef OPENACC
     {"atan", atan,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    #endif
     {"atan2", atan2,  TE_FUNCTION2 | TE_FLAG_PURE, 0},
     {"ceil", ceil,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"cos", cos,      TE_FUNCTION1 | TE_FLAG_PURE, 0},


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Follow-up to #2402, should complete #2305
1) Put `#ifndef OPENACC` around atan in tinyexpr.c since `atan` is not directly available
   (should idealy be mapped to `atan(x)=atan2(x,1.0)`, will write issue to put in `mccode-r`)
2) Use GPU-compatible `str_comp` rather than `strcmp` in `TRACE` of the instr
   (There is a define for this that seems to not cover (all of) `TRACE`, should also go in `mccode-r` or `cogen`)

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_

OpenACC / Linux with NVIDIA GPU 

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My PR is meant to fix a specific, existing issue
  * [x] I have indicated the issue number here: #2305
  * [x] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



