### PR TITLE
Small changes to tiny expression for improved usability

### DIFF
--- a/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
+++ b/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
@@ -49,9 +49,9 @@
 * %Example: sample=inc_linear Detector: lin_det_I=0.017457
 * %Example: sample=inho_linear Detector: lin_det_I=0.017457
 * %Example: sample=inc_and_inho Detector: lin_det_I=0.017457
-* %Example: -n 1e5 sample=phonon Detector: lin_det_I=0.0174609
+* %Example: sample=phonon thick=0.001 Detector: lin_det_I=0.00505839
 * %Example: sample=inc_trans Detector: lin_det_I=0.081029
-* %Example: sample=gauss_heavy Detector: lin_det_I=0.081029
+* %Example: sample=gauss_heavy Detector: lin_det_I=0.0985658
 * %Example: sample=inho_trans Detector: lin_det_I=0.081040
 *
 *
@@ -116,6 +116,7 @@ INITIALIZE
   } else if (!strcmp("inc_and_inho", sample)){
     activate_inc_and_inho_linear = 1;
   } else if (!strcmp("phonon", sample)){
+    
     activate_phonon = 1;
   } else if (!strcmp("inc_trans", sample)) {
     rot_samples = 90;
@@ -515,6 +516,14 @@ COMPONENT inho_and_inc_box = Union_box(
 ROTATED (0, 0, 0) RELATIVE arm_sample
 
 // ============================ Inhomogenous + homogenous + phononsimple process
+COMPONENT inho_phonon_proc= Inhomogenous_incoherent_process(
+  sigma_expr = "9.58/2*((z+0.0045)*1000)", unit_cell_volume = 13.827,
+  // verbose=1,
+  number_of_sample_points = 2
+)
+AT (0,0,0) RELATIVE arm_sample
+
+
 
 COMPONENT phonon_proc = PhononSimple_process(
 
@@ -525,7 +534,7 @@ AT (0,0,0) RELATIVE arm_sample
 
 COMPONENT phonon_mat = Union_make_material(
     my_absorption = 100 * 5.08 / 13.827,
-    process_string = "only_inc_proc,only_inho_proc,phonon_proc"
+    process_string = "inho_phonon_proc,phonon_proc"
 )
 AT (0,0,0) RELATIVE PREVIOUS
 

--- a/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
+++ b/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
@@ -51,6 +51,7 @@
 * %Example: sample=inc_and_inho Detector: lin_det_I=0.017457
 * %Example: -n 1e5 sample=phonon Detector: lin_det_I=0.0174609
 * %Example: sample=inc_trans Detector: lin_det_I=0.081029
+* %Example: sample=gauss_heavy Detector: lin_det_I=0.081029
 * %Example: sample=inho_trans Detector: lin_det_I=0.081040
 *
 *
@@ -83,6 +84,7 @@ DECLARE
   int activate_inc_linear;
   int activate_inc_and_inho_linear;
   int activate_phonon;
+  int activate_gauss;
   double rot_samples;
 
 %}
@@ -122,6 +124,10 @@ INITIALIZE
   } else if (!strcmp("inho_trans", sample)){
     rot_samples = 90;
     activate_inho_linear = 1;
+    width = 0.01;
+  } else if (!strcmp("gauss_heavy", sample)){
+    rot_samples = 90;
+    activate_gauss = 1;
     width = 0.01;
   }
 
@@ -503,7 +509,7 @@ COMPONENT inho_and_inc_box = Union_box(
   xwidth=width,
   yheight = 0.03,
   zdepth = thick,
-  material_string = "Inho_lin",
+  material_string = "inc_and_inho",
   number_of_activations = activate_inc_and_inho_linear
 ) AT (0,0, 0) RELATIVE arm_sample
 ROTATED (0, 0, 0) RELATIVE arm_sample
@@ -533,7 +539,30 @@ COMPONENT phonon_box = Union_box(
 ) AT (0,0, 0) RELATIVE arm_sample
 ROTATED (0, 0, 0) RELATIVE arm_sample
 
+// ============================ Inhomogenous as a gaussian and heavy side
 
+COMPONENT gauss = Inhomogenous_incoherent_process(
+  sigma_expr = "5.08 - gauss(0.01,0.001,z+0.0025) + hvs(z,0,5,0)", unit_cell_volume = 13.827,
+  // verbose=1,
+  number_of_sample_points = 10
+)
+AT (0,0,0) RELATIVE arm_sample
+
+COMPONENT gauss_mat = Union_make_material(
+    my_absorption = 100 * 5.08 / 13.827,
+    process_string = "gauss"
+)
+AT (0,0,0) RELATIVE PREVIOUS
+
+COMPONENT  gauss_box = Union_box(
+  priority = 163,
+  xwidth=width,
+  yheight = 0.03,
+  zdepth = thick,
+  material_string = "gauss_mat",
+  number_of_activations = activate_gauss
+) AT (0,0, 0) RELATIVE arm_sample
+ROTATED (0, 0, 0) RELATIVE arm_sample
 
 
 

--- a/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
+++ b/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
@@ -13,7 +13,7 @@
 * and comparison to incoherent process, and incoherent component.
 *
 * %Description
-* Test of 9 different setups. 
+* Test of different setups with the Inhomogenous_incoherent_process.
 * For all setups, the idea is the same. A source shines neutrons on the box,
 * and a detector placed right up on the side of the box, measures the 
 * incoherently scattered neutrons. 
@@ -41,6 +41,10 @@
 * nature of the two different processes, the one process curve becomes
 * continous (Inhomogenous_incoherent_process),
 * and the other discrete (Incoherent_process).
+* 
+* The 10th example plays with some more complex tiny expressions using the 
+* gaussian function and the heavyside function.
+*
 *
 *
 * %Example: sample=thin Detector: lin_det_I=0.007387
@@ -51,8 +55,8 @@
 * %Example: sample=inc_and_inho Detector: lin_det_I=0.017457
 * %Example: sample=phonon thick=0.001 Detector: lin_det_I=0.00505839
 * %Example: sample=inc_trans Detector: lin_det_I=0.081029
-* %Example: sample=gauss_heavy Detector: lin_det_I=0.0985658
 * %Example: sample=inho_trans Detector: lin_det_I=0.081040
+* %Example: sample=gauss_heavy Detector: lin_det_I=0.0985658
 *
 *
 *

--- a/mcstas-comps/share/tinyexpr.c
+++ b/mcstas-comps/share/tinyexpr.c
@@ -22,13 +22,16 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
+// THIS VERSION OF TINYEXPR HAS BEEN MODIFIED TO BETTER SUIT THE NEEDS 
+// OF THE MCSTAS SOFTWARE PACKAGE
+
 
 /* COMPILE TIME OPTIONS */
 
 /* Exponentiation associativity:
 For a^b^c = (a^b)^c and -a^b = (-a)^b do nothing.
 For a^b^c = a^(b^c) and -a^b = -(a^b) uncomment the next line.*/
-/* #define TE_POW_FROM_RIGHT */
+#define TE_POW_FROM_RIGHT 
 
 /* Logarithms
 For log = base 10 log do nothing
@@ -153,6 +156,17 @@ static double ncr(double n, double r) {
     return result;
 }
 static double npr(double n, double r) {return ncr(n, r) * fac(r);}
+static double hvs(double x, double t, double a, double b) {
+    if (x>t){
+      return a;
+    }
+    return b;
+}
+static double gauss(double A, double sig, double x){
+  double inv_sqrt_2pi = 0.3989422804;
+  double result = A * inv_sqrt_2pi / sig * exp(-0.5 * (x * x) / (sig * sig));
+  return result;
+}
 
 #ifdef _MSC_VER
 #pragma function (ceil)
@@ -175,6 +189,8 @@ static const te_variable functions[] = {
     {"exp", exp,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"fac", fac,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"floor", floor,  TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"gauss", gauss,  TE_FUNCTION3 | TE_FLAG_PURE, 0},
+    {"hvs", hvs,      TE_FUNCTION4 | TE_FLAG_PURE, 0},
     {"ln", log,       TE_FUNCTION1 | TE_FLAG_PURE, 0},
 #ifdef TE_NAT_LOG
     {"log", log,      TE_FUNCTION1 | TE_FLAG_PURE, 0},

--- a/mcstas-comps/union/Inhomogenous_incoherent_process.comp
+++ b/mcstas-comps/union/Inhomogenous_incoherent_process.comp
@@ -83,6 +83,20 @@
 * The velocities <span class="latex">$vx, vy, vz$</span>
 * and the time <span class="latex">$t$</span>
 * 
+* McStas uses a sligthly modified version of tiny expressions that evaluate 
+* exponentials from right to left instead of the standard left to right.
+* Furthermore McStas has added two functions to tiny expressions. These are:
+* A heavy side function
+* hvs(variable, switch_point, large_val,small_val) which returns large val if 
+* variable > switch_point and small val otherwise.
+*
+* A gaussian distribution:
+*
+* gauss(A,sig,x), which evaluates to A*1/sqrt(2*PI)/sig*exp(-x^2/2/sig^2)
+*
+* An example using these can be found in the Test instrument for this component,
+* called Test_inhomogenous_process.instr. Example #9 implements a gaussian and a
+* heavyside function.
 * For more information on tiny expressions, see the link below.
 *
 *


### PR DESCRIPTION
### Free-form text area
This PR adds a heavyside and gauss function to tinyexpr.c and force tinyexpr to evaluate exponentials from right to left.

This PR then implements a test of the two new functions in the relevant [test instrument](https://github.com/mccode-dev/McCode/blob/tinyexpr_additions/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr)

Finally documentation of these small additions have been added documentation to [Inhomogenous_incoherent_process.comp](https://github.com/mccode-dev/McCode/blob/tinyexpr_additions/mcstas-comps/union/Inhomogenous_incoherent_process.comp)

This adds the features requested by me in #2461.

--------------
### Development OS / boundary conditions
MacOS Tahoe 26.4

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
* ### My contribution includes patches to an **existing** instrument file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [x] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [x] I am have added reasoning and documentation for the change below

--------------



