### PR TITLE
NCrystal sampling now use the correct per-particle RNG stream

### DIFF
--- a/common/lib/share/mccode-r.c
+++ b/common/lib/share/mccode-r.c
@@ -4470,6 +4470,16 @@ double _rand01(randstate_t* state) {
 	randnum /= (double) MC_RAND_MAX + 1;
 	return randnum;
 }
+double _rand01_opague(void* opague_state) {
+	randstate_t* state = (randstate_t*)opague_state;
+	// Following lines exactly like in _rand01 just above (repeated to
+	// avoid another layer of indirection):
+	double randnum;
+	randnum = (double) _random();
+	// TODO: can we mult instead of div?
+	randnum /= (double) MC_RAND_MAX + 1;
+	return randnum;
+}
 // Return a random number between 1 and -1
 double _randpm1(randstate_t* state) {
 	double randnum;

--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -669,6 +669,9 @@ double _rand0max(double max, randstate_t* state);
 double _randminmax(double min, double max, randstate_t* state);
 #pragma acc routine
 double _randtriangle(randstate_t* state);
+// version which pass randstate_t* as opague void*
+#pragma acc routine
+double _rand01_opague(void* state);
 
 
 #ifdef USE_OPENCL

--- a/devel/bin/mccode-create-conda-yml
+++ b/devel/bin/mccode-create-conda-yml
@@ -43,9 +43,9 @@ def create_deplist( cfg ):
         if cfg.is_win:
             deps += ['m2-which','m2-sed','m2-gzip','m2-coreutils']
     if cfg.include_toplevel_extras:
-        deps += ['gsl','libnexus','nexpy','cif2hkl','mcpl','mcpl-extra']
+        deps += ['gsl','libnexus','nexpy','cif2hkl','mcpl-extra >=2.2.8']
         if cfg.is_mcstas:
-            deps += ['ncrystal']
+            deps += ['ncrystal >=4.4.2']
         if cfg.is_mcxtrace:
             deps += ['xraylib']
         if cfg.is_linux:

--- a/mcstas-comps/samples/NCrystal_sample.comp
+++ b/mcstas-comps/samples/NCrystal_sample.comp
@@ -214,17 +214,6 @@ INITIALIZE
     NCMCERR ("Invalid value of absorptionmode");
   params.absmode = absorptionmode;
 
-  #ifndef rand01
-  /* Tell NCrystal to use the rand01 function provided by McStas: */
-  ncrystal_setrandgen (rand01);
-  #else
-  /* rand01 is actually a macro not an actual C-function (most likely defined as */
-  /* _rand01(_particle->randstate) for OPENACC purposes), which we can not       */
-  /* register with NCrystal. As a workaround we tell NCrystal to use its own RNG */
-  /* algorithm, with merely the seed provided by McStas:                         */
-  ncrystal_setbuiltinrandgen_withseed (mcseed);
-  #endif
-
   /* access material info to get number density (natoms/volume): */
   ncrystal_info_t info = ncrystal_create_info (cfg);
   double numberdensity = ncrystal_info_getnumberdensity (info);

--- a/mcstas-comps/samples/NCrystal_sample.comp
+++ b/mcstas-comps/samples/NCrystal_sample.comp
@@ -148,15 +148,6 @@ SHARE
     };
   }
 
-  double
-  ncrystalsample_rand01 (void* state) {
-    // This function is needed, since we can not simply pass _rand01 to
-    // ncrystal_samplescatter_rc, since storing a double(randstate_t*) function
-    // in a function pointer of signature double(void*) is strictly speaking
-    // undefined behaviour.
-    return _rand01 ((randstate_t*)state);
-  }
-
   #ifndef NCMCERR
   /* more convenient form (only works in TRACE section, not in SHARE functions) */
   #  define NCMCERR(msg) NCMCERR2(NAME_CURRENT_COMP,msg)
@@ -307,7 +298,7 @@ TRACE
 
       /* scattering */
       double ekin_final;
-      ncrystal_samplescatter_rs (ncrystalsample_rand01, (void*)_particle->randstate, params.scat, ekin, (const double (*)[3]) & dir, &ekin_final, &dirout);
+      ncrystal_samplescatter_rs (_rand01_opague, (void*)_particle->randstate, params.scat, ekin, (const double (*)[3]) & dir, &ekin_final, &dirout);
       double delta_ekin = ekin_final - ekin;
       if (delta_ekin) {
         ekin = ekin_final;

--- a/mcstas-comps/samples/NCrystal_sample.comp
+++ b/mcstas-comps/samples/NCrystal_sample.comp
@@ -148,6 +148,14 @@ SHARE
     };
   }
 
+  double ncrystalsample_rand01(void*state) {
+    //This function is needed, since we can not simply pass _rand01 to
+    //ncrystal_samplescatter_rc, since storing a double(randstate_t*) function
+    //in a function pointer of signature double(void*) is strictly speaking
+    //undefined behaviour.
+    return _rand01((randstate_t*)state);
+  }
+
   #ifndef NCMCERR
   /* more convenient form (only works in TRACE section, not in SHARE functions) */
   #  define NCMCERR(msg) NCMCERR2(NAME_CURRENT_COMP,msg)
@@ -309,7 +317,7 @@ TRACE
 
       /* scattering */
       double ekin_final;
-      ncrystal_samplescatter (params.scat, ekin, (const double (*)[3]) & dir, &ekin_final, &dirout);
+      ncrystal_samplescatter_rs (ncrystalsample_rand01, (void*)_particle->randstate, params.scat, ekin, (const double (*)[3]) & dir, &ekin_final, &dirout);
       double delta_ekin = ekin_final - ekin;
       if (delta_ekin) {
         ekin = ekin_final;

--- a/mcstas-comps/samples/NCrystal_sample.comp
+++ b/mcstas-comps/samples/NCrystal_sample.comp
@@ -148,12 +148,13 @@ SHARE
     };
   }
 
-  double ncrystalsample_rand01(void*state) {
-    //This function is needed, since we can not simply pass _rand01 to
-    //ncrystal_samplescatter_rc, since storing a double(randstate_t*) function
-    //in a function pointer of signature double(void*) is strictly speaking
-    //undefined behaviour.
-    return _rand01((randstate_t*)state);
+  double
+  ncrystalsample_rand01 (void* state) {
+    // This function is needed, since we can not simply pass _rand01 to
+    // ncrystal_samplescatter_rc, since storing a double(randstate_t*) function
+    // in a function pointer of signature double(void*) is strictly speaking
+    // undefined behaviour.
+    return _rand01 ((randstate_t*)state);
   }
 
   #ifndef NCMCERR


### PR DESCRIPTION
### Free-form text area

This PR ensures that NCrystal sampling uses the correct per-particle RNG stream, as was always intended. The intention, however, had not survived the general migration of the RNG stream in McStas towards GPU compatibility and KISS RNG.

There is no longer any fiddling with NCrystal's global RNG settings, as the RNG stream is now simply being passed in through the new `ncrystal_samplescatter_rs` function from NCrystal 4.4.2 (from yesterday evening). This function accepts not just a `double(void)` function pointer, but instead a stateful `double(void*)` function pointer as well as the state itself (void*).

It is not well defined behaviour in C to simply cast the `_rand01` function to a `double(void*)` function pointer, so either the component itself, or globablly in `mccode-r.h`, we needed to have an opague RNG version of the `double(void*)` signature. Since the functionality is also needed in `NCrystal_process` and (in the near future` in KDSource source components, I chose to add a `_rand01_opague` function in `mccode-r.h`. Both for convenience, and to avoid paying a cost of one additional function call for each random number consumed. So this PR also touches `mccode-r.h` and `mccode-r.c`, but _only_ to add a single function which is for now not used anywhere else than in `NCrystal_sample.comp`. Thus, I feel satisfied that simply testing `mctest --comp NCrystal_sample` is sufficient to catch any issues.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [x] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [x] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [x] I am have added reasoning and documentation for the change below
  * [x] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [ ] Explanation is added in free form text above or below the checklist

--------------



