### PR TITLE
Tweaks to stabilise test output from in workflows

### DIFF
--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -358,7 +358,7 @@ jobs:
            test -n "$(command -v mcstas${EXESUFFIX})"
            mcstas${EXESUFFIX} --version
            mctest${SUFFIX} --instr=BNL_H8,ISIS_CRISP,templateSANS_Mantid,NCrystal_example,ESS_BEER_MCPL,Test_MCPL_input,Test_MCPL_output,Test_KDSource --testdir=run_basictests --suffix=${{ matrix.method }}
-           mctest${SUFFIX} --mpi=2 --instr=BNL_H8,ISIS_CRISP,templateSANS_Mantid,NCrystal_example,ESS_BEER_MCPL,Test_MCPL_input,Test_MCPL_output,Test_KDSource --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
+           mctest${SUFFIX} --mpi=auto -n3e6 --instr=BNL_H8,ISIS_CRISP,templateSANS_Mantid,NCrystal_example,ESS_BEER_MCPL,Test_MCPL_input,Test_MCPL_output,Test_KDSource --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
 
     - name: Check for modified instruments
       id: instr-test
@@ -414,7 +414,7 @@ jobs:
                  NUMMATCH=`find src/mcstas-comps -name \*.instr -exec grep -H ${comp} \{\} \; | cut -f1 -d: | sort | uniq | wc -l`
                  if [ "$NUMMATCH" -gt "0" ];
                  then
-                   ${MCTEST_EXECUTABLE} --mpi=2 --testdir run_mctest --comp=${comp} --suffix=CHANGES_${comp}_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MCTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
+                   ${MCTEST_EXECUTABLE} --mpi=auto -n3e6 --testdir run_mctest --comp=${comp} --suffix=CHANGES_${comp}_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MCTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
                  else
                    echo No matching tests found
                  fi
@@ -443,7 +443,7 @@ jobs:
                export SCOPE=" "
              fi
              mkdir -p run_mctest && cd run_mctest
-             ${MCTEST_EXECUTABLE} --mpi=2 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MCTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
+             ${MCTEST_EXECUTABLE} --mpi=auto -n3e6 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MCTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
              ${MCVIEWTEST_EXECUTABLE} --nobrowse $PWD
            fi
 

--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -358,7 +358,7 @@ jobs:
            test -n "$(command -v mcstas${EXESUFFIX})"
            mcstas${EXESUFFIX} --version
            mctest${SUFFIX} --instr=BNL_H8,ISIS_CRISP,templateSANS_Mantid,NCrystal_example,ESS_BEER_MCPL,Test_MCPL_input,Test_MCPL_output,Test_KDSource --testdir=run_basictests --suffix=${{ matrix.method }}
-           mctest${SUFFIX} --mpi=auto --instr=BNL_H8,ISIS_CRISP,templateSANS_Mantid,NCrystal_example,ESS_BEER_MCPL,Test_MCPL_input,Test_MCPL_output,Test_KDSource --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
+           mctest${SUFFIX} --mpi=2 --instr=BNL_H8,ISIS_CRISP,templateSANS_Mantid,NCrystal_example,ESS_BEER_MCPL,Test_MCPL_input,Test_MCPL_output,Test_KDSource --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
 
     - name: Check for modified instruments
       id: instr-test

--- a/.github/workflows/mcstas-conda-testsuite.yml
+++ b/.github/workflows/mcstas-conda-testsuite.yml
@@ -192,7 +192,7 @@ jobs:
 
            # Each platform's tarball contains exactly one label directory
            # directly under run_test-suite/ (e.g.
-           # mcstas-3.99.99_mpi_x_2_ubuntu-latest_openmpi_1e6_Linux_<datetime>).
+           # mcstas-3.99.99_mpi_x_2_ubuntu-latest_openmpi_<ncount>_Linux_<datetime>).
            # mcviewtest treats each such directory as one comparison "column",
            # so merging them as siblings under one shared testdir is all that's
            # needed to make them comparable.

--- a/.github/workflows/mcstas-conda-testsuite.yml
+++ b/.github/workflows/mcstas-conda-testsuite.yml
@@ -107,7 +107,7 @@ jobs:
              export TMPDIR=${HOME}/tmp
            fi
            # Run the test with 2 core mpi
-           ${MCTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=2
+           ${MCTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=auto -n3e6
     - name: 'Tar output files'
       id: tar-package
       if: always()

--- a/.github/workflows/mcstas-conda-testsuite.yml
+++ b/.github/workflows/mcstas-conda-testsuite.yml
@@ -107,7 +107,7 @@ jobs:
              export TMPDIR=${HOME}/tmp
            fi
            # Run the test with 2 core mpi
-           ${MCTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=auto
+           ${MCTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=2
     - name: 'Tar output files'
       id: tar-package
       if: always()

--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -365,7 +365,7 @@ jobs:
            test -n "$(command -v mcxtrace${EXESUFFIX})"
            mcxtrace${EXESUFFIX} --version
            mxtest${SUFFIX} --instr=JJ_SAXS,ESRF_BM29,Test_MCPL_input,Test_MCPL_output,Test_Absorption --testdir=run_basictests --suffix=${{ matrix.method }}
-           mxtest${SUFFIX} --mpi=auto --instr=JJ_SAXS,ESRF_BM29,Test_MCPL_input,Test_MCPL_output,Test_Absorption --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
+           mxtest${SUFFIX} --mpi=2 --instr=JJ_SAXS,ESRF_BM29,Test_MCPL_input,Test_MCPL_output,Test_Absorption --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
 
     - name: Check for modified instruments
       id: instr-test
@@ -421,7 +421,7 @@ jobs:
                  NUMMATCH=`find src/mcxtrace-comps -name \*.instr -exec grep -H ${comp} \{\} \; | cut -f1 -d: | sort | uniq | wc -l`
                  if [ "$NUMMATCH" -gt "0" ];
                  then
-                   ${MXTEST_EXECUTABLE} --mpi=auto --testdir run_mxtest --comp=${comp} --suffix=CHANGES_${comp}_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MXTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
+                   ${MXTEST_EXECUTABLE} --mpi=2 --testdir run_mxtest --comp=${comp} --suffix=CHANGES_${comp}_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MXTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
                  else
                    echo No matching tests found
                  fi

--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -365,7 +365,7 @@ jobs:
            test -n "$(command -v mcxtrace${EXESUFFIX})"
            mcxtrace${EXESUFFIX} --version
            mxtest${SUFFIX} --instr=JJ_SAXS,ESRF_BM29,Test_MCPL_input,Test_MCPL_output,Test_Absorption --testdir=run_basictests --suffix=${{ matrix.method }}
-           mxtest${SUFFIX} --mpi=2 --instr=JJ_SAXS,ESRF_BM29,Test_MCPL_input,Test_MCPL_output,Test_Absorption --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
+           mxtest${SUFFIX} --mpi=auto -n3e6 --instr=JJ_SAXS,ESRF_BM29,Test_MCPL_input,Test_MCPL_output,Test_Absorption --testdir=run_basictests --suffix=${{ matrix.method }}_${{ matrix.mpi }}
 
     - name: Check for modified instruments
       id: instr-test
@@ -421,7 +421,7 @@ jobs:
                  NUMMATCH=`find src/mcxtrace-comps -name \*.instr -exec grep -H ${comp} \{\} \; | cut -f1 -d: | sort | uniq | wc -l`
                  if [ "$NUMMATCH" -gt "0" ];
                  then
-                   ${MXTEST_EXECUTABLE} --mpi=2 --testdir run_mxtest --comp=${comp} --suffix=CHANGES_${comp}_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MXTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
+                   ${MXTEST_EXECUTABLE} --mpi=auto -n3e6 --testdir run_mxtest --comp=${comp} --suffix=CHANGES_${comp}_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MXTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
                  else
                    echo No matching tests found
                  fi
@@ -450,7 +450,7 @@ jobs:
                export SCOPE=" "
              fi
              mkdir -p run_mxtest && cd run_mxtest
-             ${MXTEST_EXECUTABLE} --mpi=2 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MXTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
+             ${MXTEST_EXECUTABLE} --mpi=auto -n3e6 --testdir $PWD $SCOPE --suffix=CHANGES_${{ matrix.method }}_${{ matrix.CC || 'default' }}_${{ matrix.mpi }} $PERMISSIVE --verbose || { echo "${MXTEST_EXECUTABLE} failed with exit code $?"; exit 1; }
              ${MXVIEWTEST_EXECUTABLE} --nobrowse $PWD
            fi
 

--- a/.github/workflows/mcxtrace-conda-testsuite.yml
+++ b/.github/workflows/mcxtrace-conda-testsuite.yml
@@ -107,7 +107,7 @@ jobs:
              export TMPDIR=${HOME}/tmp
            fi
            # Run the test with 2 core mpi
-           ${MXTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=auto
+           ${MXTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=2
 
     - name: 'Tar output files'
       id: tar-package

--- a/.github/workflows/mcxtrace-conda-testsuite.yml
+++ b/.github/workflows/mcxtrace-conda-testsuite.yml
@@ -107,7 +107,7 @@ jobs:
              export TMPDIR=${HOME}/tmp
            fi
            # Run the test with 2 core mpi
-           ${MXTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=2
+           ${MXTEST_EXECUTABLE} --verbose --testdir $PWD --suffix ${{ matrix.os }}_${{ matrix.mpi }} --mpi=auto -n3e6
 
     - name: 'Tar output files'
       id: tar-package

--- a/.github/workflows/mcxtrace-conda-testsuite.yml
+++ b/.github/workflows/mcxtrace-conda-testsuite.yml
@@ -194,7 +194,7 @@ jobs:
 
            # Each platform's tarball contains exactly one label directory
            # directly under run_test-suite/ (e.g.
-           # mcxtrace-1.99.99_mpi_x_2_ubuntu-latest_openmpi_1e6_Linux_<datetime>).
+           # mcxtrace-1.99.99_mpi_x_2_ubuntu-latest_openmpi_<ncount>_Linux_<datetime>).
            # mxviewtest treats each such directory as one comparison "column",
            # so merging them as siblings under one shared testdir is all that's
            # needed to make them comparable.

--- a/mcstas-comps/examples/ILL/ILL_H15_SAM/ILL_H15_SAM.instr
+++ b/mcstas-comps/examples/ILL/ILL_H15_SAM/ILL_H15_SAM.instr
@@ -31,8 +31,8 @@
 *
 * Example (typical "real-life" measurement sequence):
 *
-*	mcrun ILL_H15_SAM.instr --gravity -n1e7 -dLargeQ lambda=5.2
-*	mcrun ILL_H15_SAM.instr --gravity -n1e7 -dSmallQ guide1=0 guide2=0 guide3=0 lsd=6.8
+*	mcrun ILL_H15_SAM.instr --gravity -n1e8 -dLargeQ lambda=5.2
+*	mcrun ILL_H15_SAM.instr --gravity -n1e8 -dSmallQ guide1=0 guide2=0 guide3=0 lsd=6.8
 *
 * (Corresponding test-suite entries:)
 * %Example: ILL_H15_SAM.instr --gravity lambda=5.2 Detector: psd_I=1272.79
@@ -142,11 +142,11 @@ INITIALIZE %{
 	printf("Sample-to-detector distance = %g m\n",lsd);
 	printf("Q-range = %g-%g AA^-1\n",qmin,qmax);
 	printf("...\n\n");
-	/* Ensure that we are running with at least 1e7 neutrons if not 'displaying' */
+	/* Ensure that we are running with at least 1e8 neutrons if not 'displaying' */
 	if (!mcdotrace) {
-	  if (mcget_ncount()<1e7) {
-	    MPI_MASTER(printf("This instrument needs higher statistics to converge. Increasing your ncount=%llu to 1e7\n",mcget_ncount()));
-	    mcset_ncount(1e7);
+	  if (mcget_ncount()<1e8) {
+	    MPI_MASTER(printf("This instrument needs higher statistics to converge. Increasing your ncount=%llu to 1e8\n",mcget_ncount()));
+	    mcset_ncount(1e8);
 	  }
 	}
 %}


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

1. Experimental revert. Use mpi=2 (rather than mpi=auto) in workflows since especially mpi=3 on macOS arm seems “off”
2. Reinstated mpi=auto but increasing stats 3-fold

———————
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

———————
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


———————
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

———————



