### PR TITLE
Fix for Incoherent component limited order + hollow geometry

### DIFF
--- a/mcstas-comps/samples/Incoherent.comp
+++ b/mcstas-comps/samples/Incoherent.comp
@@ -257,6 +257,7 @@ TRACE
   int flag = 0;
   double mc_trans, p_trans, mc_scatt, p_scatt, ws;
   double p_mult = 1;
+  int flag_ishollow = 0;
 
   #ifdef OPENACC
   #ifdef USE_OFF
@@ -281,7 +282,7 @@ TRACE
     #endif
 
     if (intersect) {
-      int flag_ishollow = 0;
+      flag_ishollow = 0;
       if (thickness > 0) {
         if (VarsInc.shape == 0 && cylinder_intersect (&t1, &t2, x, y, z, vx, vy, vz, radius - thickness, yheight - 2 * thickness))
           flag_ishollow = 1;
@@ -477,11 +478,48 @@ TRACE
       intersect = off_intersect (&t0, &t3, NULL, NULL, x, y, z, vx, vy, vz, 0, 0, 0, thread_offdata);
     #endif
 
-    d_path = v * t3; /* Length of full path through sample */
+	flag_ishollow = 0;
+	if (thickness > 0) {
+	  if (VarsInc.shape == 0 && cylinder_intersect (&t1, &t2, x, y, z, vx, vy, vz, radius - thickness, yheight - 2 * thickness))
+	    flag_ishollow = 1;
+	  else if (VarsInc.shape == 2 && sphere_intersect (&t1, &t2, x, y, z, vx, vy, vz, radius - thickness))
+	    flag_ishollow = 1;
+	  else if (VarsInc.shape == 1 && box_intersect (&t1, &t2, x, y, z, vx, vy, vz, xwidth - 2 * thickness, yheight - 2 * thickness, zdepth - 2 * thickness))
+	    flag_ishollow = 1;
+	}
+	if (!flag_ishollow)
+	  t1 = t2 = t3; /* no empty space inside */
+
+	dt0 = t1 - (t0 > 0 ? t0 : 0); /* Time in first part of hollow/cylinder/box */
+	dt1 = t2 - (t1 > 0 ? t1 : 0); /* Time in hole */
+	dt2 = t3 - (t2 > 0 ? t2 : 0); /* Time in 2nd part of hollow cylinder */
+
+	if (dt0 < 0)
+	  dt0 = 0;
+	if (dt1 < 0)
+	  dt1 = 0;
+	if (dt2 < 0)
+	  dt2 = 0;
+
+	/* initialize concentric mode */
+	if (concentric && !flag_concentric && t0 >= 0 && VarsInc.shape == 0 && thickness > 0) {
+	  flag_concentric = 1;
+	}
+
+	if (flag_concentric == 1) {
+	  dt1 = dt2 = 0; /* force exit when reaching hole/2nd part */
+	}
+
+    d_path = v * (dt0+dt2); // Attenuate only for material part, not hollow part
 
     p_trans = exp (-my_t * d_path);
     p *= p_trans;
-    PROP_DT (t3);
+	
+	if (flag_concentric == 1 && flag_ishollow == 1 && t1 > 0) {
+      PROP_DT (t1); // When conentric, only propagate ray to start of hollow part
+	} else {
+      PROP_DT (t3); // Otherwise propagate out of the sample
+    }
   }
 %}
 

--- a/mcstas-comps/samples/Incoherent.comp
+++ b/mcstas-comps/samples/Incoherent.comp
@@ -478,46 +478,46 @@ TRACE
       intersect = off_intersect (&t0, &t3, NULL, NULL, x, y, z, vx, vy, vz, 0, 0, 0, thread_offdata);
     #endif
 
-	flag_ishollow = 0;
-	if (thickness > 0) {
-	  if (VarsInc.shape == 0 && cylinder_intersect (&t1, &t2, x, y, z, vx, vy, vz, radius - thickness, yheight - 2 * thickness))
-	    flag_ishollow = 1;
-	  else if (VarsInc.shape == 2 && sphere_intersect (&t1, &t2, x, y, z, vx, vy, vz, radius - thickness))
-	    flag_ishollow = 1;
-	  else if (VarsInc.shape == 1 && box_intersect (&t1, &t2, x, y, z, vx, vy, vz, xwidth - 2 * thickness, yheight - 2 * thickness, zdepth - 2 * thickness))
-	    flag_ishollow = 1;
-	}
-	if (!flag_ishollow)
-	  t1 = t2 = t3; /* no empty space inside */
+    flag_ishollow = 0;
+    if (thickness > 0) {
+      if (VarsInc.shape == 0 && cylinder_intersect (&t1, &t2, x, y, z, vx, vy, vz, radius - thickness, yheight - 2 * thickness))
+        flag_ishollow = 1;
+      else if (VarsInc.shape == 2 && sphere_intersect (&t1, &t2, x, y, z, vx, vy, vz, radius - thickness))
+        flag_ishollow = 1;
+      else if (VarsInc.shape == 1 && box_intersect (&t1, &t2, x, y, z, vx, vy, vz, xwidth - 2 * thickness, yheight - 2 * thickness, zdepth - 2 * thickness))
+        flag_ishollow = 1;
+    }
+    if (!flag_ishollow)
+      t1 = t2 = t3; /* no empty space inside */
 
-	dt0 = t1 - (t0 > 0 ? t0 : 0); /* Time in first part of hollow/cylinder/box */
-	dt1 = t2 - (t1 > 0 ? t1 : 0); /* Time in hole */
-	dt2 = t3 - (t2 > 0 ? t2 : 0); /* Time in 2nd part of hollow cylinder */
+    dt0 = t1 - (t0 > 0 ? t0 : 0); /* Time in first part of hollow/cylinder/box */
+    dt1 = t2 - (t1 > 0 ? t1 : 0); /* Time in hole */
+    dt2 = t3 - (t2 > 0 ? t2 : 0); /* Time in 2nd part of hollow cylinder */
 
-	if (dt0 < 0)
-	  dt0 = 0;
-	if (dt1 < 0)
-	  dt1 = 0;
-	if (dt2 < 0)
-	  dt2 = 0;
+    if (dt0 < 0)
+      dt0 = 0;
+    if (dt1 < 0)
+      dt1 = 0;
+    if (dt2 < 0)
+      dt2 = 0;
 
-	/* initialize concentric mode */
-	if (concentric && !flag_concentric && t0 >= 0 && VarsInc.shape == 0 && thickness > 0) {
-	  flag_concentric = 1;
-	}
+    /* initialize concentric mode */
+    if (concentric && !flag_concentric && t0 >= 0 && VarsInc.shape == 0 && thickness > 0) {
+      flag_concentric = 1;
+    }
 
-	if (flag_concentric == 1) {
-	  dt1 = dt2 = 0; /* force exit when reaching hole/2nd part */
-	}
+    if (flag_concentric == 1) {
+      dt1 = dt2 = 0; /* force exit when reaching hole/2nd part */
+    }
 
-    d_path = v * (dt0+dt2); // Attenuate only for material part, not hollow part
+    d_path = v * (dt0 + dt2); // Attenuate only for material part, not hollow part
 
     p_trans = exp (-my_t * d_path);
     p *= p_trans;
-	
-	if (flag_concentric == 1 && flag_ishollow == 1 && t1 > 0) {
+
+    if (flag_concentric == 1 && flag_ishollow == 1 && t1 > 0) {
       PROP_DT (t1); // When conentric, only propagate ray to start of hollow part
-	} else {
+    } else {
       PROP_DT (t3); // Otherwise propagate out of the sample
     }
   }


### PR DESCRIPTION
### Free-form text area
Proposed fix for Incoherent component issue that occurs when using a limited order and hollow geometry as reported in issue  #2502

--------------
### Development OS / boundary conditions
OS X 14.8.7

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [X] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [x] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [X] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [ ] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [X] I have indicated the issue number here:  #2502 
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [ ] Explanation is added in free form text above or below the checklist

--------------



