### PR TITLE
New tool: mcplotdiff-matplotlib, render difference plots between two datasets (follow-up for #2562)

### DIFF
--- a/cmake/Modules/InstallMCCODE.cmake
+++ b/cmake/Modules/InstallMCCODE.cmake
@@ -415,7 +415,7 @@ macro(installMCCODE)
     install(PROGRAMS ${WORK}/support/${FLAVOR}-labenv.bat DESTINATION "${DEST_BINDIR}")
 
     # Python/Perl related batches special handling
-    foreach (name run.bat doc.bat test.bat viewtest.bat resplot.bat plot.bat plotdiff.bat display.bat gui.bat guistart.bat plot-pyqtgraph.bat plotdiff-pyqtgraph.bat plot-matplotlib.bat plot-matlab.bat plot-html.bat plotdiff-html.bat display-webgl.bat display-webgl-classic.bat display-pyqtgraph.bat display-cad.bat display-matplotlib.bat display-mantid.bat display-matlab.bat)
+    foreach (name run.bat doc.bat test.bat viewtest.bat resplot.bat plot.bat plotdiff.bat display.bat gui.bat guistart.bat plot-pyqtgraph.bat plotdiff-pyqtgraph.bat plot-matplotlib.bat plotdiff-matplotlib.bat plot-matlab.bat plot-html.bat plotdiff-html.bat display-webgl.bat display-webgl-classic.bat display-pyqtgraph.bat display-cad.bat display-matplotlib.bat display-mantid.bat display-matlab.bat)
       configure_file(
 	      cmake/support/run-scripts/${name}.in
 	      work/support/${MCCODE_PREFIX}${name}

--- a/cmake/support/run-scripts/display-matplotlib.bat.in
+++ b/cmake/support/run-scripts/display-matplotlib.bat.in
@@ -1,5 +1,6 @@
-@CALL @CPACK_NSIS_INSTALL_ROOT@\bin\@FLAVOR@env.bat
+@echo off
 @set BINDIR=%~dp0
+@CALL %BINDIR%\mccodeenv.bat
 @SET PATH=%BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@display\matplotlib;%PATH%
 @REM Isn't windows a lovely place???
 @@MCCODE_PREFIX@run %* --trace=2 --no-output-files -n1e2 | python %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@display\matplotlib\@MCCODE_PREFIX@display.py

--- a/cmake/support/run-scripts/plot-matplotlib.bat.in
+++ b/cmake/support/run-scripts/plot-matplotlib.bat.in
@@ -1,5 +1,6 @@
-@CALL @CPACK_NSIS_INSTALL_ROOT@\bin\mccodeenv.bat
+@echo off
 @set BINDIR=%~dp0
+@CALL %BINDIR%\mccodeenv.bat
 @SET PATH=%BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib;%PATH%
 @REM Isn't windows a lovely place???
 @python %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib\@MCCODE_PREFIX@plot.py %*

--- a/cmake/support/run-scripts/plotdiff-matplotlib.bat.in
+++ b/cmake/support/run-scripts/plotdiff-matplotlib.bat.in
@@ -1,0 +1,6 @@
+@CALL @CPACK_NSIS_INSTALL_ROOT@\bin\mccodeenv.bat
+@set BINDIR=%~dp0
+@SET PATH=%BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib;%PATH%
+@REM Isn't windows a lovely place???
+@python %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib\@MCCODE_PREFIX@plotdiff.py %*
+@exit

--- a/cmake/support/run-scripts/plotdiff-matplotlib.bat.in
+++ b/cmake/support/run-scripts/plotdiff-matplotlib.bat.in
@@ -1,5 +1,6 @@
-@CALL @CPACK_NSIS_INSTALL_ROOT@\bin\mccodeenv.bat
+@echo off
 @set BINDIR=%~dp0
+@CALL %BINDIR%\mccodeenv.bat
 @SET PATH=%BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib;%PATH%
 @REM Isn't windows a lovely place???
 @python %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib\@MCCODE_PREFIX@plotdiff.py %*

--- a/tools/Python/mcplot/matplotlib/CMakeLists.txt
+++ b/tools/Python/mcplot/matplotlib/CMakeLists.txt
@@ -87,14 +87,33 @@ install(
   RENAME "${P}plot.py"
   )
 
+# Configure fallback script for the a-b difference plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcplotdiff.in" "${WORK}/${P}plotdiff-matplotlib" @ONLY)
+
+# Configure doc for the a-b difference plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mcplotdiff-matplotlib.md.in" "${WORK}/${P}plotdiff-matplotlib.md" @ONLY)
+
+# Difference-plotter script, including rename mc/mxplotdiff
+install(
+  PROGRAMS "${PROJECT_SOURCE_DIR}/mcplotdiff.py"
+  DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+  RENAME "${P}plotdiff.py"
+  )
+
 # Other .py infrastructure
-# None
+# plotfuncs.py holds the shared, non-CLI plotting/interaction code used by
+# both mcplot.py and mcplotdiff.py; it is NOT renamed (unlike mcplot.py),
+# so both scripts can import it by a fixed name regardless of flavor.
+install(
+  FILES "${PROJECT_SOURCE_DIR}/plotfuncs.py"
+  DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+  )
 
 # Wrapper-scripts on windows are handled via
 # cmake Modules/MCUtil
 if(NOT WINDOWS)
   add_custom_target(
-    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot-matplotlib"
+    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot-matplotlib" "${WORK}/${P}plotdiff-matplotlib"
     )
 
   install(
@@ -110,6 +129,22 @@ if(NOT WINDOWS)
     
   install(
     FILES "${WORK}/${P}plot-matplotlib.md"
+    DESTINATION "${DEST_DATADIR_DOC}"
+  )
+
+  install(
+    PROGRAMS ${PROJECT_SOURCE_DIR}/mcplotdiff.py
+    DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+    RENAME "${P}plotdiff.py"
+  )
+
+  install(
+    PROGRAMS "${WORK}/${P}plotdiff-matplotlib"
+    DESTINATION ${DEST_BINDIR}
+    )
+
+  install(
+    FILES "${WORK}/${P}plotdiff-matplotlib.md"
     DESTINATION "${DEST_DATADIR_DOC}"
   )
 endif()

--- a/tools/Python/mcplot/matplotlib/mcplot.py
+++ b/tools/Python/mcplot/matplotlib/mcplot.py
@@ -8,296 +8,20 @@ import logging
 import os
 import sys
 import subprocess
-import math
-import numpy as np
-import matplotlib 
+import matplotlib
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 
+import plotfuncs
+
 from mccodelib.mcplotloader import McCodeDataLoader, test_decfuncs
 from mccodelib.plotgraph import PlotGraphPrint
-
-from mccodelib.plotgraph import PNSingle
-from mccodelib.mcplotloader import Data1D, Data2D
 from mccodelib.mccode_config import get_mccode_prefix
-filenamebase=get_mccode_prefix() + 'plot'
 from mccodelib import mccode_config
-
-FONTSIZE = 10
-
-# Global placeholder for later import of pylab inside main()
-# - necessary due to use of matplotlib.use() which has to happen
-# before import of pylab
-pylab=0
-
-
-def plot_single_data(node, i, n, log):
-    ''' plot the data of node, at index i, to a subplot '''
-    def calc_panel_size(nfigs):
-        nx = int(math.sqrt(nfigs*1.61803398875)) # golden ratio
-        ny = nfigs // nx + int(bool(nfigs % nx))
-        return nx, ny
-
-    if type(node) == PNSingle and i != 0:
-        raise Exception("inconsistent plot request, idx=%s" % str(i))
-
-    dims = calc_panel_size(n)
-    subplt = pylab.subplot(dims[1],dims[0],i+1)
-    data = node.getdata_idx(i)
-
-    verbose = n == 1
-
-    if type(data) is Data1D:
-        ''' plot 1D data '''
-        xmin = data.xlimits[0]
-        xmax = data.xlimits[1]
-        pylab.xlim(xmin,xmax)
-
-        x = np.array(data.xvals).astype(float)
-        y = np.array(data.yvals).astype(float)
-        yerr = np.array(data.y_err_vals).astype(float)
-
-        ylabel = data.ylabel
-        if log == True:
-            # handle Log intensity
-            invalid = np.where(y <= 0)
-            valid   = np.where(y > 0)
-            if len(valid[0]):
-                min_valid  = np.min(y[valid])
-                y[invalid] = min_valid/10
-            yerr=yerr / y
-            y=np.log(y)
-            ylabel ="log(" + data.ylabel +")"
-
-        pylab.errorbar(x, y, yerr)
-
-        pylab.xlabel(data.xlabel, fontsize=FONTSIZE, fontweight='bold')
-        pylab.ylabel(ylabel, fontsize=FONTSIZE, fontweight='bold')
-        try:
-            title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
-        except:
-            title = '%s\n[%s]' % (data.component, data.filename)
-        pylab.title(title, fontsize=FONTSIZE, fontweight='bold')
-
-    elif type(data) is Data2D:
-        ''' plot 2D data '''
-        zvals = np.array(data.zvals)
-
-        xmin = data.xlimits[0]
-        xmax = data.xlimits[1]
-        ymin = data.xlimits[2]
-        ymax = data.xlimits[3]
-
-        mysize=zvals.shape
-        x = pylab.linspace(xmin, xmax, mysize[1])
-        y = pylab.linspace(ymin, ymax, mysize[0])
-        pylab.xlim(xmin, xmax)
-        pylab.ylim(ymin, ymax)
-
-        if log == True:
-            invalid = np.where(zvals <= 0)
-            valid = np.where(zvals > 0)
-            min_valid = np.min(zvals[valid])
-            zvals[invalid] = min_valid/10
-            zvals = np.log(zvals)
-
-        ''' out-commented code: alternative plot types '''
-        #from mpl_toolkits.mplot3d import Axes3D
-        #ax = Axes3D(pylab.gcf())
-        #pylab.contour(x,y,zvals)
-        #ax.plot_surface(x,y,zvals)
-        pylab.pcolor(x,y,zvals)
-        pylab.colorbar()
-
-        pylab.xlabel(data.xlabel, fontsize=FONTSIZE, fontweight='bold')
-        pylab.ylabel(data.ylabel, fontsize=FONTSIZE, fontweight='bold')
-
-        try:
-            title = '%s\nI = %s' % (data.component, data.values[0])
-            if verbose:
-                title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
-        except:
-            title = '%s\n[%s]' % (data.component, data.filename)
-        pylab.title(title, fontsize=FONTSIZE, fontweight='bold')
-
-    else:
-        print("Unsuported plot data type %s" % type(data))
-
-    return subplt
-
-
-class McMatplotlibPlotter():
-    ''' matplotlib plotting frontend '''
-    def __init__(self, sourcedir, log):
-        self.sourcedir = sourcedir
-        self.event_dc_cid = None
-        self.log = log
-
-
-    def _flip_log(self):
-        self.log = not self.log
-
-
-    def _click_proxy(self, event):
-        ''' state-updating proxy for click handler '''
-        dc_cb = lambda: pylab.disconnect(self.event_dc_cid)
-        click(event, subplts=self.subplts, click_cbs=self.click_cbs,
-              ctrl_cbs=self.ctrl_cbs, back_cb=self.back_cb, dc_cb=dc_cb)
-
-
-    def _keypress_proxy(self, event):
-        ''' state-updating proxy for keypress handler '''
-        keypress(event, back_cb=self.back_cb, replot_cb=self.replot_cb,
-                 togglelog_cb=self._flip_log)
-
-
-    def plot_node(self, node):
-        ''' plot recursion '''
-        # safety
-        if not node:
-            return
-
-        # clear
-        pylab.close()
-
-        # plot data and keep subplots for the click area filter
-        n = node.getnumdata()
-        self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
-
-        # create callbacks
-        self.click_cbs = [lambda nde=n: self.plot_node(nde) for n in node.primaries]
-        self.ctrl_cbs = [lambda nde=n: self.plot_node(nde) for n in node.secondaries]
-        # we need root node back click to prompt a replot, rather than to be ignored,
-        # because disconnect is always called by the click handler
-        bck_node = node.parent if node.parent else node 
-        self.back_cb = lambda n=bck_node: self.plot_node(n)
-        self.replot_cb = lambda n=node: self.plot_node(n) if node else None
-
-        # regiseter click events
-        self.event_dc_cid = pylab.connect('button_press_event', self._click_proxy)
-
-        # register keypress events
-        pylab.connect('key_press_event', self._keypress_proxy)
-
-        # show the plot
-        pylab.show()
-
-
-    def html_node(self, node, fileobj):
-        '''  plots node and saves to html using mpld3 '''
-        import mpld3
-        
-        n = node.getnumdata()
-        self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
-        
-        mpld3.save_html(pylab.gcf(), fileobj)
-
-
-def keypress(event, back_cb, replot_cb, togglelog_cb):
-    key = event.key.lower()
-
-    if key == 'q':
-        quit()
-    elif key == 'l':
-        togglelog_cb()
-        replot_cb()
-    elif event.key == 'p':
-        dumpfile('ps')
-    elif event.key == 'd':
-        dumpfile('pdf')
-    elif event.key == 'n':
-        dumpfile('png')
-    elif event.key == 'j':
-        dumpfile('jpg')
-    elif key == 'b':
-        back_cb()
-    elif key == 'f5':
-        replot_cb()
-    elif key == 'f1' or key == 'h':
-        print_help()
-    elif key == 'b':
-        back_cb()
-
-
-def print_help(nogui=False):
-    helplines = []
-    helplines.append('')
-    helplines.append('q              - quit')
-    helplines.append('F1/h           - help')
-    helplines.append('l              - toggle log')
-    helplines.append('p              - save ps')
-    helplines.append('d              - save pdf')
-    helplines.append('n              - save png')
-    helplines.append('j              - save jpg')
-    helplines.append('s              - native save dialog')
-    helplines.append('F5             - replot')
-    helplines.append('click          - display subplot')
-    helplines.append('right-click/b  - back')
-    helplines.append('ctrl + click   - sweep monitors')
-    print('\n'.join(helplines))
-
-
-def dumpfile(frmat, filename = None):
-    """ save current fig to softcopy """
-    from pylab import savefig
-
-    global filenamebase
-    
-    if filename is None:
-        filename = filenamebase
-        
-    # get directory, basename and extension
-    if isinstance(filename, list):
-        filename = filename[0]
-    basename  = os.path.splitext(filename)[0] # contains full path and base filename
-    if frmat is None:
-        ext       = os.path.splitext(filename)[1] # extension with the dot
-    else:
-        ext = frmat
-    if ext[0] != '.':
-        ext = '.'+ext
-    # assemble target name
-    saveto = basename + ext
-    
-    # Check for existance of earlier exports
-    if os.path.isfile(saveto):
-        index=1
-        saveto = f"{basename}_{index}{frmat}"
-        while os.path.isfile(saveto):
-            index += 1
-            saveto = f"{basename}_{index}{frmat}"
-
-    savefig(saveto)
-    print("Saved " + saveto)
-
-
-def click(event, subplts, click_cbs, ctrl_cbs, back_cb, dc_cb):
-    subplt = event.inaxes
-    if not subplt:
-        return False
-    else:
-        lclick = event.button==1
-        rclick = event.button==3
-        ctrlmod = (event.key == 'control' or event.key == 'cmd' or event.key == 'x')
-
-        if lclick and len(click_cbs) > 0 and not ctrlmod:
-            # left button
-            idx = subplts.index(subplt)
-            dc_cb()
-            click_cbs[idx]()
-        elif rclick and back_cb and not ctrlmod:
-            # right button
-            dc_cb()
-            back_cb()
-        elif ctrlmod and len(ctrl_cbs) > 0:
-            # control-click
-            idx = subplts.index(subplt)
-            dc_cb()
-            ctrl_cbs[idx]()
 
 
 def main(args):
-    ''' load data from mcplot backend and send it to the pyqtgraph frontend above '''
+    ''' load data from mcplot backend and send it to the matplotlib frontend above '''
     logging.basicConfig(level=logging.INFO)
     
     # ensure keyboardinterrupt ctr-c
@@ -343,8 +67,8 @@ def main(args):
                 print('backend use error: ' + e.__str__())
                 return
 
-        global pylab
         from matplotlib import pylab
+        plotfuncs.pylab = pylab
 
         # load data
         loader = McCodeDataLoader(simfile=simfile)
@@ -353,26 +77,26 @@ def main(args):
         except Exception as e:
             # invallid input case:
             print('mcplot loader: ' + e.__str__())
-            print_help(nogui=True)
+            plotfuncs.print_help(nogui=True)
             quit()
         rootnode = loader.plot_graph
         if args.test:
             PlotGraphPrint(rootnode)
 
         # start the plotter
-        plotter = McMatplotlibPlotter(sourcedir=loader.directory,log=args.log)
+        plotter = plotfuncs.McMatplotlibPlotter(sourcedir=loader.directory, log=args.log)
 
         if (sys.platform == "linux" or sys.platform == "linux2") & args.html:
             # save to html and exit
             plotter.html_node(rootnode, open('%s.html' % os.path.splitext(simfile)[0], 'w'))
         else:
             # display gui / prepare graphics dump
-            print_help(nogui=True)
+            plotfuncs.print_help(nogui=True)
             plotter.plot_node(rootnode)
         
         if args.output or args.format:
             try:
-                dumpfile(args.format, args.output)
+                plotfuncs.dumpfile(args.format, args.output)
             except Exception as e:
                 print('dumpfile issue: ' + e.__str__())
 
@@ -405,3 +129,4 @@ if __name__ == '__main__':
     mccode_config.load_config("user")
 
     main(args)
+

--- a/tools/Python/mcplot/matplotlib/mcplotdiff-matplotlib.md.in
+++ b/tools/Python/mcplot/matplotlib/mcplotdiff-matplotlib.md.in
@@ -1,0 +1,87 @@
+% @MCCODE_PREFIX@PLOTDIFF-MATPLOTLIB(1)
+% @FLAVOR_UPPER@ @MCCODE_PARTICLE@ Ray Tracing Team
+% @MCCODE_DATE@
+
+# NAME
+
+**@MCCODE_PREFIX@plotdiff-matplotlib** - Plotting the difference between two @MCCODE_NAME@ simulation results using Matplotlib
+
+# SYNOPSIS
+
+**@MCCODE_PREFIX@plotdiff-matplotlib** [-h] [-A LABEL_A] [-B LABEL_B] [-t] [--html] [--format FORMAT] [--output OUTPUT] [--log] [--backend BACKEND] a b
+
+# DESCRIPTION
+
+The front-end **@MCCODE_PREFIX@plotdiff-matplotlib** produces plots of the
+*difference* between the monitors of two @MCCODE_NAME@ simulation results,
+i.e. `diff.monN = a.monN - b.monN` for every monitor output file `monN` that
+is present, with matching binning, in both simulation results `a` and `b`.
+This is useful to quickly spot how two simulation runs differ, e.g. after a
+component or parameter change, a McCode version upgrade, or comparing MPI
+vs. non-MPI results.
+
+`a` and `b` may each be either a simulation output directory (as produced by
+`@MCCODE_PREFIX@run`, containing a `mccode.sim` file) or a single monitor
+data file. Only monitors present in both `a` and `b`, with identical
+binning, are compared; monitors found in only one of the two inputs, or with
+mismatched binning, are skipped with a warning printed to the console.
+
+This tool reuses the same Matplotlib-based plotting code as
+**@MCCODE_PREFIX@plot-matplotlib** (mouse click drill-down, keyboard
+shortcuts, PNG/PDF/SVG export, etc. -- see the keyboard shortcuts printed on
+startup), applied to the computed diff monitors instead of a single
+simulation's monitors.
+
+# OPTIONS
+
+**-h, --help**
+:   show this help message and exit
+
+**-A LABEL_A, --label-a LABEL_A**
+:   short label used for simulation `a` in titles/filenames (default: the
+    basename of `a`)
+
+**-B LABEL_B, --label-b LABEL_B**
+:   short label used for simulation `b` in titles/filenames (default: the
+    basename of `b`)
+
+**-t, --test**
+:   plot graph structure test/print
+
+**--html**
+:   save plot to html using mpld3 (linux only)
+
+**--format FORMAT**
+:   save plot to pdf/png/eps/svg... without bringing up window
+
+**--output OUTPUT**
+:   save plot to given file without bringing up window. Extension (e.g.
+    pdf/png/eps/svg) can be specified in the file name or `--format`
+
+**--log**
+:   initiate plot(s) with log of signal
+
+**--backend BACKEND**
+:   use non-default backend for matplotlib plot
+
+# FILES
+
+/usr/share/@FLAVOR@/resources
+/usr/share/@FLAVOR@/tools/Python/mccodelib/mccode_config.json
+~/.@FLAVOR@/mccode_config.json
+http://www.@FLAVOR@.org
+
+# EXAMPLES
+
+Run the *Test_SX* example (Single crystal diffraction) twice with different parameters, and plot the difference
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_a -n 1e7 TTH=13.4`
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_b -n 1e7 TTH=14.0`
+:   - `@MCCODE_PREFIX@plotdiff-matplotlib output_a output_b`
+
+# AUTHORS
+
+@MCCODE_NAME@ Team (@FLAVOR@.org)
+
+# SEE ALSO
+
+@FLAVOR@(1), @MCCODE_PREFIX@doc(1), @MCCODE_PREFIX@plot(1), @MCCODE_PREFIX@plot-matplotlib(1), @MCCODE_PREFIX@plotdiff-html(1), @MCCODE_PREFIX@plotdiff-pyqtgraph(1), @MCCODE_PREFIX@run(1), @MCCODE_PREFIX@gui(1), @MCCODE_PREFIX@display(1)

--- a/tools/Python/mcplot/matplotlib/mcplotdiff.in
+++ b/tools/Python/mcplot/matplotlib/mcplotdiff.in
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Wrapper script for @P@plotdiff-matplotlib-py
+
+@MCCODE_BASH_STANDARD_PREAMBLE@
+
+TOOL="@P@plotdiff"
+UTILDIR="${MCCODE_TOOLDIR}/Python/@P@plot/matplotlib"
+
+
+#NB: miniconda should be installed next to the tool folder:
+if [ -d "${MCCODE_TOOLDIR}/../miniconda3" ]; then
+    source "${MCCODE_TOOLDIR}/../miniconda3/bin/activate" "${MCCODE_TOOLDIR}/../miniconda3"
+    export PATH=${MCCODE_TOOLDIR}/../miniconda3/bin/:$PATH
+fi
+
+canrun() {
+    if ! [ -x "${UTILDIR}/${TOOL}.py" ]; then
+        exit 127;
+    fi
+
+    modules="matplotlib numpy"
+    cmd=""
+    for name in ${modules}; do
+        cmd="${cmd}import ${name}; "
+    done
+    python3 -c "${cmd}"
+}
+
+if ( canrun ); then
+    python3 -u ${UTILDIR}/${TOOL}.py "$@"
+else
+    @FLAVOR@_errmsg Failed to run Python ${TOOL} - permissions or missing dependencies\?
+fi

--- a/tools/Python/mcplot/matplotlib/mcplotdiff.py
+++ b/tools/Python/mcplot/matplotlib/mcplotdiff.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+'''
+matplotlib mcplotdiff frontend.
+
+This is an alternative variant of mcplot.py (the mcplot-matplotlib /
+mxplot-matplotlib tool) that, instead of interactively browsing the monitors
+of a single simulation, takes two simulation folders (or two single monitor
+files) 'a' and 'b' and interactively browses the *difference*
+diff.monN = a.monN - b.monN, for every monitor that is present (with
+matching binning) in both simulations.
+
+The monitor-loading, matching and subtraction logic lives in
+mccodelib.mcplotdiffloader (shared with the mcplot-diff-html and
+mcplot-diff-pyqtgraph frontends); this script just assembles a plot graph
+from the diff data and hands it to the same plotting code (plotfuncs.py)
+used by ordinary mcplot-matplotlib, so that difference data can be browsed,
+zoomed, and saved to disk exactly like regular simulation data.
+'''
+import argparse
+import logging
+import os
+import sys
+import matplotlib
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+import plotfuncs
+
+from mccodelib.plotgraph import PlotGraphPrint
+from mccodelib import mcplotdiffloader as diffloader
+from mccodelib import mccode_config
+
+
+def main(args):
+    ''' load and diff two simulation results, then hand the resulting diff
+        plot graph to the matplotlib frontend, same way mcplot.py does for a
+        single simulation. '''
+    logging.basicConfig(level=logging.INFO)
+
+    # ensure keyboardinterrupt ctr-c
+    import signal
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    try:
+        label_a = args.label_a[0] if args.label_a else None
+        label_b = args.label_b[0] if args.label_b else None
+
+        if args.format or args.output:
+            matplotlib.use('template')
+
+        if args.backend:
+            try:
+                matplotlib.use(args.backend)
+            except Exception as e:
+                print('backend use error: ' + e.__str__())
+                return
+
+        from matplotlib import pylab
+        plotfuncs.pylab = pylab
+
+        try:
+            diffs, dir_a, dir_b, label_a, label_b = diffloader.load_and_diff(
+                args.a, args.b, label_a, label_b)
+        except Exception as e:
+            print('mcplotdiff loader: ' + e.__str__())
+            plotfuncs.print_help(nogui=True)
+            quit()
+
+        if len(diffs) == 0:
+            print("mcplotdiff: no matching monitors found between '%s' and '%s', nothing to plot."
+                  % (args.a, args.b))
+            quit()
+
+        graph = diffloader.build_diff_plotgraph(diffs)
+
+        if args.test:
+            PlotGraphPrint(graph)
+
+        # default base name for --format/--output dumps and for --html,
+        # since there's no single simulation file to derive it from
+        plotfuncs.filenamebase = "diff_%s_vs_%s" % (label_a, label_b)
+
+        plotter = plotfuncs.McMatplotlibPlotter(
+            sourcedir='diff: %s - %s' % (label_a, label_b), log=args.log)
+
+        if (sys.platform == "linux" or sys.platform == "linux2") and args.html:
+            # save to html and exit
+            plotter.html_node(graph, open('%s.html' % plotfuncs.filenamebase, 'w'))
+        else:
+            # display gui / prepare graphics dump
+            plotfuncs.print_help(nogui=True)
+            plotter.plot_node(graph)
+
+        if args.output or args.format:
+            try:
+                plotfuncs.dumpfile(args.format, args.output)
+            except Exception as e:
+                print('dumpfile issue: ' + e.__str__())
+
+    except KeyboardInterrupt:
+        print('keyboard interrupt')
+    except Exception as e:
+        print('mcplotdiff error: %s' % e.__str__())
+        raise e
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('a', help='first simulation file or directory (the minuend, "a")')
+    parser.add_argument('b', help='second simulation file or directory (the subtrahend, "b"); diff = a - b')
+    parser.add_argument('-A', '--label-a', nargs=1, help='short label used for simulation a in titles/filenames')
+    parser.add_argument('-B', '--label-b', nargs=1, help='short label used for simulation b in titles/filenames')
+    parser.add_argument('-t', '--test', action='store_true', default=False, help='plot graph structure test/print')
+    parser.add_argument('--html', action='store_true', help='save plot to html using mpld3 (linux only)')
+    parser.add_argument('--format', dest='format', help='save plot to pdf/png/eps/svg... without bringing up window')
+    parser.add_argument('--output', nargs=1, dest='output', default=None,
+                         help='save plot to given file without bringing up window. Extension '
+                              '(e.g. pdf/png/eps/svg) can be specified in the file name or --format')
+    parser.add_argument('--log', action='store_true', help='initiate plot(s) with log of signal')
+    parser.add_argument('--backend', dest='backend', help='use non-default backend for matplotlib plot')
+
+    args = parser.parse_args()
+
+    mccode_config.load_config("user")
+
+    main(args)

--- a/tools/Python/mcplot/matplotlib/plotfuncs.py
+++ b/tools/Python/mcplot/matplotlib/plotfuncs.py
@@ -1,0 +1,297 @@
+'''
+Reusable matplotlib plotting/interaction code for mcplot-matplotlib.
+
+This mirrors the pyqtgraph tool's plotfuncs.py / pqtgfrontend.py split: the
+plot-graph-driven rendering and interaction logic lives here (unrenamed, so
+it can be imported by name regardless of McStas/McXtrace flavor), while
+mcplot.py stays a thin CLI wrapper around it. mcplot-diff-matplotlib reuses
+this exact module, applied to a diff plot graph instead of an ordinary
+simulation's plot graph.
+'''
+import os
+import sys
+import math
+import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from mccodelib.plotgraph import PNSingle
+from mccodelib.mcplotloader import Data1D, Data2D
+from mccodelib.mccode_config import get_mccode_prefix
+
+FONTSIZE = 10
+
+# Global placeholder for later import of pylab by the caller
+# - necessary due to use of matplotlib.use() which has to happen
+# before import of pylab
+pylab = 0
+
+# Default base name used by dumpfile(); callers can override this
+# (e.g. mcplot.py sets it from the loaded simulation, mcplotdiff.py sets it
+# from the two simulation labels) before calling dumpfile().
+filenamebase = get_mccode_prefix() + 'plot'
+
+
+def plot_single_data(node, i, n, log):
+    ''' plot the data of node, at index i, to a subplot '''
+    def calc_panel_size(nfigs):
+        nx = int(math.sqrt(nfigs*1.61803398875)) # golden ratio
+        ny = nfigs // nx + int(bool(nfigs % nx))
+        return nx, ny
+
+    if type(node) == PNSingle and i != 0:
+        raise Exception("inconsistent plot request, idx=%s" % str(i))
+
+    dims = calc_panel_size(n)
+    subplt = pylab.subplot(dims[1],dims[0],i+1)
+    data = node.getdata_idx(i)
+
+    verbose = n == 1
+
+    if type(data) is Data1D:
+        ''' plot 1D data '''
+        xmin = data.xlimits[0]
+        xmax = data.xlimits[1]
+        pylab.xlim(xmin,xmax)
+
+        x = np.array(data.xvals).astype(float)
+        y = np.array(data.yvals).astype(float)
+        yerr = np.array(data.y_err_vals).astype(float)
+
+        ylabel = data.ylabel
+        if log == True:
+            # handle Log intensity
+            invalid = np.where(y <= 0)
+            valid   = np.where(y > 0)
+            if len(valid[0]):
+                min_valid  = np.min(y[valid])
+                y[invalid] = min_valid/10
+            yerr=yerr / y
+            y=np.log(y)
+            ylabel ="log(" + data.ylabel +")"
+
+        pylab.errorbar(x, y, yerr)
+
+        pylab.xlabel(data.xlabel, fontsize=FONTSIZE, fontweight='bold')
+        pylab.ylabel(ylabel, fontsize=FONTSIZE, fontweight='bold')
+        try:
+            title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
+        except:
+            title = '%s\n[%s]' % (data.component, data.filename)
+        pylab.title(title, fontsize=FONTSIZE, fontweight='bold')
+
+    elif type(data) is Data2D:
+        ''' plot 2D data '''
+        zvals = np.array(data.zvals)
+
+        xmin = data.xlimits[0]
+        xmax = data.xlimits[1]
+        ymin = data.xlimits[2]
+        ymax = data.xlimits[3]
+
+        mysize=zvals.shape
+        x = pylab.linspace(xmin, xmax, mysize[1])
+        y = pylab.linspace(ymin, ymax, mysize[0])
+        pylab.xlim(xmin, xmax)
+        pylab.ylim(ymin, ymax)
+
+        if log == True:
+            invalid = np.where(zvals <= 0)
+            valid = np.where(zvals > 0)
+            min_valid = np.min(zvals[valid])
+            zvals[invalid] = min_valid/10
+            zvals = np.log(zvals)
+
+        ''' out-commented code: alternative plot types '''
+        #from mpl_toolkits.mplot3d import Axes3D
+        #ax = Axes3D(pylab.gcf())
+        #pylab.contour(x,y,zvals)
+        #ax.plot_surface(x,y,zvals)
+        pylab.pcolor(x,y,zvals)
+        pylab.colorbar()
+
+        pylab.xlabel(data.xlabel, fontsize=FONTSIZE, fontweight='bold')
+        pylab.ylabel(data.ylabel, fontsize=FONTSIZE, fontweight='bold')
+
+        try:
+            title = '%s\nI = %s' % (data.component, data.values[0])
+            if verbose:
+                title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
+        except:
+            title = '%s\n[%s]' % (data.component, data.filename)
+        pylab.title(title, fontsize=FONTSIZE, fontweight='bold')
+
+    else:
+        print("Unsuported plot data type %s" % type(data))
+
+    return subplt
+
+
+class McMatplotlibPlotter():
+    ''' matplotlib plotting frontend '''
+    def __init__(self, sourcedir, log):
+        self.sourcedir = sourcedir
+        self.event_dc_cid = None
+        self.log = log
+
+
+    def _flip_log(self):
+        self.log = not self.log
+
+
+    def _click_proxy(self, event):
+        ''' state-updating proxy for click handler '''
+        dc_cb = lambda: pylab.disconnect(self.event_dc_cid)
+        click(event, subplts=self.subplts, click_cbs=self.click_cbs,
+              ctrl_cbs=self.ctrl_cbs, back_cb=self.back_cb, dc_cb=dc_cb)
+
+
+    def _keypress_proxy(self, event):
+        ''' state-updating proxy for keypress handler '''
+        keypress(event, back_cb=self.back_cb, replot_cb=self.replot_cb,
+                 togglelog_cb=self._flip_log)
+
+
+    def plot_node(self, node):
+        ''' plot recursion '''
+        # safety
+        if not node:
+            return
+
+        # clear
+        pylab.close()
+
+        # plot data and keep subplots for the click area filter
+        n = node.getnumdata()
+        self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
+
+        # create callbacks
+        self.click_cbs = [lambda nde=n: self.plot_node(nde) for n in node.primaries]
+        self.ctrl_cbs = [lambda nde=n: self.plot_node(nde) for n in node.secondaries]
+        # we need root node back click to prompt a replot, rather than to be ignored,
+        # because disconnect is always called by the click handler
+        bck_node = node.parent if node.parent else node 
+        self.back_cb = lambda n=bck_node: self.plot_node(n)
+        self.replot_cb = lambda n=node: self.plot_node(n) if node else None
+
+        # regiseter click events
+        self.event_dc_cid = pylab.connect('button_press_event', self._click_proxy)
+
+        # register keypress events
+        pylab.connect('key_press_event', self._keypress_proxy)
+
+        # show the plot
+        pylab.show()
+
+
+    def html_node(self, node, fileobj):
+        '''  plots node and saves to html using mpld3 '''
+        import mpld3
+        
+        n = node.getnumdata()
+        self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
+        
+        mpld3.save_html(pylab.gcf(), fileobj)
+
+
+def keypress(event, back_cb, replot_cb, togglelog_cb):
+    key = event.key.lower()
+
+    if key == 'q':
+        quit()
+    elif key == 'l':
+        togglelog_cb()
+        replot_cb()
+    elif event.key == 'p':
+        dumpfile('ps')
+    elif event.key == 'd':
+        dumpfile('pdf')
+    elif event.key == 'n':
+        dumpfile('png')
+    elif event.key == 'j':
+        dumpfile('jpg')
+    elif key == 'b':
+        back_cb()
+    elif key == 'f5':
+        replot_cb()
+    elif key == 'f1' or key == 'h':
+        print_help()
+    elif key == 'b':
+        back_cb()
+
+
+def print_help(nogui=False):
+    helplines = []
+    helplines.append('')
+    helplines.append('q              - quit')
+    helplines.append('F1/h           - help')
+    helplines.append('l              - toggle log')
+    helplines.append('p              - save ps')
+    helplines.append('d              - save pdf')
+    helplines.append('n              - save png')
+    helplines.append('j              - save jpg')
+    helplines.append('s              - native save dialog')
+    helplines.append('F5             - replot')
+    helplines.append('click          - display subplot')
+    helplines.append('right-click/b  - back')
+    helplines.append('ctrl + click   - sweep monitors')
+    print('\n'.join(helplines))
+
+
+def dumpfile(frmat, filename = None):
+    """ save current fig to softcopy """
+    from pylab import savefig
+
+    global filenamebase
+    
+    if filename is None:
+        filename = filenamebase
+        
+    # get directory, basename and extension
+    if isinstance(filename, list):
+        filename = filename[0]
+    basename  = os.path.splitext(filename)[0] # contains full path and base filename
+    if frmat is None:
+        ext       = os.path.splitext(filename)[1] # extension with the dot
+    else:
+        ext = frmat
+    if ext[0] != '.':
+        ext = '.'+ext
+    # assemble target name
+    saveto = basename + ext
+    
+    # Check for existance of earlier exports
+    if os.path.isfile(saveto):
+        index=1
+        saveto = f"{basename}_{index}{frmat}"
+        while os.path.isfile(saveto):
+            index += 1
+            saveto = f"{basename}_{index}{frmat}"
+
+    savefig(saveto)
+    print("Saved " + saveto)
+
+
+def click(event, subplts, click_cbs, ctrl_cbs, back_cb, dc_cb):
+    subplt = event.inaxes
+    if not subplt:
+        return False
+    else:
+        lclick = event.button==1
+        rclick = event.button==3
+        ctrlmod = (event.key == 'control' or event.key == 'cmd' or event.key == 'x')
+
+        if lclick and len(click_cbs) > 0 and not ctrlmod:
+            # left button
+            idx = subplts.index(subplt)
+            dc_cb()
+            click_cbs[idx]()
+        elif rclick and back_cb and not ctrlmod:
+            # right button
+            dc_cb()
+            back_cb()
+        elif ctrlmod and len(ctrl_cbs) > 0:
+            # control-click
+            idx = subplts.index(subplt)
+            dc_cb()
+            ctrl_cbs[idx]()

--- a/tools/Python/mcplot/matplotlib/plotfuncs.py
+++ b/tools/Python/mcplot/matplotlib/plotfuncs.py
@@ -167,19 +167,22 @@ def plot_single_data(node, i, n, log):
             y=np.log(y)
             ylabel ="log(" + data.ylabel +")"
 
-        pylab.errorbar(x, y, yerr)
+        errbar = pylab.errorbar(x, y, yerr)
 
         pylab.xlabel(data.xlabel, fontsize=fontsize, fontweight='bold')
         pylab.ylabel(ylabel, fontsize=fontsize, fontweight='bold')
         try:
-            title = '%s\nI = %s' % (data.component, data.values[0])
+            legend_text = '%s\nI = %s' % (data.component, data.values[0])
             if verbose:
-                title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
+                legend_text = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:
-            title = '%s\n[%s]' % (data.component, data.filename)
+            legend_text = '%s\n[%s]' % (data.component, data.filename)
         title_fontsize = _title_fontsize(n)
-        title = _wrap_title(title, _title_wrap_width(n, title_fontsize))
-        pylab.title(title, fontsize=title_fontsize, fontweight='bold')
+        legend_text = _wrap_title(legend_text, _title_wrap_width(n, title_fontsize))
+        errbar[0].set_label(legend_text)
+        leg = pylab.legend(loc='upper left', fontsize=title_fontsize, framealpha=0.85,
+                            handlelength=1.2, handletextpad=0.5, borderpad=0.4)
+        leg.set_draggable(True)
 
     elif type(data) is Data2D:
         ''' plot 2D data '''
@@ -215,14 +218,20 @@ def plot_single_data(node, i, n, log):
         pylab.ylabel(data.ylabel, fontsize=fontsize, fontweight='bold')
 
         try:
-            title = '%s\nI = %s' % (data.component, data.values[0])
+            legend_text = '%s\nI = %s' % (data.component, data.values[0])
             if verbose:
-                title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
+                legend_text = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:
-            title = '%s\n[%s]' % (data.component, data.filename)
+            legend_text = '%s\n[%s]' % (data.component, data.filename)
         title_fontsize = _title_fontsize(n)
-        title = _wrap_title(title, _title_wrap_width(n, title_fontsize))
-        pylab.title(title, fontsize=title_fontsize, fontweight='bold')
+        legend_text = _wrap_title(legend_text, _title_wrap_width(n, title_fontsize))
+        # pcolor() returns a QuadMesh, which doesn't make a useful legend
+        # swatch; use an invisible dummy artist to carry the label instead
+        # (same technique the pyqtgraph tool's plot_Data2D uses).
+        pylab.plot([], [], ' ', label=legend_text)
+        leg = pylab.legend(loc='upper left', fontsize=title_fontsize, framealpha=0.85,
+                            handlelength=0, handletextpad=0, borderpad=0.4)
+        leg.set_draggable(True)
 
     else:
         print("Unsuported plot data type %s" % type(data))
@@ -276,12 +285,12 @@ class McMatplotlibPlotter():
         self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
 
         # Tighten the outer margins (matplotlib's defaults leave a
-        # surprisingly large blank border) and open up the vertical gap
-        # between rows so multi-line titles have room to breathe instead of
-        # overlapping the plot above them.
-        _, rows = _calc_panel_size(n)
-        fig.subplots_adjust(left=0.06, right=0.98, top=0.92, bottom=0.06,
-                             wspace=0.35, hspace=0.65 if rows > 2 else 0.45)
+        # surprisingly large blank border). Titles now live as an in-plot
+        # legend rather than text spanning above each panel, so there's no
+        # longer a need for the extra hspace headroom that used to guard
+        # against titles overlapping the row above.
+        fig.subplots_adjust(left=0.06, right=0.98, top=0.97, bottom=0.06,
+                             wspace=0.3, hspace=0.35)
 
         # create callbacks
         self.click_cbs = [lambda nde=n: self.plot_node(nde) for n in node.primaries]
@@ -313,9 +322,8 @@ class McMatplotlibPlotter():
 
         self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
 
-        _, rows = _calc_panel_size(n)
-        fig.subplots_adjust(left=0.06, right=0.98, top=0.92, bottom=0.06,
-                             wspace=0.35, hspace=0.65 if rows > 2 else 0.45)
+        fig.subplots_adjust(left=0.06, right=0.98, top=0.97, bottom=0.06,
+                             wspace=0.3, hspace=0.35)
 
         mpld3.save_html(pylab.gcf(), fileobj)
 

--- a/tools/Python/mcplot/matplotlib/plotfuncs.py
+++ b/tools/Python/mcplot/matplotlib/plotfuncs.py
@@ -11,6 +11,7 @@ simulation's plot graph.
 import os
 import sys
 import math
+import textwrap
 import numpy as np
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -19,6 +20,9 @@ from mccodelib.plotgraph import PNSingle
 from mccodelib.mcplotloader import Data1D, Data2D
 from mccodelib.mccode_config import get_mccode_prefix
 
+# Legacy fixed font size, kept for backward compatibility with any external
+# code that may reference plotfuncs.FONTSIZE directly. Plotting itself now
+# uses _panel_fontsize(n), which scales with the number of panels in view.
 FONTSIZE = 10
 
 # Global placeholder for later import of pylab by the caller
@@ -32,21 +36,114 @@ pylab = 0
 filenamebase = get_mccode_prefix() + 'plot'
 
 
+def _calc_panel_size(nfigs):
+    ''' golden-ratio-ish grid dimensions (ncols, nrows) for nfigs panels '''
+    nx = int(math.sqrt(nfigs*1.61803398875)) # golden ratio
+    ny = nfigs // nx + int(bool(nfigs % nx))
+    return nx, ny
+
+
+# matplotlib's own stock default figure size (inches)
+_DEFAULT_FIGSIZE = (6.4, 4.8)
+
+# Scale-up applied to the single-plot (drill-down) view, relative to
+# matplotlib's stock default. The grid-based overview sizing below does NOT
+# reduce to this by itself at n=1 (it would actually come out smaller than
+# the stock default), so n<=1 is special-cased.
+_SINGLE_VIEW_SCALE = 2.0
+
+
+def _figure_size(n):
+    ''' (width, height) in inches for a view of n panels.
+
+        n <= 1: the single-plot drill-down view, sized as a multiple of
+        matplotlib's own default figure size (rather than the grid formula
+        below, which would otherwise come out smaller than that default).
+
+        n > 1: overview grid, sized to the panel grid so multi-panel views
+        actually use the available window/screen real estate, capped so
+        very large grids don't produce an unreasonably huge window. '''
+    if n <= 1:
+        return (_DEFAULT_FIGSIZE[0] * _SINGLE_VIEW_SCALE,
+                _DEFAULT_FIGSIZE[1] * _SINGLE_VIEW_SCALE)
+    cols, rows = _calc_panel_size(n)
+    fig_w = min(3.4 * cols + 1.0, 22)
+    fig_h = min(2.8 * rows + 1.0, 14)
+    return (fig_w, fig_h)
+
+
+def _panel_fontsize(n):
+    ''' Point size for axis labels, scaled by how many panels are in view:
+        a couple of panels can afford large, readable text; once a view
+        gets past a dozen or so panels, labels need to shrink substantially
+        or they crowd the plot. '''
+    if n <= 2:
+        return 14
+    elif n <= 16:
+        return 10
+    else:
+        return 8
+
+
+def _title_fontsize(n):
+    ''' Point size for panel titles specifically. Deliberately smaller than
+        _panel_fontsize(): titles here can carry a long, multi-field string
+        (component/filename/title/I/Err/N/statistics), and that combination
+        of digits, decimals and "="/"+"/"-" symbols renders noticeably wider
+        per character than ordinary prose at the same point size - so
+        titles need a smaller size than axis labels to reliably fit. '''
+    if n <= 2:
+        return 11
+    elif n <= 16:
+        return 9
+    else:
+        return 7
+
+
+def _title_wrap_width(n, fontsize):
+    ''' Approximate number of characters that fit across one panel's width
+        at the given fontsize, used to wrap long titles instead of letting
+        them overflow the figure. Deliberately a rough heuristic (average
+        bold-character width as a fraction of the font's point size) rather
+        than an exact text-measurement - good enough to catch the common
+        case of a long component/filename/statistics string, without
+        depending on a renderer being available at layout time.
+
+        The titles this wraps tend to be dense with digits and symbols
+        ("I = 1.2E+7 Err = ...; X0=...; dX=...;"), which render wider per
+        character than ordinary prose, so the width-per-character factor
+        here is deliberately generous (i.e. wraps a bit earlier than a
+        prose-tuned estimate would) to leave headroom against that. '''
+    fig_w, _ = _figure_size(n)
+    cols, _ = _calc_panel_size(n) if n > 1 else (1, 1)
+    panel_w_in = fig_w / max(cols, 1)
+
+    avg_char_width_in = (fontsize * 0.85) / 72.0  # bold, digit/symbol-heavy text
+    usable_w_in = panel_w_in * 0.88               # leave a bit more margin
+    return max(15, int(usable_w_in / avg_char_width_in))
+
+
+def _wrap_title(title, width):
+    ''' Wrap each already-newline-separated line of `title` to at most
+        `width` characters, so a long component/filename/statistics line
+        doesn't run wider than the figure. '''
+    return '\n'.join(
+        textwrap.fill(line, width=width) if line else line
+        for line in title.split('\n')
+    )
+
+
 def plot_single_data(node, i, n, log):
     ''' plot the data of node, at index i, to a subplot '''
-    def calc_panel_size(nfigs):
-        nx = int(math.sqrt(nfigs*1.61803398875)) # golden ratio
-        ny = nfigs // nx + int(bool(nfigs % nx))
-        return nx, ny
-
     if type(node) == PNSingle and i != 0:
         raise Exception("inconsistent plot request, idx=%s" % str(i))
 
-    dims = calc_panel_size(n)
+    dims = _calc_panel_size(n)
     subplt = pylab.subplot(dims[1],dims[0],i+1)
     data = node.getdata_idx(i)
 
     verbose = n == 1
+    fontsize = _panel_fontsize(n)
 
     if type(data) is Data1D:
         ''' plot 1D data '''
@@ -72,13 +169,17 @@ def plot_single_data(node, i, n, log):
 
         pylab.errorbar(x, y, yerr)
 
-        pylab.xlabel(data.xlabel, fontsize=FONTSIZE, fontweight='bold')
-        pylab.ylabel(ylabel, fontsize=FONTSIZE, fontweight='bold')
+        pylab.xlabel(data.xlabel, fontsize=fontsize, fontweight='bold')
+        pylab.ylabel(ylabel, fontsize=fontsize, fontweight='bold')
         try:
-            title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
+            title = '%s\nI = %s' % (data.component, data.values[0])
+            if verbose:
+                title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:
             title = '%s\n[%s]' % (data.component, data.filename)
-        pylab.title(title, fontsize=FONTSIZE, fontweight='bold')
+        title_fontsize = _title_fontsize(n)
+        title = _wrap_title(title, _title_wrap_width(n, title_fontsize))
+        pylab.title(title, fontsize=title_fontsize, fontweight='bold')
 
     elif type(data) is Data2D:
         ''' plot 2D data '''
@@ -110,8 +211,8 @@ def plot_single_data(node, i, n, log):
         pylab.pcolor(x,y,zvals)
         pylab.colorbar()
 
-        pylab.xlabel(data.xlabel, fontsize=FONTSIZE, fontweight='bold')
-        pylab.ylabel(data.ylabel, fontsize=FONTSIZE, fontweight='bold')
+        pylab.xlabel(data.xlabel, fontsize=fontsize, fontweight='bold')
+        pylab.ylabel(data.ylabel, fontsize=fontsize, fontweight='bold')
 
         try:
             title = '%s\nI = %s' % (data.component, data.values[0])
@@ -119,7 +220,9 @@ def plot_single_data(node, i, n, log):
                 title = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:
             title = '%s\n[%s]' % (data.component, data.filename)
-        pylab.title(title, fontsize=FONTSIZE, fontweight='bold')
+        title_fontsize = _title_fontsize(n)
+        title = _wrap_title(title, _title_wrap_width(n, title_fontsize))
+        pylab.title(title, fontsize=title_fontsize, fontweight='bold')
 
     else:
         print("Unsuported plot data type %s" % type(data))
@@ -163,7 +266,22 @@ class McMatplotlibPlotter():
 
         # plot data and keep subplots for the click area filter
         n = node.getnumdata()
+
+        # Size the figure to the view: 2x matplotlib's stock default for a
+        # single-plot drill-down, or to the panel grid for an overview, so
+        # either way the window actually uses available screen real estate.
+        fig_w, fig_h = _figure_size(n)
+        fig = pylab.figure(figsize=(fig_w, fig_h))
+
         self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
+
+        # Tighten the outer margins (matplotlib's defaults leave a
+        # surprisingly large blank border) and open up the vertical gap
+        # between rows so multi-line titles have room to breathe instead of
+        # overlapping the plot above them.
+        _, rows = _calc_panel_size(n)
+        fig.subplots_adjust(left=0.06, right=0.98, top=0.92, bottom=0.06,
+                             wspace=0.35, hspace=0.65 if rows > 2 else 0.45)
 
         # create callbacks
         self.click_cbs = [lambda nde=n: self.plot_node(nde) for n in node.primaries]
@@ -189,8 +307,16 @@ class McMatplotlibPlotter():
         import mpld3
         
         n = node.getnumdata()
+
+        fig_w, fig_h = _figure_size(n)
+        fig = pylab.figure(figsize=(fig_w, fig_h))
+
         self.subplts = [plot_single_data(node, i, n, self.log) for i in range(n)]
-        
+
+        _, rows = _calc_panel_size(n)
+        fig.subplots_adjust(left=0.06, right=0.98, top=0.92, bottom=0.06,
+                             wspace=0.35, hspace=0.65 if rows > 2 else 0.45)
+
         mpld3.save_html(pylab.gcf(), fileobj)
 
 


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

New tool: mcplotdiff-matplotlib, render difference plots between two datasets (follow-up to#2562)

Also includes general improvements of layout and visibility of plots with this backend.

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

Claude prompts:
"Now focus on the matplotlib-based mcplot variant located in tools/Python/mcplot/matplotlib.

Using the adapted mccodelib, please make me a matplotlib variant of mcplotdiff in the same spirit as the html and pyqtgraph variants.”

- Plus various following tweaks to improve this mcplot-plotting backend.



--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



