### PR TITLE
Add option to "emulate" McCode default 'Unix epoch' seed in mctest

### DIFF
--- a/tools/Python/mctest/mctest.py
+++ b/tools/Python/mctest/mctest.py
@@ -828,7 +828,7 @@ def main(args):
     elif args.s:
         seed = args.s[0]
 
-    if seed == "0" or seeed == "NULL":
+    if seed == "0" or seed == "NULL":
         # Emulate McCode 'epoch' seed, however applied to all active tests / sim runs...
         seed = round((datetime.now() - datetime(1970, 1, 1)).total_seconds())
 

--- a/tools/Python/mctest/mctest.py
+++ b/tools/Python/mctest/mctest.py
@@ -17,6 +17,7 @@ import shutil
 import platform
 import subprocess
 import io
+from datetime import datetime
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from mccodelib import utils, mccode_config
@@ -827,6 +828,10 @@ def main(args):
     elif args.s:
         seed = args.s[0]
 
+    if seed == "0" or seeed == "NULL":
+        # Emulate McCode 'epoch' seed, however applied to all active tests / sim runs...
+        seed = round((datetime.now() - datetime(1970, 1, 1)).total_seconds())
+
     if args.local:
         runLocal = args.local
 
@@ -893,8 +898,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--ncount', nargs=1, help='ncount sent to %s' % (mccode_config.configuration["MCRUN"]) )
     parser.add_argument('-n', nargs=1, help='ncount sent to %s' % (mccode_config.configuration["MCRUN"]) )
-    parser.add_argument('--seed', nargs=1, help='seed sent to %s (default 1000)' % (mccode_config.configuration["MCRUN"]) )
-    parser.add_argument('-s', nargs=1, help='seed sent to %s (default 1000)' % (mccode_config.configuration["MCRUN"]) )
+    parser.add_argument('--seed', nargs=1, help='seed sent to %s (default 1000 - use 0/NULL to "randomize")' % (mccode_config.configuration["MCRUN"]) )
+    parser.add_argument('-s', nargs=1, help='seed sent to %s (default 1000 - use 0/NULL to "randomize")' % (mccode_config.configuration["MCRUN"]) )
     parser.add_argument('--mpi', nargs=1, help='mpi nodecount sent to %s' % (mccode_config.configuration["MCRUN"]) )
     parser.add_argument('--openacc', action='store_true', help='openacc flag sent to %s' % (mccode_config.configuration["MCRUN"]))
     parser.add_argument('--config', nargs="?", help='test this specific config only - label name or absolute path')


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Add option to "emulate" McCode default 'Unix epoch' seed in mctest. 

NOTA BENE: A constant seed of “whatever the time is” is applied at Python level across all tests within the current test run.
(The alternative would be a mccode-r / code-generator change to let `-s 0` or equivalent map to the “default” / “unset” state, but this is left as an afterthought.)

--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



