### PR TITLE
Fix ascii reallocation in Union_mesh

### DIFF
--- a/mcstas-comps/share/union-lib.c
+++ b/mcstas-comps/share/union-lib.c
@@ -2278,6 +2278,7 @@ struct lines_to_draw draw_line_with_highest_priority(Coords position1,Coords pos
     struct pointer_to_1d_double_list intersection_list;
 
     intersection_list.num_elements = 0;
+    intersection_list.elements = NULL;
 
     r1[0] = position1.x;
     r1[1] = position1.y;
@@ -2334,8 +2335,9 @@ struct lines_to_draw draw_line_with_highest_priority(Coords position1,Coords pos
     free(temp_intersection);
     // Now we have a list of intersection distances between r1 and r2 and all volumes.
     // This list needs to be sorted before we continue!
-
-    qsort(intersection_list.elements,intersection_list.num_elements,sizeof (double), Sample_compare_doubles);
+	if (intersection_list.num_elements > 0) {
+    	qsort(intersection_list.elements,intersection_list.num_elements,sizeof (double), Sample_compare_doubles);
+	}
     
     Coords *points=malloc((intersection_list.num_elements+2)*sizeof(Coords));
     if (!points) {

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -62,6 +62,8 @@
 * focus_r:       [m]   focusing on circle with this radius
 * skip_convex_check: [1] when set to 1, skips the check for whether input .off file is convex.
 * coordinate_scale [1e-3] Multiplier that the vertex positions are multiplied by. Set to 1 for input coordinates in meters. Set to 1e-3 for input coordinates in mm.
+* surface:       [string] Comma seperated string of Union surface definitions defined prior to this component
+* cut_surface:   [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts
 * init:          [string] name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -62,7 +62,7 @@
 * focus_r:       [m]   focusing on circle with this radius
 * skip_convex_check: [1] when set to 1, skips the check for whether input .off file is convex.
 * coordinate_scale [1e-3] Multiplier that the vertex positions are multiplied by. Set to 1 for input coordinates in meters. Set to 1e-3 for input coordinates in mm.
-* surface:       [string] Comma seperated string of Union surface definitions defined prior to this component
+* all_surfaces:       [string] Comma seperated string of Union surface definitions defined prior to this component
 * cut_surface:   [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts
 * init:          [string] name of Union_init component (typically "init", default)
 *

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -130,7 +130,7 @@ SHARE
     uint16_t attribute_byte_count;
   } Triangle;
   #pragma pack(pop)
- void 
+  void
   check_open_file_errors (FILE* fp, char* filename) {
     if (fp == NULL) {
       printf ("\n\nERROR: %s could not be opened by Union_mesh component.\n\n", filename);
@@ -277,8 +277,8 @@ SHARE
     int x_are_equal, y_are_equal, z_are_equal;
     int* map_old_to_unique = malloc (sizeof (int) * *n_verts);
     if (map_old_to_unique == NULL || unique_vertices == NULL) {
-      printf("\nERROR ON MALLOC IN UNION MESH STL READ\n"); 
-      exit(1);
+      printf ("\nERROR ON MALLOC IN UNION MESH STL READ\n");
+      exit (1);
     }
     int unique_counter = 0;
     int vert_index_in_faces = 0;

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -213,10 +213,10 @@ SHARE
           if (count >= capacity) {
             capacity *= 2;
             void* tmp = realloc (triangles, capacity * sizeof (Triangle));
-            if (tmp) {
+            if (!tmp) {
+              perror ("ERROR: Memory reallocation failed");
               free (triangles);
               free (tmp);
-              perror ("ERROR: Memory reallocation failed");
               fclose (file);
               exit (1);
             }


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_
Fixed small error that exit if reallocation of memory in Union_mesh is successful, rather than exiting if it fails.


--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_
OS X 14.8.7

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [X] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [x] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [X] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised

--------------



