### PR TITLE
Filter.comp is in fact incomplete for refraction and shape != cube.

### DIFF
--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_ANATOMIX/SOLEIL_ANATOMIX.instr
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_ANATOMIX/SOLEIL_ANATOMIX.instr
@@ -55,7 +55,7 @@
 * EH3             | 165.7-174.1 | Guard slits; TXM sample stage and zone-plate table;  microtomography sample stage; detector table | EH3
 * EH4             | 197.2-208.5 | Guard slits; microtomography sample stage; detector table; X-ray grating interferometer | EH4
 *
-* %Example: -n 1e5 E0=17 Detector: psd_monitor_after_cc_I=8.7e+17
+* %Example: -n 1e5 E0=17 Detector: psd_monitor_after_cc_I=1e18
 *
 * %Parameters
 * E0:    [keV] Energy selected at the Undulator.
@@ -76,6 +76,7 @@ DEFINE INSTRUMENT SOLEIL_ANATOMIX(E0=11, Emono=0, dE=1, ANGLE=0, string sample="
 DECLARE
 %{
     double calculated_angle;
+    char emonopts[128];
 %}
 
 INITIALIZE
@@ -91,6 +92,7 @@ INITIALIZE
     } else {
       exit(printf("%s: ERROR: Monochromator energy is outside the Undulator bandwidth.\n", NAME_INSTRUMENT));
     }
+    sprintf(emonopts,"energy limits=[%g %g], y",E0-dE,E0+dE);
 %}
 
 TRACE
@@ -110,7 +112,7 @@ COMPONENT e_repartition_before_cc = Monitor_nD(
     xwidth=0.01, 
     yheight=0.01, 
     restore_xray=1, 
-    options="auto energy, y", bins=100,
+    options=emonopts, bins=100,
     filename="e_repartition_before_cc")
 AT (0, 0, 50) RELATIVE PREVIOUS
 

--- a/mcxtrace-comps/optics/Filter.comp
+++ b/mcxtrace-comps/optics/Filter.comp
@@ -39,7 +39,7 @@
 * material_datafile: [str] File where the material parameters for the filter may be found. Format is similar to what may be found off the NIST website. [Be.txt]
 * geometry:   [str] File containing the polygon definition of a general shape object. When xwidth is also given, the object is rescaled accordingly (OFF/PLY)
 * fixed_delta:[0/1] Use a fixed delta to compute refraction - useful for debugging.
-* refraction: [0/1] If nonzero, refraction is enabled.
+* refraction: [0/1] If nonzero, refraction is enabled. (Only functional for box-geometery.)
 *
 * %Link
 * Meshlab https://www.meshlab.net/
@@ -57,7 +57,7 @@
 *******************************************************************************/
 DEFINE COMPONENT Filter
 
-SETTING PARAMETERS (refraction=1,fixed_delta=0,string material_datafile="Be.txt",
+SETTING PARAMETERS (refraction=0,fixed_delta=0,string material_datafile="Be.txt",
     string geometry=0,xwidth=0,yheight=0,zdepth=0,radius=0)
 
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */ 
@@ -175,6 +175,12 @@ INITIALIZE
     printf ("%s: Rebinning material data (%s) for faster tracing...", NAME_CURRENT_COMP, material_datafile);
     Table_Rebin (&(table));
     printf ("done\n");
+  }
+  if (shape != CUBE) {
+    if (refraction) {
+      fprintf (stderr, "Warning(%s): refraction=1 not supported with chosen geometry\n", NAME_CURRENT_COMP);
+      refraction=0;
+    }
   }
 %}
 


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Filter.comp is in fact incomplete for refraction and shape != cube.
Will add an issue later.

For now this serves as a patch to rectify test results for instrument SOLEIL_ANATOMIX across platforms...

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



