### PR TITLE
Fix missing PyQt5->PyQt6 correction for mcdisplay-pyqtgraph

### DIFF
--- a/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py
+++ b/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py
@@ -396,7 +396,11 @@ class McDisplay2DGui(object):
             self._set_rays(rays)
             self._unzoom()
             self._display_nextray()
-        return self.app.exec_()
+
+        if hasattr(self.app, 'exec'):
+            return self.app.exec()
+        else:
+            return self.app.exec_()
     
     def run_ui_tof(self, instr, rays):
         '''  '''
@@ -418,11 +422,14 @@ class McDisplay2DGui(object):
         
         # plot rays
         plot_1d_tof_rays(instr, rays, plt)
-        
+
         self.layout.scene().keyPressEvent = self._key_handler
-        
-        return self.app.exec_()
-    
+
+        if hasattr(self.app, 'exec'):
+            return self.app.exec()
+        else:
+            return self.app.exec_()
+
     def _set_and_plot_instr(self, instr, enable_clickable=False):
         ''' set internal references to the full instrument and three 2d instrument set of coordinate pairs '''
         self.instr = instr

--- a/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py
+++ b/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py
@@ -358,7 +358,7 @@ class McDisplay2DGui(object):
             if self.zoomstate == self.ZoomState.ZOOM:
                 self._unzoom()
         if event.key() == 81:                   # q
-            QtWidgets.QApplication.quit()
+            sys.exit(0)
         elif event.key() == 80:                 # p
             self._dumpfile(format='png')
         elif event.key() == 83:                 # s
@@ -401,7 +401,7 @@ class McDisplay2DGui(object):
             return self.app.exec()
         else:
             return self.app.exec_()
-    
+   
     def run_ui_tof(self, instr, rays):
         '''  '''
         self.instr = instr


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Annoyingly, mcdisplay-pyqtgraph shipped with 3.7.1 crashes during on startup with the below error message (at least on some systems…). This PR fixes the problem and will result in a scoop-up 3.7.2 likely next week...

```
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py", line 553, in main
    sys.exit(gui.run_ui(instrument, rays))
             ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py", line 399, in run_ui
    return self.app.exec_()
           ^^^^^^^^^^^^^^
AttributeError: 'QApplication' object has no attribute 'exec_'. Did you mean: 'exec'?

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py", line 585, in <module>
    main(**args)
    ~~~~^^^^^^^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py", line 557, in main
    sys.exit(gui.run_ui(instrument, rays))
             ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py", line 398, in run_ui
    self._display_nextray()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py", line 468, in _display_nextray
    plt.clear()
    ~~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 1767, in clear
    self.scatter.clear()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/site-packages/pyqtgraph/graphicsItems/ScatterPlotItem.py", line 861, in clear
    self.invalidate()
    ~~~~~~~~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/site-packages/pyqtgraph/graphicsItems/ScatterPlotItem.py", line 597, in invalidate
    self.update()
    ~~~~~~~~~~~^^
RuntimeError: wrapped C/C++ object of type ScatterPlotItem has been deleted
```


--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



