### PR TITLE
ILL_SALSA fix linter and add n reflections to parameters

### DIFF
--- a/mcstas-comps/contrib/Monochromator_bent.comp
+++ b/mcstas-comps/contrib/Monochromator_bent.comp
@@ -13,6 +13,7 @@
 * Origin: ILL/NBI
 *
 * A bent crystal monochromator. Based on the model implemented by Jan &Scaron;aroun in NIMA 529 (2004) pp 162-165.
+* An article describing the component has been written and can be seen in Quantum Beam Sci. 2026, 10, 6. https://doi.org/10.3390/qubs10010006
 * Mosacity and bending radius can be set.
 *
 * %D
@@ -55,6 +56,7 @@
 *
 * %L 
 * <a href="https://doi.org/10.1016/j.nima.2004.04.197">Jan &Scaron;aroun NIM A Volume 529, Issue 1-3 (2004), pp162-165</a>
+* <a href="https://www.mdpi.com/2412-382X/10/1/6"> Christensen, D.L.; Cabeza, S.; Pirling, T.; Lefmann, K.; Šaroun, J. Simulating Neutron Diffraction from Deformed Mosaic Crystals in McStas. Quantum Beam Sci. 2026, 10, 6. https://doi.org/10.3390/qubs10010006</a>
 * 
 * %E
 *******************************************************************************/

--- a/mcstas-comps/contrib/Monochromator_bent.comp
+++ b/mcstas-comps/contrib/Monochromator_bent.comp
@@ -49,6 +49,7 @@
 * x_rot:      [vector] Rotation around x-axis for each crystal
 * y_rot:      [vector] Rotation around y-axis for each crystal
 * z_rot:      [vector] Rotation around z-axis for each crystal NOTE: Rotations happen around x, then y, then z.
+* n_reflections:    [ ] The maximum number of reflections a neutron can undergo in the crystal array.
 * verbose:            [ ] Verbosity of the monochromator. Used for debugging. 
 * draw_as_rectangles: [ ] Draw the monochromators as boxes. DOES NOT WORK WHEN USING _rot parameters.
 *
@@ -77,6 +78,7 @@ SETTING PARAMETERS (zwidth=0.2,
 					vector x_rot=NULL,
 					vector y_rot=NULL,
 					vector z_rot=NULL,
+          int n_reflections=100,
 					int verbose=0,
 					int draw_as_rectangles=0)
 // Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) 
@@ -1317,7 +1319,6 @@ DECLARE
   int counter;
   int counter2;
   double curvature;
-  int MAX_REFLECTIONS;
 
   struct neutron_values neutron;
   struct Monochromator_array mono_arr;
@@ -1518,7 +1519,6 @@ INITIALIZE
   neutron.direction = 1; // Default direction is going away from the instrument
   counter = 0;
   counter2 = 0;
-  MAX_REFLECTIONS = 100; // Chosen maximum number of reflections
 
   // Free the position and rotations memories
   if (x_pos_mem_flag)
@@ -1557,7 +1557,7 @@ TRACE
     calculate_probabilities_of_reflection (&mono_arr, &neutron, _particle);
     choose_crystal_to_reflect_from (&mono_arr, &neutron, &optimize, _particle);
     check_if_neutron_should_pass_through (&mono_arr, &neutron, &p, &weight_init);
-    if (neutron.reflections > MAX_REFLECTIONS) {
+    if (neutron.reflections > n_reflections) {
       neutron.transmit_neutron = 1;
     }
     if (neutron.transmit_neutron) {

--- a/mcstas-comps/contrib/Monochromator_bent_complex.comp
+++ b/mcstas-comps/contrib/Monochromator_bent_complex.comp
@@ -73,6 +73,7 @@ SETTING PARAMETERS (vector zwidth=NULL,
 					int n_crystals=1,
 					int optimize=0,
 					int verbose=0,
+          int n_reflections=100,
 					int draw_as_rectangles=0)
 // Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) 
 NOACC
@@ -107,7 +108,6 @@ DECLARE
   int counter;
   int counter2;
   double curvature;
-  int MAX_REFLECTIONS;
   struct neutron_values neutron;
   struct Monochromator_array mono_arr;
 %}
@@ -291,7 +291,6 @@ INITIALIZE
   neutron.direction = 1; // Default direction is going away from the instrument
   counter = 0;
   counter2 = 0;
-  MAX_REFLECTIONS = 100; // Chosen maximum number of reflections
 %}
 
 TRACE INHERIT Monochromator_bent 

--- a/mcstas-comps/examples/ILL/ILL_SALSA/ILL_SALSA.instr
+++ b/mcstas-comps/examples/ILL/ILL_SALSA/ILL_SALSA.instr
@@ -128,12 +128,23 @@ INITIALIZE
       Rh_H22_6  = L_H22_6 /gRh*RAD2DEG;
     }
     printf("Instrument: ILL_H22 (H22@ILL thermal guide).\n");
-        mono_sandwich_x = (double*)malloc(lamellas*monochromator_slabs*sizeof(double));
+    mono_sandwich_x = (double*)malloc(lamellas*monochromator_slabs*sizeof(double));
     mono_sandwich_y = (double*)malloc(lamellas*monochromator_slabs*sizeof(double));
     mono_sandwich_z = (double*)malloc(lamellas*monochromator_slabs*sizeof(double));
     mono_sandwich_rot_x = (double*)malloc(lamellas*monochromator_slabs*sizeof(double));
     mono_sandwich_rot_y = (double*)malloc(lamellas*monochromator_slabs*sizeof(double));
     mono_sandwich_rot_z = (double*)malloc(lamellas*monochromator_slabs*sizeof(double));
+    if (NULL == mono_sandwich_x || NULL == mono_sandwich_y || NULL == mono_sandwich_z
+          || NULL == mono_sandwich_rot_x || NULL == mono_sandwich_rot_y || NULL == mono_sandwich_rot_z){
+      free(mono_sandwich_x);
+      free(mono_sandwich_y);
+      free(mono_sandwich_z);
+      free(mono_sandwich_rot_x);
+      free(mono_sandwich_rot_y);
+      free(mono_sandwich_rot_z);
+      printf("ERROR: monochromator not properly allocated. Exiting\n");
+      exit(-1);
+    }
     //FOCUSING MONOCHROMATOR ARRRAY
     double gap = 0.0001;
     double total_mono_height = 0.209;


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_
Fixes ILL_SALSA emitting linter errors #2096, adds a link in the header of monochromator bent to the article on the component, and finally moves the MAX_REFLECTIONS variable, to the parameters of the component as n_reflections. 

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_
OS Tahoes 26.5.2

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [x] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [x] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [x] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised

--------------



