### PR TITLE
Fix filter geometry

### DIFF
--- a/mcxtrace-comps/examples/Tests_optics/Test_Filter_geom/Test_Filter_geom.instr
+++ b/mcxtrace-comps/examples/Tests_optics/Test_Filter_geom/Test_Filter_geom.instr
@@ -1,0 +1,90 @@
+/*******************************************************************************
+*         McXtrace instrument definition URL=http://www.mcxtrace.org
+*
+* Instrument: Test_filter
+*
+* %Identification
+* Written by: Erik Knudsen (erkn@risoe.dtu.dk)
+* Date: July 5th 2011
+* Origin: Ris&oslash; DTU
+* Version: 1.0_rc2
+* %INSTRUMENT_SITE: Tests_optics
+*
+* Test instrument for checking the Filter.comp component
+*
+* %Description
+* Test instrument for checking the Filter.comp component
+*
+* %Parameters
+* filter_mat: []   Chemical symbol of the filter material
+* thickness:  [m]  thickness of the filter block
+* L0:         [AA] centre wavlength of the source
+* DL:         [AA] half width of the (uniform) wavelength distribution
+* F2:         [1]  add a 2nd filter component further away
+*
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" Detector: l_mon1_I=1.31502e-07
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" shape=1 Detector: l_mon1_I=1.31502e-07
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" shape=2 Detector: l_mon1_I=1.31502e-07
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 Detector: l_mon1_I=1.31502e-07
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 shape=1 Detector: l_mon1_I=1.31502e-07
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 shape=2 Detector: l_mon1_I=1.31502e-07
+*
+* %End
+*******************************************************************************/
+
+DEFINE INSTRUMENT Test_Filter_geom(string filter_mat="Rh.txt",thickness=100e-6,L0=1,DL=0.1, F2=0, int shape=0, refraction=0)
+
+DECLARE
+%{
+%}
+
+INITIALIZE
+%{
+%}
+
+
+TRACE
+
+COMPONENT Origin = Progress_bar()
+AT(0,0,0) ABSOLUTE
+
+
+COMPONENT Source=Source_div(
+    lambda0=L0,dlambda=DL,  xwidth=thickness*2, yheight=thickness*2
+)
+AT (0,0,0) RELATIVE Origin
+
+COMPONENT l_mon0 = L_monitor(
+    filename="l_mon0",nL=200,xwidth=0.1, yheight=0.1, Lmin=L0-1.1*DL, Lmax=L0+1.1*DL
+)
+AT (0,0,1e-6) RELATIVE Source
+
+COMPONENT filter_box = Filter(
+    material_datafile=filter_mat, xwidth=thickness, yheight=0.1,zdepth=thickness, refraction=refraction
+)
+WHEN (shape == 0) AT (0,0,0.5) RELATIVE Source
+
+COMPONENT filter_sphere = Filter(
+    material_datafile=filter_mat, radius=thickness, refraction=refraction
+)
+WHEN (shape == 1) AT (0,0,0.5) RELATIVE Source
+
+COMPONENT filter_cyl = Filter(
+    material_datafile=filter_mat,yheight=0.1,radius=thickness, refraction=refraction
+)
+WHEN (shape == 2) AT (0,0,0.5) RELATIVE Source
+
+COMPONENT psd1 = PSD_monitor(xwidth = thickness*4, yheight= thickness*4, nx=512, ny=512, filename="psd1", restore_xray=1)
+AT(0,0,thickness*2) RELATIVE filter_box
+
+COMPONENT psd2 = PSD_monitor(xwidth = thickness*4, yheight= thickness*4, nx=512, ny=512, filename="psd2", restore_xray=1)
+AT(0,0,0.1) RELATIVE filter_box
+
+COMPONENT l_mon1 = L_monitor(
+    filename="l_mon1",nL=200,xwidth=0.1, yheight=0.1, Lmin=L0-1.1*DL, Lmax=L0+1.1*DL
+)
+AT (0,0,1) RELATIVE Source
+
+
+
+END

--- a/mcxtrace-comps/examples/Tests_optics/Test_Filter_geom/Test_Filter_geom.instr
+++ b/mcxtrace-comps/examples/Tests_optics/Test_Filter_geom/Test_Filter_geom.instr
@@ -1,7 +1,7 @@
 /*******************************************************************************
 *         McXtrace instrument definition URL=http://www.mcxtrace.org
 *
-* Instrument: Test_filter
+* Instrument: Test_filter_geom
 *
 * %Identification
 * Written by: Erik Knudsen (erkn@risoe.dtu.dk)
@@ -10,10 +10,11 @@
 * Version: 1.0_rc2
 * %INSTRUMENT_SITE: Tests_optics
 *
-* Test instrument for checking the Filter.comp component
+* Test instrument for checking the geometry options of the Filter.comp component
 *
 * %Description
 * Test instrument for checking the Filter.comp component
+* Specifically this instrument checks the geometry options and refraction
 *
 * %Parameters
 * filter_mat: []   Chemical symbol of the filter material
@@ -22,12 +23,12 @@
 * DL:         [AA] half width of the (uniform) wavelength distribution
 * F2:         [1]  add a 2nd filter component further away
 *
-* %Example: DL=4.9 L0=5 filter_mat="Be.txt" Detector: l_mon1_I=1.31502e-07
-* %Example: DL=4.9 L0=5 filter_mat="Be.txt" shape=1 Detector: l_mon1_I=1.31502e-07
-* %Example: DL=4.9 L0=5 filter_mat="Be.txt" shape=2 Detector: l_mon1_I=1.31502e-07
-* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 Detector: l_mon1_I=1.31502e-07
-* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 shape=1 Detector: l_mon1_I=1.31502e-07
-* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 shape=2 Detector: l_mon1_I=1.31502e-07
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" Detector: psd2_I=0.760008
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" shape=1 Detector: psd2_I=0.57936
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" shape=2 Detector: psd2_I=0.415209
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 Detector: psd2_I=0.759422
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 shape=1 Detector: psd2_I=0.571845
+* %Example: DL=4.9 L0=5 filter_mat="Be.txt" refraction=1 shape=2 Detector: psd2_I=0.40875
 *
 * %End
 *******************************************************************************/

--- a/mcxtrace-comps/optics/Filter.comp
+++ b/mcxtrace-comps/optics/Filter.comp
@@ -14,14 +14,14 @@
 * Release: McXtrace 1.1
 *
 * Block of an attenuating material
-* 
+*
 * %Description
 * A chunk of attenuating material. Attenuation is computed through
-* the effective length travelled within the material. 
+* the effective length travelled within the material.
 * No scattering is modelled at present.
 *
 * Filter shape may be a cylinder, a sphere, a box or any other shape.
-*   box/plate:       xwidth x yheight x zdepth 
+*   box/plate:       xwidth x yheight x zdepth
 *   cylinder:        radius x yheight (along Y axis)
 *   sphere:          radius
 *   any shape:       geometry=OFF/PLY_file
@@ -46,7 +46,7 @@
 * %Link
 * Geomview and Object File Format (OFF) <http://www.geomview.org>
 * %Link
-* Java version of Geomview (display only) jroff.jar <http://www.holmes3d.net/graphics/roffview/> 
+* Java version of Geomview (display only) jroff.jar <http://www.holmes3d.net/graphics/roffview/>
 * %Link
 * qhull <http://qhull.org>
 * %Linkink
@@ -60,7 +60,7 @@ DEFINE COMPONENT Filter
 SETTING PARAMETERS (refraction=1,fixed_delta=0,string material_datafile="Be.txt",
     string geometry=0,xwidth=0,yheight=0,zdepth=0,radius=0)
 
-/* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */ 
+/* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
 
 SHARE
 %{
@@ -223,6 +223,11 @@ TRACE
           nz = 1.0;
         };
         break;
+      case SPHERE:
+        nx = x;
+        ny = y;
+        nz = z;
+        break;
       default:
         1;
       }
@@ -264,6 +269,11 @@ TRACE
           ny = 0.0;
           nz = 1.0;
         };
+        break;
+      case SPHERE:
+        nx = x;
+        ny = y;
+        nz = z;
         break;
       default:
         1;

--- a/mcxtrace-comps/optics/Filter.comp
+++ b/mcxtrace-comps/optics/Filter.comp
@@ -28,6 +28,9 @@
 *
 * Example: Filter(material_datafile="Ge.txt",
 *   geometry="wire.ply",xwidth=0.02,yheight=0,zdepth=0)
+* Example: Filter(material_datafile="Ge.txt",xwidth=0.02,yheight=0.02, zdepth=1e-4)
+* Example: Filter(material_datafile="Ge.txt",radius=1e-4,yheight=0.02)
+* Example: Filter(material_datafile="Ge.txt",radius=1e-3, refraction=1)
 *
 * %Parameters
 * INPUT PARAMETERS
@@ -237,7 +240,7 @@ TRACE
         } else {
           nx = x;
           nz = z;
-          y = 0.0;
+          ny = 0.0;
           NORM(nx,ny,nz);
         }
         break;
@@ -297,7 +300,7 @@ TRACE
         } else {
           nx = x;
           nz = z;
-          y = 0.0;
+          ny = 0.0;
           NORM(nx,ny,nz);
         }
         break;

--- a/mcxtrace-comps/optics/Filter.comp
+++ b/mcxtrace-comps/optics/Filter.comp
@@ -230,10 +230,10 @@ TRACE
         nx = x;
         ny = y;
         nz = z;
-        NORM(nx,ny,nz);
+        NORM (nx, ny, nz);
         break;
       case CYLINDER:
-        if (fabs(y - yheight * 0.5)< FLT_EPSILON || fabs(y + yheight * 0.5) < FLT_EPSILON){
+        if (fabs (y - yheight * 0.5) < FLT_EPSILON || fabs (y + yheight * 0.5) < FLT_EPSILON) {
           x = 0.0;
           y = 1.0;
           z = 0.0;
@@ -241,7 +241,7 @@ TRACE
           nx = x;
           nz = z;
           ny = 0.0;
-          NORM(nx,ny,nz);
+          NORM (nx, ny, nz);
         }
         break;
       default:
@@ -290,10 +290,10 @@ TRACE
         nx = x;
         ny = y;
         nz = z;
-        NORM(nx,ny,nz);
+        NORM (nx, ny, nz);
         break;
       case CYLINDER:
-        if (fabs(y - yheight * 0.5)< FLT_EPSILON || fabs(y + yheight * 0.5) < FLT_EPSILON){
+        if (fabs (y - yheight * 0.5) < FLT_EPSILON || fabs (y + yheight * 0.5) < FLT_EPSILON) {
           x = 0.0;
           y = 1.0;
           z = 0.0;
@@ -301,7 +301,7 @@ TRACE
           nx = x;
           nz = z;
           ny = 0.0;
-          NORM(nx,ny,nz);
+          NORM (nx, ny, nz);
         }
         break;
       default:

--- a/mcxtrace-comps/optics/Filter.comp
+++ b/mcxtrace-comps/optics/Filter.comp
@@ -228,6 +228,18 @@ TRACE
         ny = y;
         nz = z;
         break;
+      case CYLINDER:
+        if (fabs(y - yheight * 0.5)< FLT_EPSILON || fabs(y + yheight * 0.5) < FLT_EPSILON){
+          x = 0.0;
+          y = 1.0;
+          z = 0.0;
+        } else {
+          nx = x;
+          nz = z;
+          y = 0.0;
+          NORM(nx,ny,nz);
+        }
+        break;
       default:
         1;
       }
@@ -274,6 +286,18 @@ TRACE
         nx = x;
         ny = y;
         nz = z;
+        break;
+      case CYLINDER:
+        if (fabs(y - yheight * 0.5)< FLT_EPSILON || fabs(y + yheight * 0.5) < FLT_EPSILON){
+          x = 0.0;
+          y = 1.0;
+          z = 0.0;
+        } else {
+          nx = x;
+          nz = z;
+          y = 0.0;
+          NORM(nx,ny,nz);
+        }
         break;
       default:
         1;

--- a/mcxtrace-comps/optics/Filter.comp
+++ b/mcxtrace-comps/optics/Filter.comp
@@ -227,6 +227,7 @@ TRACE
         nx = x;
         ny = y;
         nz = z;
+        NORM(nx,ny,nz);
         break;
       case CYLINDER:
         if (fabs(y - yheight * 0.5)< FLT_EPSILON || fabs(y + yheight * 0.5) < FLT_EPSILON){
@@ -286,6 +287,7 @@ TRACE
         nx = x;
         ny = y;
         nz = z;
+        NORM(nx,ny,nz);
         break;
       case CYLINDER:
         if (fabs(y - yheight * 0.5)< FLT_EPSILON || fabs(y + yheight * 0.5) < FLT_EPSILON){

--- a/mcxtrace-comps/sources/Source_div.comp
+++ b/mcxtrace-comps/sources/Source_div.comp
@@ -8,7 +8,7 @@
 * Component: Source_div
 *
 * %Identification
-* Written by: Erik Knudsen 
+* Written by: Erik Knudsen
 * Date: November 11, 2009
 * Origin: Risoe
 * Release: McXtrace 0.1
@@ -21,9 +21,9 @@
 * in the range [-focus_ax,focus_ay]. If gauss is set, the focux_ax,focus_ay is considered
 * the standard deviation of the gaussian profile.
 * Currently focussing is only active for flat profile. The "focus window" is defined by focus_xw,focus_yh and dist.
-* The spectral intensity profile is uniformly distributed in the energy interval defined by e0+-dE/2 or 
+* The spectral intensity profile is uniformly distributed in the energy interval defined by e0+-dE/2 or
 * by wavelength lambda0+-dlambda/2
-* 
+*
 * Example: Source_div(xwidth=0.1, yheight=0.1, focus_aw=2, focus_ah=2, E0=14, dE=2, gauss=0)
 *
 * %Parameters
@@ -35,7 +35,7 @@
 * focus_yh: [m]   Height of sampling window
 * dist:     [m]   Downstream distance to place sampling target window
 * E0:       [keV] Mean energy of X-rays.
-* dE:       [keV] Energy half spread of X-rays. If gauss==0 dE is the half-spread, i.e. E\in[E0-dE,E0+dE], if gauss!=0 it's interpreted as the standard dev. 
+* dE:       [keV] Energy half spread of X-rays. If gauss==0 dE is the half-spread, i.e. E\in[E0-dE,E0+dE], if gauss!=0 it's interpreted as the standard dev.
 * lambda0:  [AA]  Mean wavelength of X-rays (only relevant for E0=0).
 * dlambda:  [AA]  Wavelength half spread of X-rays.
 * gauss:    [1]   Criterion: 0: uniform, 1: Gaussian distribution of energy/wavelength.
@@ -57,7 +57,7 @@ SETTING PARAMETERS (string spectrum_file="NULL", xwidth=0, yheight=0, dist=0,
     focus_xw=0, focus_yh=0,focus_aw=0, focus_ah=0, focus_ar=0, radius=0,
     E0=0, dE=0, lambda0=0, dlambda=0, flux=0, gauss=0, gauss_a=0, int randomphase=1, phase=0, int verbose=0)
 
-/* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */ 
+/* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
 
 SHARE
 %{
@@ -133,7 +133,7 @@ INITIALIZE
   pmul *= 1.0 / ((double)mcget_ncount ());
 
   if (dist == 0 && (focus_xw != 0 || focus_yh != 0)) {
-    fprintf (stderr, "ERROR (%s): Cannot have focus sampling window (focus_xw x focus_yh) = (%g x %g) with dist=0.\n", NAME_CURRENT_COMP);
+    fprintf (stderr, "ERROR (%s): Cannot have focus sampling window (focus_xw x focus_yh) = (%g x %g) with dist=0.\n", NAME_CURRENT_COMP, focus_xw, focus_yh);
     exit (-1);
   }
 


### PR DESCRIPTION
### Free-form text area
This PR adds cylinder and sphere geometries to the Filter component. They were previously only present as placeholders


--------------
### Development OS / boundary conditions
Debian 13

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [x] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [x] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised



