### PR TITLE
Speed up execution of mcplot-matplotlib (especially for big 2D matrices)

### DIFF
--- a/tools/Python/mcplot/matplotlib/plotfuncs.py
+++ b/tools/Python/mcplot/matplotlib/plotfuncs.py
@@ -211,7 +211,16 @@ def plot_single_data(node, i, n, log):
         #ax = Axes3D(pylab.gcf())
         #pylab.contour(x,y,zvals)
         #ax.plot_surface(x,y,zvals)
-        pylab.pcolor(x,y,zvals)
+        # pcolormesh (QuadMesh) instead of pcolor (PolyCollection): pcolor
+        # builds one vector polygon per grid cell, which is dramatically
+        # slower to construct and render for vector output formats
+        # (mctest.py generates a PDF overview per test via --format=pdf),
+        # and produces much larger files. pcolormesh is a same-signature
+        # drop-in given our regularly-gridded x/y (from linspace), and
+        # rasterized=True has vector backends embed it as a single bitmap
+        # rather than thousands of individual polygons; PNG/interactive
+        # output is raster either way and unaffected.
+        pylab.pcolormesh(x, y, zvals, shading='auto', rasterized=True)
         pylab.colorbar()
 
         pylab.xlabel(data.xlabel, fontsize=fontsize, fontweight='bold')


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Simple drop-in replacement of pcolor() -> pylab.pcolormesh() in matplotlib-plotter.

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

I did use Claude for this suggestion, but change is so compact and simple that I will proceed to merge without full rigour of review etc.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



