### PR TITLE
Add fflush(stdout) protection of DEBUG_COMPONENT (fix #2486)

### DIFF
--- a/common/lib/share/mccode-r.h.in
+++ b/common/lib/share/mccode-r.h.in
@@ -567,7 +567,9 @@ int _getcomp_index(char* compname);
      "POS: %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g\n", \
      name, c.x, c.y, c.z, t[0][0], t[0][1], t[0][2], \
      t[1][0], t[1][1], t[1][2], t[2][0], t[2][1], t[2][2]); \
-     printf("Component %30s AT (%g,%g,%g)\n", name, c.x, c.y, c.z); }
+     fflush(stdout);\
+     printf("Component %30s AT (%g,%g,%g)\n", name, c.x, c.y, c.z);\
+     fflush(stdout);}
 #define DEBUG_INSTR_END() if(!mcdotrace); else printf("INSTRUMENT END:\n");
 #define DEBUG_ENTER() if(!mcdotrace); else printf("ENTER:\n");
 #define DEBUG_COMP(c) if(!mcdotrace); else printf("COMP: \"%s\"\n", c);


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Protect DEBUG_COMPONENT macro by adding fflush(stdout) to avoid split tokens / data. See #2486 for details.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



