### PR TITLE
Pass at key points in mcdisplay particleparser instead of raising exceptions.

### DIFF
--- a/tools/Python/mccodelib/fcparticleparser.py
+++ b/tools/Python/mccodelib/fcparticleparser.py
@@ -139,17 +139,19 @@ class ParticleBundleWeaver(object):
     
     def new_comp(self, compname):
         if self._story is None:
-            raise Exception("You must add a particle story before adding a compgroup.")
-        if self._compgroup is not None:
-            raise Exception("Close the current compgroup before adding a new one.")
-        self._compgroup = ParticleCompGroup(compname)
-        self._story.add_group(self._compgroup)
+            pass
+        elif self._compgroup is not None:
+            pass
+        else:
+            self._compgroup = ParticleCompGroup(compname)
+            self._story.add_group(self._compgroup)
 
     def new_point(self, point_str):
         if self._compgroup is None:
-            raise Exception("You must add a compgroup before adding points.")
-        point = ParticleState(point_str)
-        self._compgroup.add_event(point)
+            pass
+        else:
+            point = ParticleState(point_str)
+            self._compgroup.add_event(point)
     
     def close_comp(self):
         self._compgroup = None


### PR DESCRIPTION
Pass at key points in mcdisplay particleparser instead of raising exceptions.

(Simple instrument with arms only would refuse to render with ncount >=1)

### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_



--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



