### PR TITLE
Exit minus 1 harmonization

### DIFF
--- a/mcstas-comps/contrib/SNS_source.comp
+++ b/mcstas-comps/contrib/SNS_source.comp
@@ -420,7 +420,7 @@ void Pcalc(double (*func)(double,double,double*,double*),
   }
   if (idx1<1){
    printf("Error: lower energy limit is out of bounds\n");
-   exit(0);
+   exit(-1);
   }
   *idxstart=idx1;
    Prob[idx1]=integ1((*func),llim,xvec[idx1],0.001, veclen, xvec, inyvec);

--- a/mcstas-comps/examples/Tests_optics/Test_Fermi/Test_Fermi.instr
+++ b/mcstas-comps/examples/Tests_optics/Test_Fermi/Test_Fermi.instr
@@ -51,7 +51,7 @@ INITIALIZE
   case 1:
     printf("Using FermiChopper\n"); break;
   case 2:
-    printf("Using Vitess_ChopperFermi - unsupported.\n"); exit(0);
+    printf("Using Vitess_ChopperFermi - unsupported.\n"); exit(-1);
   case 3:
     printf("Using FermiChopper_ILL\n"); break;
   case 4:

--- a/mcstas-comps/examples/Tools/Histogrammer/Histogrammer.instr
+++ b/mcstas-comps/examples/Tools/Histogrammer/Histogrammer.instr
@@ -88,7 +88,7 @@ INITIALIZE
     printf("  2 - MCPL event file\n");
     printf("'options' - options string for Monitor_nD, see mcdoc Monitor_nD.comp\n\n");
 
-    exit(0);
+    exit(-1);
   } else if (file_mode == 1) {
     printf("%s: Mode is 1 (Virtual_input event file)\n", NAME_INSTRUMENT);
     VirtualI_filename = filename;

--- a/mcstas-comps/sources/ESS_moderator.comp
+++ b/mcstas-comps/sources/ESS_moderator.comp
@@ -126,7 +126,7 @@ INITIALIZE
   if (Lmin>=Lmax) {
     printf("ESS_moderator: %s: Unmeaningful definition of wavelength range!\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
 
   sgnport=(beamport_angle>0 ? 1:-1);

--- a/mcstas-comps/sources/Moderator.comp
+++ b/mcstas-comps/sources/Moderator.comp
@@ -63,7 +63,7 @@ p_in = flux*1e4*PI*radius*radius/mcget_ncount();
       printf("Moderator: %s: Error in input parameter values!\n"
              "ERROR          Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
 %}
 TRACE

--- a/mcstas-comps/sources/Source_4PI.comp
+++ b/mcstas-comps/sources/Source_4PI.comp
@@ -48,13 +48,13 @@ INITIALIZE %{
   if ((!lambda0 && !E0 && !dE && !dlambda)) {
     printf("Source_4PI: %s: You must specify either a wavelength or energy range!\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-    exit(0);
+    exit(-1);
   }
   if ((!lambda0 && !dlambda && (E0 <= 0 || dE < 0 || E0-dE <= 0))
     || (!E0 && !dE && (lambda0 <= 0 || dlambda < 0 || lambda0-dlambda <= 0))) {
     printf("Source_4PI: %s: Unmeaningful definition of wavelength or energy range!\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
 %}
 

--- a/mcstas-comps/sources/Source_Maxwell_3.comp
+++ b/mcstas-comps/sources/Source_Maxwell_3.comp
@@ -115,7 +115,7 @@ INITIALIZE
       printf("Source_Maxwell_3: %s: Error in input parameter values!\n"
              "ERROR          Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
 
 %}

--- a/mcstas-comps/sources/Source_adapt.comp
+++ b/mcstas-comps/sources/Source_adapt.comp
@@ -161,7 +161,7 @@ if (target_index && !dist)
       printf("Source_adapt: %s: Error in given wavelength range!\n"
              "ERROR          Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
 
   source_area = (xmax - xmin)*(ymax - ymin)*1e4; /* cm^2 */

--- a/mcstas-comps/sources/Source_div.comp
+++ b/mcstas-comps/sources/Source_div.comp
@@ -82,18 +82,18 @@ sigmah = DEG2RAD*focus_aw/(sqrt(8.0*log(2.0)));
       printf("Source_div: %s: Error in input parameter values!\n"
              "ERROR       Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
   if ((!lambda0 && !E0 && !dE && !dlambda)) {
     printf("Source_div: %s: You must specify either a wavelength or energy range!\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-    exit(0);
+    exit(-1);
   }
   if ((!lambda0 && !dlambda && (E0 <= 0 || dE < 0 || E0-dE <= 0))
     || (!E0 && !dE && (lambda0 <= 0 || dlambda < 0 || lambda0-dlambda <= 0))) {
     printf("Source_div: %s: Unmeaningful definition of wavelength or energy range!\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
   /* compute distance to next component */
   Coords ToTarget;

--- a/mcstas-comps/sources/Source_simple.comp
+++ b/mcstas-comps/sources/Source_simple.comp
@@ -103,24 +103,24 @@ if (radius && !yheight && !xwidth ) {
   if (srcArea <= 0) {
     printf("Source_simple: %s: Source area is <= 0 !\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-    exit(0);
+    exit(-1);
   }
   if (dist <= 0 || focus_xw <= 0 || focus_yh <= 0) {
     printf("Source_simple: %s: Target area unmeaningful! (negative dist / focus_xw / focus_yh)\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-    exit(0);
+    exit(-1);
   }
 
   if ((!lambda0 && !E0 && !dE && !dlambda)) {
     printf("Source_simple: %s: You must specify either a wavelength or energy range!\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-    exit(0);
+    exit(-1);
   }
   if ((!lambda0 && !dlambda && (E0 <= 0 || dE < 0 || E0-dE <= 0))
     || (!E0 && !dE && (lambda0 <= 0 || dlambda < 0 || lambda0-dlambda <= 0))) {
     printf("Source_simple: %s: Unmeaningful definition of wavelength or energy range!\n ERROR - Exiting\n",
            NAME_CURRENT_COMP);
-      exit(0);
+      exit(-1);
   }
 %}
 TRACE

--- a/mcxtrace-comps/examples/DTU/Pump_probe_solvent/Pump_probe_solvent.instr
+++ b/mcxtrace-comps/examples/DTU/Pump_probe_solvent/Pump_probe_solvent.instr
@@ -77,7 +77,7 @@ INITIALIZE
   }
   if(NOSOLUTE && NOSOLVENT){
       fprintf(stderr,"Warning (Pump_probe_solvent): You have disabled solute and solvent scattering.\nAborting to avoid wasting your time.\n");
-      exit(0);
+      exit(-1);
   }
 
 %}


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Standardise: Any comp / instr raising an `exit()` during init due to failure / meaningless parameters should give non-zero value (we opt for -1). This fixes at least some instances of hung mcdisplay as mentioned in https://github.com/mccode-dev/McCode/issues/2480

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



