### PR TITLE
Fix issue 2561 - make 2D-plot colorbars visible in “more” cases

### DIFF
--- a/tools/Python/mccodelib/pqtgfrontend.py
+++ b/tools/Python/mccodelib/pqtgfrontend.py
@@ -426,13 +426,17 @@ class McPyqtgraphPlotter():
         verbose  = n <= 4
         # NOTE: plotfuncs.plot_Data2D() only draws its colour-bar panel when
         # fontsize >= 8 (it (mis)uses this text-sizing value as a crowding
-        # threshold). With the original (4, 10, 14) tuple, any view with
-        # n >= 12 total monitors (1D+2D combined) dropped to fontsize=4,
-        # silently suppressing the colour bar for every 2D monitor in that
-        # view - not just making it small, but never drawing it at all.
-        # Bumping the low end from 4 to 8 keeps text reasonably compact in
-        # crowded views while guaranteeing the colour bar always renders.
-        fontsize = (8, 10, 14)[int(n <= 2) + int(n < 12)]
+        # threshold), so the smallest tier below must never go under 8.
+        # The breakpoint for that smallest tier is deliberately set above 12
+        # (rather than at 12) since a 12-pane overview is common enough that
+        # it should keep the more readable 10pt size; only genuinely dense
+        # views (>16 monitors) drop to 8pt.
+        if n <= 2:
+            fontsize = 14
+        elif n <= 16:
+            fontsize = 10
+        else:
+            fontsize = 8
 
         if self.viewmodel.logstate():
             cbmin = cbmax = None

--- a/tools/Python/mccodelib/pqtgfrontend.py
+++ b/tools/Python/mccodelib/pqtgfrontend.py
@@ -227,8 +227,8 @@ class McPyqtgraphPlotter():
             # Very old Qt5 fallback
             rect = QtWidgets.QApplication.desktop().screenGeometry()
 
-        w = int(0.7 * rect.width())
-        h = int(0.7 * rect.height())
+        w = int(0.85 * rect.width())
+        h = int(0.85 * rect.height())
         self.main_window.resize(w, h)
 
         self.plot_layout = pg.GraphicsLayout(border=None)

--- a/tools/Python/mccodelib/pqtgfrontend.py
+++ b/tools/Python/mccodelib/pqtgfrontend.py
@@ -424,7 +424,15 @@ class McPyqtgraphPlotter():
         rowlen = get_golden_rowlen(n)
 
         verbose  = n <= 4
-        fontsize = (4, 10, 14)[int(n <= 2) + int(n < 12)]
+        # NOTE: plotfuncs.plot_Data2D() only draws its colour-bar panel when
+        # fontsize >= 8 (it (mis)uses this text-sizing value as a crowding
+        # threshold). With the original (4, 10, 14) tuple, any view with
+        # n >= 12 total monitors (1D+2D combined) dropped to fontsize=4,
+        # silently suppressing the colour bar for every 2D monitor in that
+        # view - not just making it small, but never drawing it at all.
+        # Bumping the low end from 4 to 8 keeps text reasonably compact in
+        # crowded views while guaranteeing the colour bar always renders.
+        fontsize = (8, 10, 14)[int(n <= 2) + int(n < 12)]
 
         if self.viewmodel.logstate():
             cbmin = cbmax = None

--- a/tools/Python/mccodelib/pqtgfrontend.py
+++ b/tools/Python/mccodelib/pqtgfrontend.py
@@ -382,7 +382,7 @@ class McPyqtgraphPlotter():
     # ------------------------------------------------------------------
 
     def get_plot_func_opts(self, fromzero, log, legend, icolormap,
-                           verbose, fontsize, cbmin=None, cbmax=None):
+                           verbose, fontsize, cbmin=None, cbmax=None, cell_height=None):
         d = {}
         d['log']       = log
         d['fromzero']  = fromzero
@@ -390,6 +390,7 @@ class McPyqtgraphPlotter():
         d['icolormap'] = icolormap
         d['verbose']   = verbose
         d['fontsize']  = fontsize
+        d['cell_height'] = cell_height
         if cbmin is not None and cbmax is not None:
             d['cbmin'] = cbmin
             d['cbmax'] = cbmax
@@ -422,6 +423,15 @@ class McPyqtgraphPlotter():
 
         plt    = pg.PlotItem()
         rowlen = get_golden_rowlen(n)
+        rows   = math.ceil(n / rowlen) if rowlen > 0 else 1
+
+        # Approximate on-screen height of a single grid cell, from the
+        # *current* window size (so it reacts to live window resizes, not
+        # just the size at startup). Used to scale the colour bar's tick
+        # font: the same 12-pane overview should get a bigger colour bar
+        # font on a large/maximised window than squeezed into a small one.
+        win_size = self.main_window.size()
+        cell_height = win_size.height() / rows if rows > 0 else win_size.height()
 
         verbose  = n <= 4
         # NOTE: plotfuncs.plot_Data2D() only draws its colour-bar panel when
@@ -448,7 +458,7 @@ class McPyqtgraphPlotter():
             self.viewmodel.logstate(),
             self.viewmodel.legendstate(),
             self.viewmodel.cmapindex(),
-            verbose, fontsize, cbmin, cbmax)
+            verbose, fontsize, cbmin, cbmax, cell_height=cell_height)
 
         view_box, plt_itm = self.plot_func(node, i, plt, options)
         if view_box:

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -34,7 +34,7 @@ def plot(node, i, plt, opts):
         view_box, lyt = plot_Data2D(data, plt, log=opts['log'], legend=opts['legend'], icolormap=opts['icolormap'],
                                     verbose=opts['verbose'], fontsize=opts['fontsize'],
                                     cbmin=opts.get('cbmin', None), cbmax=opts.get('cbmax', None),
-                                    nplots=opts.get('nplots', None))
+                                    nplots=opts.get('nplots', None), cell_height=opts.get('cell_height', None))
         return view_box, lyt
     elif type(data) is Data0D:
         view_box = plot_Data0D(data, plt, log=opts['log'], legend=opts['legend'], icolormap=opts['icolormap'],
@@ -187,25 +187,39 @@ def get_color_map(idx, pos_min, pos_max):
     return pg.ColorMap(pos, colormap)
 
 
-def _colorbar_fontsize(nplots, fontsize):
+def _colorbar_fontsize(nplots, fontsize, cell_height=None):
     ''' Point size for the colour bar's tick labels.
 
-        Scales with the total number of monitors currently in view
-        (nplots), not the already-bucketed `fontsize` used for the main
-        plot text: stays at 8pt for views of 12 monitors or fewer, then
-        shrinks gradually (floored at 6pt) as the view gets more crowded.
+        Base size scales with the total number of monitors currently in
+        view (nplots), not the already-bucketed `fontsize` used for the
+        main plot text: stays at 8pt for views of 12 monitors or fewer,
+        then shrinks gradually (floored at 6pt) as the view gets more
+        crowded. Falls back to the previous fontsize-derived sizing if
+        `nplots` isn't supplied.
 
-        Falls back to the previous fontsize-derived sizing if `nplots`
-        isn't supplied (e.g. an older caller that hasn't been updated to
-        pass it through). '''
+        That base size is then scaled by `cell_height` - the actual
+        on-screen pixel height of one grid cell - relative to a reference
+        cell height (REFERENCE_CELL_HEIGHT). This means the same 12-pane
+        overview gets a visibly bigger colour bar font on a large/maximised
+        window than when squeezed into a small one, rather than a fixed
+        size regardless of how much room is actually available. Result is
+        clamped to [6, 14]pt. '''
     if nplots is None:
-        return max(6, int(fontsize) - 4)
-    if nplots <= 12:
-        return 8
-    return max(6, 8 - (nplots - 12) // 6)
+        base = max(6, int(fontsize) - 4)
+    elif nplots <= 12:
+        base = 8
+    else:
+        base = max(6, 8 - (nplots - 12) // 6)
+
+    if not cell_height:
+        return base
+
+    REFERENCE_CELL_HEIGHT = 300  # px; roughly a 12-pane overview on a typical laptop screen
+    scaled = round(base * (cell_height / REFERENCE_CELL_HEIGHT))
+    return max(6, min(scaled, 14))
 
 
-def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, fontsize=10, cbmin=None, cbmax=None, nplots=None):
+def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, fontsize=10, cbmin=None, cbmax=None, nplots=None, cell_height=None):
     ''' create a layout and populate a plotItem with data Data2D, adding a color bar '''
     # data
     img = pg.ImageItem()
@@ -323,7 +337,7 @@ def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, f
         # axis/legend text (which uses `fontsize` as-is), since the bar
         # itself is only 40px wide and doesn't need large numbers.
         cb_font = QtGui.QFont()
-        cb_font.setPointSize(_colorbar_fontsize(nplots, fontsize))
+        cb_font.setPointSize(_colorbar_fontsize(nplots, fontsize, cell_height))
         colorbar.axes['right']['item'].setTickFont(cb_font)
 
         colorbar.getViewBox().autoRange(padding=0)

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -33,7 +33,8 @@ def plot(node, i, plt, opts):
     elif type(data) is Data2D:
         view_box, lyt = plot_Data2D(data, plt, log=opts['log'], legend=opts['legend'], icolormap=opts['icolormap'],
                                     verbose=opts['verbose'], fontsize=opts['fontsize'],
-                                    cbmin=opts.get('cbmin', None), cbmax=opts.get('cbmax', None))
+                                    cbmin=opts.get('cbmin', None), cbmax=opts.get('cbmax', None),
+                                    nplots=opts.get('nplots', None))
         return view_box, lyt
     elif type(data) is Data0D:
         view_box = plot_Data0D(data, plt, log=opts['log'], legend=opts['legend'], icolormap=opts['icolormap'],
@@ -186,7 +187,25 @@ def get_color_map(idx, pos_min, pos_max):
     return pg.ColorMap(pos, colormap)
 
 
-def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, fontsize=10, cbmin=None, cbmax=None):
+def _colorbar_fontsize(nplots, fontsize):
+    ''' Point size for the colour bar's tick labels.
+
+        Scales with the total number of monitors currently in view
+        (nplots), not the already-bucketed `fontsize` used for the main
+        plot text: stays at 8pt for views of 12 monitors or fewer, then
+        shrinks gradually (floored at 6pt) as the view gets more crowded.
+
+        Falls back to the previous fontsize-derived sizing if `nplots`
+        isn't supplied (e.g. an older caller that hasn't been updated to
+        pass it through). '''
+    if nplots is None:
+        return max(6, int(fontsize) - 4)
+    if nplots <= 12:
+        return 8
+    return max(6, 8 - (nplots - 12) // 6)
+
+
+def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, fontsize=10, cbmin=None, cbmax=None, nplots=None):
     ''' create a layout and populate a plotItem with data Data2D, adding a color bar '''
     # data
     img = pg.ImageItem()
@@ -299,6 +318,13 @@ def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, f
         colorbar.axes['left']['item'].show()
         colorbar.axes['left']['item'].setStyle(showValues=False)
         colorbar.axes['right']['item'].show()
+
+        # Colour bar tick labels: noticeably smaller than the main plot's
+        # axis/legend text (which uses `fontsize` as-is), since the bar
+        # itself is only 40px wide and doesn't need large numbers.
+        cb_font = QtGui.QFont()
+        cb_font.setPointSize(_colorbar_fontsize(nplots, fontsize))
+        colorbar.axes['right']['item'].setTickFont(cb_font)
 
         colorbar.getViewBox().autoRange(padding=0)
 


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

It turns out that #2561 was partly intentional: fontsize 4 was used as a ‘filter’ to not show the colorbar in overviews when ‘enough’ plots were present.

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

Ping-pong with claude to help pinpoint the relevant parts of the tool code.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



