### PR TITLE
Disable MPI when testing non-conda mingw Windows

### DIFF
--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -207,7 +207,7 @@ jobs:
         type .\install_mcstas\share\mcstas\tools\Python\mccodelib\mccode_config.json
         .\install_mcstas\bin\mcrun -h
         .\install_mcstas\bin\mcstas -v
-        if [ "${{ matrix.cc }}" != "cl.exe" ];
+        if [ "${{ matrix.CC }}" != "cl.exe" ];
         then
           mcpl-config -s
           ncrystal-config -s
@@ -291,7 +291,7 @@ jobs:
            test -f ./install_mcstas/bin/mcstas${EXESUFFIX}
            ./install_mcstas/bin/mcstas${EXESUFFIX} --version
            ./install_mcstas/bin/mctest${SUFFIX} --instr=BNL_H8 --testdir=run_singletests --suffix=${{ matrix.mpi }}
-           if [ "${{ matrix.cc }}" != "cl.exe" ];
+           if [ "${{ matrix.CC }}" != "cl.exe" ];
            then
              ./install_mcstas/bin/mctest${SUFFIX} --instr=BNL_H8 --mpi=2 --testdir=run_singletests --suffix=${{ matrix.mpi }}
            fi
@@ -373,7 +373,7 @@ jobs:
            fi
            test -f ./install_mcstas/bin/mcstas${EXESUFFIX}
            ./install_mcstas/bin/mctest${SUFFIX} --instr=NCrystal_example --testdir=run_singletests --suffix=${{ matrix.mpi }}
-           if [ "${{ matrix.cc }}" != "cl.exe" ];
+           if [ "${{ matrix.CC }}" != "cl.exe" ];
            then
              ./install_mcstas/bin/mctest${SUFFIX} --instr=NCrystal_example --mpi=2 --testdir=run_singletests --suffix=${{ matrix.mpi }}
            fi
@@ -400,7 +400,7 @@ jobs:
            fi
            test -f ./install_mcstas/bin/mcstas${EXESUFFIX}
            ./install_mcstas/bin/mctest${SUFFIX} --instr=templateSANS_Mantid --testdir=run_singletests --suffix=${{ matrix.mpi }}
-           if [ "${{ matrix.cc }}" != "cl.exe" ];
+           if [ "${{ matrix.CC }}" != "cl.exe" ];
            then
              ./install_mcstas/bin/mctest${SUFFIX} --instr=templateSANS_Mantid --mpi=2 --testdir=run_singletests --suffix=${{ matrix.mpi }}
            fi
@@ -466,7 +466,7 @@ jobs:
                mctest --mpi=2 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.mpi }} $PERMISSIVE
                mcviewtest --nobrowse $PWD
              else
-               mctest.bat --mpi=2 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.mpi }}  $PERMISSIVE
+               mctest.bat --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.CC }}  $PERMISSIVE
                mcviewtest.bat --nobrowse $PWD
              fi
            fi

--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -216,7 +216,7 @@ jobs:
         type .\install_mcxtrace\share\mcxtrace\tools\Python\mccodelib\mccode_config.json
         .\install_mcxtrace\bin\mxrun -h
         .\install_mcxtrace\bin\mcxtrace -v
-        if [ "${{ matrix.cc }}" != "cl.exe" ];
+        if [ "${{ matrix.CC }}" != "cl.exe" ];
         then
           mcpl-config -s
         fi
@@ -298,7 +298,7 @@ jobs:
            test -f ./install_mcxtrace/bin/mcxtrace${EXESUFFIX}
            ./install_mcxtrace/bin/mcxtrace${EXESUFFIX} --version
            ./install_mcxtrace/bin/mxtest${SUFFIX} --instr=JJ_SAXS --testdir=run_singletests --suffix=${{ matrix.mpi }}
-           if [ "${{ matrix.cc }}" != "cl.exe" ];
+           if [ "${{ matrix.CC }}" != "cl.exe" ];
            then
              ./install_mcxtrace/bin/mxtest${SUFFIX} --instr=JJ_SAXS --mpi=2 --testdir=run_singletests --suffix=${{ matrix.mpi }}
            fi
@@ -325,7 +325,7 @@ jobs:
            test -f ./install_mcxtrace/bin/mcxtrace${EXESUFFIX}
            ./install_mcxtrace/bin/mcxtrace${EXESUFFIX} --version
            ./install_mcxtrace/bin/mxtest${SUFFIX} --instr=ESRF_BM29 --testdir=run_singletests --suffix=${{ matrix.mpi }}
-           if [ "${{ matrix.cc }}" != "cl.exe" ];
+           if [ "${{ matrix.CC }}" != "cl.exe" ];
            then
              ./install_mcxtrace/bin/mxtest${SUFFIX} --instr=ESRF_BM29 --mpi=2 --testdir=run_singletests --suffix=${{ matrix.mpi }}
            fi
@@ -449,7 +449,7 @@ jobs:
                mxtest --mpi=2 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.mpi }} $PERMISSIVE
                mxviewtest --nobrowse $PWD
              else
-               mxtest.bat --mpi=2 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.mpi }}  $PERMISSIVE
+               mxtest.bat --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.CC }}  $PERMISSIVE
                mxviewtest.bat --nobrowse $PWD
              fi
            fi


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Disable MPI when testing **non-conda mingw Windows** (not always stable)

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



