### PR TITLE
Silence mcdisplay-matplotlib noise when pressing 'q'

### DIFF
--- a/tools/Python/mcdisplay/matplotlib/mcdisplay.in
+++ b/tools/Python/mcdisplay/matplotlib/mcdisplay.in
@@ -27,12 +27,13 @@ canrun() {
 }
 
 if ( canrun ); then
-    arguments=""
     ncountmax="1e2"
     ncount=""
     trace=""
     next=0
     found_ncount=0
+    backend=""
+    args=()
     for arg in "${@}"; do
 	if [ "${next}" == "1" ];               # We found -n or --ncount in last pass, this is NUMBER
 	then
@@ -56,6 +57,10 @@ if ( canrun ); then
 	elif [[ ${arg} =~ ^--trace= ]];       # Case: --trace=NUMBER
 	then
 	    trace=`echo $arg | cut -f2 -d=`
+	    args+=("$arg")
+	elif [[ ${arg} =~ ^--backend= ]];       # Case: --backend=Something
+	then
+	    backend=`echo $arg | cut -f2 -d=`
 	elif [[ ${arg} =~ ^--help ]];       # Case: --help
 	then
 	    script=`basename $0`
@@ -67,10 +72,12 @@ if ( canrun ); then
 	    echo "       --ncount=N    - set number of particles to trace, max/default N=1e2"
 	    echo "             -n N "
 	    echo "              -nN "
+	    echo "      --backend=B    - use matplotlib backend 'B' (e.g. WebAgg, pdf etc.)"
+	    echo "                       Backends 'pdf', 'pgf', 'ps', 'svg' saves a hardcopy."
 	    echo ""
 	    exit
 	else
-	    arguments="$arguments $arg"
+	    args+=("$arg")
 	fi
     done
     if [ "${trace}" == "" ];
@@ -89,7 +96,7 @@ if ( canrun ); then
     else
 	ncount=$ncountmax
     fi
-    @P@run  $* --trace=$trace --no-output-files -n $ncount | python3 ${UTILDIR}/${TOOL}.py
+    @P@run  ${args[@]} --trace=${trace} --no-output-files -n ${ncount} | python3 ${UTILDIR}/${TOOL}.py ${backend}
 else
     @FLAVOR@_errmsg Failed to run Python ${TOOL} - permissions or missing dependencies\?
 fi

--- a/tools/Python/mcdisplay/matplotlib/mcdisplay.py
+++ b/tools/Python/mcdisplay/matplotlib/mcdisplay.py
@@ -176,7 +176,10 @@ def parse_trace():
 
     set_axis_limits(ax)
 
-    plt.show()
+    try:
+        plt.show()
+    except KeyboardInterrupt:
+        pass
 
 
 def process_circle(ax, line, color, comp, transparency):

--- a/tools/Python/mcdisplay/matplotlib/mcdisplay.py
+++ b/tools/Python/mcdisplay/matplotlib/mcdisplay.py
@@ -5,8 +5,11 @@
 import matplotlib as mpl
 from mpl_toolkits.mplot3d import art3d
 from matplotlib import pyplot as plt
+from matplotlib import use
 import numpy as np
 import json
+import sys
+import os
 
 from util import (parse_multiline, rotate, rotate_points, draw_circle, get_line,
                   draw_box, draw_sphere, draw_cylinder, draw_disc, rotate_xyz, draw_cone, draw_hollow_box, draw_annulus, draw_new_circle)
@@ -47,19 +50,50 @@ transparency = 1
 x_max_polygon = y_max_polygon = z_max_polygon = float('-inf')
 x_min_polygon = y_min_polygon = z_min_polygon = float('inf')
 
+def dumpfile(frmat, filename = None):
+    """ save current fig to softcopy """
+    from pylab import savefig
 
-def parse_trace():
+    if filename is None:
+        filename = "display_matplotlib"
+
+    # get directory, basename and extension
+    if isinstance(filename, list):
+        filename = filename[0]
+    basename  = os.path.splitext(filename)[0] # contains full path and base filename
+    if frmat is None:
+        ext       = os.path.splitext(filename)[1] # extension with the dot
+    else:
+        ext = frmat
+    if ext[0] != '.':
+        ext = '.'+ext
+    # assemble target name
+    saveto = basename + ext
+
+    # Check for existance of earlier exports
+    if os.path.isfile(saveto):
+        index=1
+        saveto = f"{basename}_{index}{frmat}"
+        while os.path.isfile(saveto):
+            index += 1
+            saveto = f"{basename}_{index}{frmat}"
+
+    savefig(saveto)
+    print("Saved " + saveto)
+
+def parse_trace(backend):
     ''' Parse McStas trace output from stdin and write results
         to file objects csv_comps and csv_lines '''
+
+    if backend is not None:
+        use(backend)
+        if backend in ('pdf', 'pgf', 'ps', 'svg'):
+            use('template')
 
     mpl.rcParams['legend.fontsize'] = 10
 
     ax = plt.figure(figsize=plt.figaspect(0.5) * 1.5).add_subplot(projection='3d')
-    ax.set(xlabel='z', ylabel='x', zlabel='y')
-    try:
-        ax.set_aspect('equal')
-    except:
-        print("manual aspect not supported")
+    ax.set(xlabel='z / [m]', ylabel='x / [m]', zlabel='y / [m]')
 
     color = 0
 
@@ -174,10 +208,13 @@ def parse_trace():
         else:
             print(line)
 
+    ax.set_box_aspect(None)
     set_axis_limits(ax)
 
     try:
         plt.show()
+        if backend in ('pdf', 'pgf', 'ps', 'svg'):
+            dumpfile(backend)
     except KeyboardInterrupt:
         pass
 
@@ -430,4 +467,7 @@ def set_axis_limits(ax):
 
 
 if __name__ == '__main__':
-    parse_trace()
+    backend=None
+    if len(sys.argv) > 1:
+        backend = sys.argv[1]
+    parse_trace(backend)


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

On macOS / mcdisplay-matplotlib pressing ‘q’ would yield the below noise. This PR removes the noise.

```
Traceback (most recent call last):
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/matplotlib/mcdisplay.py", line 430, in <module>
    parse_trace()
    ~~~~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/share/mcstas/tools/Python/mcdisplay/matplotlib/mcdisplay.py", line 179, in parse_trace
    plt.show()
    ~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/site-packages/matplotlib/pyplot.py", line 613, in show
    return _get_backend_mod().show(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/site-packages/matplotlib/backend_bases.py", line 3550, in show
    cls.mainloop()
    ~~~~~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/site-packages/matplotlib/backends/backend_macosx.py", line 179, in start_main_loop
    with _allow_interrupt_macos():
         ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/contextlib.py", line 148, in __exit__
    next(self.gen)
    ~~~~^^^^^^^^^^
  File "/Users/peterwillendrup/micromamba/envs/mcstas-3.7.1/lib/python3.14/site-packages/matplotlib/backend_bases.py", line 1660, in _allow_interrupt
    old_sigint_handler(*handler_args)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyboardInterrupt

```

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



