### PR TITLE
Provide SCATTER_func for libraries to replicate SCATTER functionality

### DIFF
--- a/mccode/nlib/share/mcstas-r.c
+++ b/mccode/nlib/share/mcstas-r.c
@@ -108,6 +108,20 @@ _class_particle mcgetstate(_class_particle mcneutron, double *x, double *y, doub
   return(mcneutron);
 } /* mcgetstate */
 
+/*******************************************************************************
+* SCATTER_func: provides function to SCATTER from within libaries
+*******************************************************************************/
+void SCATTER_func(_class_particle *_particle) {
+  if(mcdotrace) {
+    printf("SCATTER: %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g\n", 
+           _particle->x,_particle->y,_particle->z,
+           _particle->vx,_particle->vy,_particle->vz,
+		   _particle->t,
+		   _particle->sx,_particle->sy,_particle->sz,
+		   _particle->p);
+  }
+  if (!_particle->_absorbed) _particle->_scattered++;
+}  /* SCATTER_func */
 
 /*******************************************************************************
 * mcgenstate: set default neutron parameters

--- a/mccode/nlib/share/mcstas-r.h
+++ b/mccode/nlib/share/mcstas-r.h
@@ -52,6 +52,8 @@
 #define SCATTER0 do {DEBUG_SCATTER(); SCATTERED++;} while(0)
 #define SCATTER SCATTER0
 
+void SCATTER_func(_class_particle *_particle); /* provides function to SCATTER from within libaries */
+
 #define JUMPTOCOMP(comp) mcneutron->_index = INDEX_COMP(comp);
 
 #define MAGNET_ON \

--- a/mccode/xlib/share/mcxtrace-r.c
+++ b/mccode/xlib/share/mcxtrace-r.c
@@ -88,6 +88,20 @@ _class_particle mcgetstate(_class_particle mcphoton, double *x, double *y, doubl
   return(mcphoton);
 } /* mcgetstate */
 
+/*******************************************************************************
+* SCATTER_func: provides function to SCATTER from within libaries
+*******************************************************************************/
+void SCATTER_func(_class_particle *_particle) {
+  if(mcdotrace) {
+	  printf("SCATTER: %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g, %g\n",
+	         _particle->x,_particle->y,_particle->z,
+	         _particle->kx,_particle->ky,_particle->kz,
+			 _particle->phi,_particle->t,
+			 _particle->Ex,_particle->Ey,_particle->Ez,
+			 _particle->p);
+  }
+  if (!_particle->_absorbed) _particle->_scattered++;
+}  /* SCATTER_func */
 
 /*******************************************************************************
 * mcgenstate: set default photon parameters 

--- a/mccode/xlib/share/mcxtrace-r.h
+++ b/mccode/xlib/share/mcxtrace-r.h
@@ -49,6 +49,8 @@
 #define SCATTER0 do {DEBUG_SCATTER(); SCATTERED++;} while(0)
 #define SCATTER SCATTER0
 
+void SCATTER_func(_class_particle *_particle); /* provides function to SCATTER from within libaries */
+
 #define JUMPTOCOMP(comp) mcphoton->_index = INDEX_COMP(comp);
 
 /*magnet stuff is probably redundant*/

--- a/mcstas-comps/share/conic.h
+++ b/mcstas-comps/share/conic.h
@@ -863,6 +863,9 @@ void traceNeutronDisk(_class_particle* p, Disk d) {
         return;
 
     move_class_particleT(t, p);
+	
+	SCATTER_func(p);
+	
     if (d.absorb)
       absorb_class_particle(p);
 }
@@ -1702,6 +1705,7 @@ void traceNeutronConic(_class_particle* _particle, ConicSurf c) {
         return;
     else {
         move_class_particleT(t, _particle);
+		SCATTER_func(_particle);
         double ga = reflectNeutronConic(_particle, c);
 #if REC_MAX_GA
         if (ga > c.max_ga) {
@@ -1725,7 +1729,7 @@ void traceNeutronFlat(_class_particle* _particle, FlatSurf f) {
     else {
 
         move_class_particleT(t, _particle);
-
+		SCATTER_func(_particle);
         double ga = reflectNeutronFlat(_particle, f);
 
 #if REC_MAX_GA


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_
The SCATTER keyword works in components and provides the current position of the ray to plotting.

That makro is however not available within .c and .h files in share, so components that do most work there can not visualize the ray path in mcdisplay. Here a small function that replicate SCATTER is added to McStas and McXtrace. It is used in conic.h to show the ray path within nested mirror optics.

The function is called SCATTER_func and takes a pointer to the particle, _particle. It returns void.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_
OS X

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [X] I am have added reasoning and documentation for the change below
  * [] I am attaching test output in the comments

--------------



