### PR TITLE
Use filenames in MCPL instrument Monitor_nD instances to get rid of timestamps

### DIFF
--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input/Test_MCPL_input.instr
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input/Test_MCPL_input.instr
@@ -53,27 +53,27 @@ COMPONENT Origin = Progress_bar()
 COMPONENT vin = MCPL_input(filename=MCPLFILE,verbose=1,repeat_count=repeat,v_smear=v_smear,pos_smear=pos_smear,dir_smear=dir_smear)
 AT( 0,0,0) RELATIVE PREVIOUS
 
-COMPONENT m1 = Monitor_nD(
+COMPONENT m1 = Monitor_nD(filename="m1",
   xwidth=0.2, yheight=0.2,
   options="lambda limits=[0.5 11], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m2 = Monitor_nD(
+COMPONENT m2 = Monitor_nD(filename="m2",
   xwidth=0.2, yheight=0.2,
   options="x limits=[-0.005 0.005],  y limits=[-0.005 0.005], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m3 = Monitor_nD(
+COMPONENT m3 = Monitor_nD(filename="m3",
   xwidth=0.2, yheight=0.2,
   options="t limits=[0 1e-3]parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m4 = Monitor_nD(
+COMPONENT m4 = Monitor_nD(filename="m4",
   xwidth=0.2, yheight=0.2,
   options="E, limits=[0 90] parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m5 = Monitor_nD(
+COMPONENT m5 = Monitor_nD(filename="m5",
   xwidth=0.2, yheight=0.2, 
   options="parallel, previous, neutron, energy, x, y, z, vx, vy, vz, time, list all neutrons"
 ) AT (0,0,0) ABSOLUTE

--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input_once/Test_MCPL_input_once.instr
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input_once/Test_MCPL_input_once.instr
@@ -51,27 +51,27 @@ COMPONENT Origin = Progress_bar()
 COMPONENT vin = MCPL_input_once(filename=MCPLFILE,verbose=1,v_smear=v_smear,pos_smear=pos_smear,dir_smear=dir_smear)
 AT( 0,0,0) RELATIVE PREVIOUS
 
-COMPONENT m1 = Monitor_nD(
+COMPONENT m1 = Monitor_nD(filename="m1",
   xwidth=0.2, yheight=0.2,
   options="lambda limits=[0.5 11], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m2 = Monitor_nD(
+COMPONENT m2 = Monitor_nD(filename="m2",
   xwidth=0.2, yheight=0.2,
   options="x limits=[-0.005 0.005],  y limits=[-0.005 0.005], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m3 = Monitor_nD(
+COMPONENT m3 = Monitor_nD(filename="m3",
   xwidth=0.2, yheight=0.2,
   options="t limits=[0 1e-3]parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m4 = Monitor_nD(
+COMPONENT m4 = Monitor_nD(filename="m4",
   xwidth=0.2, yheight=0.2,
   options="E, limits=[0 90] parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m5 = Monitor_nD(
+COMPONENT m5 = Monitor_nD(filename="m5",
   xwidth=0.2, yheight=0.2, 
   options="parallel, previous, neutron, energy, x, y, z, vx, vy, vz, time, list all neutrons"
 ) AT (0,0,0) ABSOLUTE

--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_output/Test_MCPL_output.instr
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_output/Test_MCPL_output.instr
@@ -56,22 +56,22 @@ COMPONENT vout = MCPL_output(
      userflag="flag", userflagcomment="Neutron Id")
 AT(0,0,0) RELATIVE PREVIOUS
 
-COMPONENT m1 = Monitor_nD(
+COMPONENT m1 = Monitor_nD(filename="m1",
   xwidth=0.2, yheight=0.2,
   options="lambda limits=[1 11] bins=100 parallel", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m2 = Monitor_nD(
+COMPONENT m2 = Monitor_nD(filename="m2",
   xwidth=0.2, yheight=0.2,
   options="x y, parallel", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m3 = Monitor_nD(
+COMPONENT m3 = Monitor_nD(filename="m3",
   xwidth=0.2, yheight=0.2,
   options="t limits=[0 1e-3]parallel", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m4 = Monitor_nD(
+COMPONENT m4 = Monitor_nD(filename="m4",
   xwidth=0.2, yheight=0.2,
   options="E limits=[0 82] parallel", bins=40
 ) AT (0,0,0) ABSOLUTE

--- a/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_input/Test_MCPL_input.instr
+++ b/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_input/Test_MCPL_input.instr
@@ -58,22 +58,22 @@ COMPONENT m1 = Monitor_nD(
   options="lambda limits=[0.1 11], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m2 = Monitor_nD(
+COMPONENT m2 = Monitor_nD(filename="m2",
   xwidth=0.2, yheight=0.2,
   options="x limits=[-0.005 0.005],  y limits=[-0.005 0.005], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m3 = Monitor_nD(
+COMPONENT m3 = Monitor_nD(filename="m3",
   xwidth=0.2, yheight=0.2,
   options="t limits=[0 1e-3]parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m4 = Monitor_nD(
+COMPONENT m4 = Monitor_nD(filename="m4",
   xwidth=0.2, yheight=0.2,
   options="E, limits=[0 90] parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m5 = Monitor_nD(
+COMPONENT m5 = Monitor_nD(filename="m5",
   xwidth=0.2, yheight=0.2, user1="22", username1="photons",
   options="parallel, previous, photon, user1, energy, x, y, z, vx, vy, vz, time, list all photons"
 ) AT (0,0,0) ABSOLUTE

--- a/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_output/Test_MCPL_output.instr
+++ b/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_output/Test_MCPL_output.instr
@@ -53,22 +53,22 @@ COMPONENT vout = MCPL_output(
         filename="voutput", verbose=1, userflag="flag", userflagcomment="Photon Id")
 AT(0,0,0) RELATIVE PREVIOUS
 
-COMPONENT m1 = Monitor_nD(
+COMPONENT m1 = Monitor_nD(filename="m1",
   xwidth=0.2, yheight=0.2,
   options="lambda limits=[0.1 11], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m2 = Monitor_nD(
+COMPONENT m2 = Monitor_nD(filename="m2",
   xwidth=0.2, yheight=0.2,
   options="x limits=[-0.005 0.005],  y limits=[-0.005 0.005], parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m3 = Monitor_nD(
+COMPONENT m3 = Monitor_nD(filename="m3",
   xwidth=0.2, yheight=0.2,
   options="t limits=[0 1e-3]parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE
 
-COMPONENT m4 = Monitor_nD(
+COMPONENT m4 = Monitor_nD(filename="m4",
   xwidth=0.2, yheight=0.2,
   options="E, limits=[0 90] parallel, previous", bins=40
 ) AT (0,0,0) ABSOLUTE


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Use actual filename="" for Monitor_nD instances to get rid of timestamps, works better with incoming changes for mcviewtest / mcplotdiff-*

--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



