### PR TITLE
Repair 'autobuild' download of 'innosetup' installer

### DIFF
--- a/.github/workflows/mcstas-autobuild.yml
+++ b/.github/workflows/mcstas-autobuild.yml
@@ -52,7 +52,7 @@ jobs:
            if [ "$RUNNER_OS" == "Linux" ]; then sudo apt-get -y install xvfb mingw-w64 gfortran-mingw-w64 mingw-w64-x86-64-dev libz-mingw-w64-dev dos2unix nsis wine64; fi
            if [ "$RUNNER_OS" == "Linux" ]; then sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install wine32; fi
            ( if [ "$RUNNER_OS" == "Linux" ]; then Xvfb :0 -screen 0 1024x768x16 ; fi ) &
-           if [ "$RUNNER_OS" == "Linux" ]; then mkdir /tmp/innosetup && cd /tmp/innosetup && wget https://jrsoftware.org/download.php/is.exe && DISPLAY=:0 wine ./is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /DOWNLOADISCRYPT=1 ; fi
+           if [ "$RUNNER_OS" == "Linux" ]; then mkdir /tmp/innosetup && cd /tmp/innosetup && wget https://github.com/jrsoftware/issrc/releases/download/is-7_0_2/innosetup-7.0.2-x64.exe -O is.exe && DISPLAY=:0 wine ./is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /DOWNLOADISCRYPT=1 ; fi
            if [ "$RUNNER_OS" == "Linux" ]; then killall -9 Xvfb ; fi
 
     - name: Setup build-deps-linux-arm

--- a/.github/workflows/mcxtrace-autobuild.yml
+++ b/.github/workflows/mcxtrace-autobuild.yml
@@ -52,7 +52,7 @@ jobs:
            if [ "$RUNNER_OS" == "Linux" ]; then sudo apt-get -y install xvfb mingw-w64 gfortran-mingw-w64 mingw-w64-x86-64-dev libz-mingw-w64-dev dos2unix nsis wine64; fi
            if [ "$RUNNER_OS" == "Linux" ]; then sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install wine32; fi
            ( if [ "$RUNNER_OS" == "Linux" ]; then Xvfb :0 -screen 0 1024x768x16 ; fi ) &
-           if [ "$RUNNER_OS" == "Linux" ]; then mkdir /tmp/innosetup && cd /tmp/innosetup && wget https://jrsoftware.org/download.php/is.exe && DISPLAY=:0 wine ./is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /DOWNLOADISCRYPT=1 ; fi
+           if [ "$RUNNER_OS" == "Linux" ]; then mkdir /tmp/innosetup && cd /tmp/innosetup && wget https://github.com/jrsoftware/issrc/releases/download/is-7_0_2/innosetup-7.0.2-x64.exe -O is.exe && DISPLAY=:0 wine ./is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /DOWNLOADISCRYPT=1 ; fi
            if [ "$RUNNER_OS" == "Linux" ]; then killall -9 Xvfb ; fi
 
     - name: Setup build-deps-linux-arm


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

The download-URL of innosetup (used to generate the McStas/McXtrace “bulky installers”) has changed. This PR fixes the problem and lets us run the ‘autobuild’ scripts again.

Tested functional on https://github.com/willend/McCode (main)
* [Manually triggered run](https://github.com/willend/McCode/actions/runs/29503202886) completed OK for McXtrace
* [Manually triggered run](https://github.com/willend/McCode/actions/runs/29503183414) completed OK for McStas
--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



