### PR TITLE
Fix of another mcdisplay-pyqtgraph PyQt6 vs PyQt5 bug

### DIFF
--- a/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py
+++ b/tools/Python/mcdisplay/pyqtgraph/mcdisplay.py
@@ -251,7 +251,10 @@ def create_infowindow(comp_colour_pairs):
                 self.verticalLayoutTechnicalReason.addWidget(self.scrollArea)
                 
                 self.labels = []
-                self.spacerItem = QtWidgets.QSpacerItem(20, 448, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+                try: # Prefer Qt6 style, fallback to Qt5
+                    self.spacerItem = QtWidgets.QSpacerItem(20, 448, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+                except:
+                    self.spacerItem = QtWidgets.QSpacerItem(20, 448, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
                 
         def set_components(self, str_colour_pairs):
             ''' colours are tri-tupples of rgb '''


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Caught yet another PyQt6 vs PyQt5 bug: mcdisplay-pyqtgraph would crash on PyQt6-based systems when raising the help dialogue (`h`). Fixed by try-catch for Qt6 vs Qt5 property location within loaded Qt widget set.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



