### PR TITLE
Let the HTML diffplotter write "diff datasets"

### DIFF
--- a/tools/Python/mccodelib/mcplotdiffloader.py
+++ b/tools/Python/mccodelib/mcplotdiffloader.py
@@ -13,6 +13,7 @@ into any existing plot-graph-based frontend (e.g. the interactive
 pyqtgraph frontend in pqtgfrontend.py).
 '''
 import os
+import datetime
 
 import numpy as np
 
@@ -270,3 +271,222 @@ def build_diff_plotgraph(diffs):
     root.set_primaries(primnodes)
     root.set_secondaries(primnodes)  # only one way to click here, as in load_simulation()
     return root
+
+
+# ---------------------------------------------------------------------------
+# writing diff datasets back out in McCode ASCII format
+# ---------------------------------------------------------------------------
+
+def _fmt(x):
+    """ Standard number formatting for McCode-format file bodies/headers. """
+    return '%.10g' % float(x)
+
+
+def _sanitize(s):
+    """ Collapses a string to something safe for a single-line "# field:
+        value" header (diff titles in particular start with a leading
+        newline, intended for on-screen display, which would otherwise
+        split the header across two physical lines - the second of which
+        has no leading "#" and so corrupts the file for any reader). """
+    return ' '.join(str(s).split())
+
+
+def _common_header_lines(data):
+    return [
+        '# Format: McCode with text headers',
+        '# URL: http://www.mccode.org',
+        '# Creator: mcplotdiff (McCode difference tool)',
+        '# component: %s' % _sanitize(data.component),
+        '# filename: %s' % _sanitize(data.filename),
+        '# title: %s' % _sanitize(data.title),
+    ]
+
+
+def _write_1d_dat(data, outdir, prefix):
+    filename = prefix + data.filename
+    filepath = os.path.join(outdir, filename)
+
+    lines = _common_header_lines(data)
+    # Required: mcplotloader.py's _load_monitor() reads this line to decide
+    # which parser to dispatch to (_parse_1D_monitor vs _parse_2D_monitor)
+    # *before* either parser ever runs - without it, loading fails at the
+    # dispatch step itself, not inside the parser.
+    lines.insert(3, '# type: array_1d(%d)' % len(data.xvals))
+    lines.append('# xlabel: %s' % _sanitize(data.xlabel))
+    lines.append('# ylabel: %s' % _sanitize(data.ylabel))
+    lines.append('# xvar: %s' % _sanitize(data.xvar))
+    lines.append('# yvar: (%s,%s)' % (data.yvar[0], data.yvar[1]))
+    lines.append('# xlimits: %s %s' % (_fmt(data.xlimits[0]), _fmt(data.xlimits[1])))
+    lines.append('# variables: %s %s %s N' % (data.xvar, data.yvar[0], data.yvar[1]))
+    lines.append('# values: %s %s %s' % (_fmt(data.values[0]), _fmt(data.values[1]), _fmt(data.values[2])))
+    # The standard "# statistics: X0=...; dX=...;" field is a
+    # weighted centroid/width, which assumes a non-negative intensity
+    # distribution - not generally meaningful for signed difference data,
+    # so it's written as zero here rather than a misleading number. The
+    # real per-source statistics (from the original a/b datasets) are kept
+    # as an additional, non-standard comment line for human reference;
+    # readers (including mcplotloader.py's own parser) that only look for
+    # the standard fields simply ignore it.
+    lines.append('# statistics: X0=0; dX=0;')
+    lines.append('# Diff-statistics: %s' % _sanitize(data.statistics.replace('\n', ' | ')))
+
+    with open(filepath, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+        for x, y, yerr, n in zip(data.xvals, data.yvals, data.y_err_vals, data.Nvals):
+            f.write('%s %s %s %s\n' % (_fmt(x), _fmt(y), _fmt(yerr), _fmt(n)))
+
+    return filepath
+
+
+def _write_2d_dat(data, outdir, prefix):
+    filename = prefix + data.filename
+    filepath = os.path.join(outdir, filename)
+
+    lines = _common_header_lines(data)
+    zshape = np.shape(data.zvals) if data.zvals else (0, 0)
+    lines.insert(3, '# type: array_2d(%d, %d)' % (zshape[0], zshape[1] if len(zshape) > 1 else 0))
+    lines.append('# xlabel: %s' % _sanitize(data.xlabel))
+    lines.append('# ylabel: %s' % _sanitize(data.ylabel))
+    lines.append('# xvar: %s' % _sanitize(data.xvar))
+    lines.append('# yvar: %s' % _sanitize(data.yvar))
+    lines.append('# zvar: %s' % _sanitize(data.zvar))
+    lines.append('# xylimits: %s %s %s %s' % tuple(_fmt(v) for v in data.xlimits))
+    lines.append('# values: %s %s %s' % (_fmt(data.values[0]), _fmt(data.values[1]), _fmt(data.values[2])))
+    zarr = np.array(data.zvals, dtype=float) if data.zvals else np.zeros((1, 1))
+    lines.append('# signal: Min=%s; Max=%s; Mean=%s;' % (_fmt(zarr.min()), _fmt(zarr.max()), _fmt(zarr.mean())))
+    # see _write_1d_dat() for why this is zeroed rather than reusing
+    # data.statistics directly
+    lines.append('# statistics: X0=0; dX=0; Y0=0; dY=0;')
+    lines.append('# Diff-statistics: %s' % _sanitize(data.statistics.replace('\n', ' | ')))
+
+    with open(filepath, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+        f.write('# Data [%s/%s] %s:\n' % (_sanitize(data.component), _sanitize(data.filename), _sanitize(data.zvar)))
+        for row in data.zvals:
+            f.write(' '.join(_fmt(v) for v in row) + '\n')
+        if data.counts:
+            f.write('# Events [%s/%s] N:\n' % (_sanitize(data.component), _sanitize(data.filename)))
+            for row in data.counts:
+                f.write(' '.join(_fmt(v) for v in row) + '\n')
+
+    return filepath
+
+
+def write_mccode_dat(data, outdir, prefix='diff_'):
+    """ Writes a single diff Data1D/Data2D object out in the same ASCII
+        "# comment header + data body" format ordinary McCode monitor
+        output files use - readable back in by mcplotloader.py itself (and,
+        since it follows the same conventions, by any other tool that
+        already reads McCode monitor output, e.g. Mantid's loaders).
+
+        Returns the path written, or None if `data` isn't a supported type. """
+    if isinstance(data, Data1D):
+        return _write_1d_dat(data, outdir, prefix)
+    elif isinstance(data, Data2D):
+        return _write_2d_dat(data, outdir, prefix)
+    return None
+
+
+def write_all_mccode_dat(diffs, outdir, prefix='diff_'):
+    """ Convenience: write_mccode_dat() for every diff dataset in `diffs`,
+        into `outdir` (created if missing). Returns the list of paths
+        written. """
+    os.makedirs(outdir, exist_ok=True)
+    paths = []
+    for d in diffs:
+        p = write_mccode_dat(d, outdir, prefix=prefix)
+        if p:
+            paths.append(p)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# writing a mccode.sim index alongside the diff .dat files
+# ---------------------------------------------------------------------------
+
+def write_mccode_sim(diffs, outdir, label_a=None, label_b=None, instrument='diff',
+                      prefix='diff_', filename='mccode.sim'):
+    """ Writes a mccode.sim index file summarizing a set of diff datasets
+        (as returned by compute_diffs()), in the same style a real McStas/
+        McXtrace simulation directory uses, so `outdir` can be opened as a
+        genuine simulation directory (e.g. `mcplot-html <outdir>/`) via the
+        standard "mccode.sim + monitors" loading path
+        (mcplotloader.is_mccodesim_w_monitors() -> load_simulation()),
+        rather than falling back to the "folder full of loose .dat files"
+        path (which also works, but is the less standard route, and
+        wouldn't be recognised the same way by other McCode-aware tools
+        that expect a simulation directory to have an index).
+
+        Must be called *after* write_mccode_dat()/write_all_mccode_dat()
+        have already written each diff monitor's own .dat file into
+        `outdir` with the same `prefix` - this only writes the index, not
+        the monitor data itself, and the "filename:" lines it writes must
+        match the files actually on disk.
+
+        The only thing mcplotloader.py's own parser
+        (_get_filenames_from_mccodesim) actually requires is one
+        "begin data ... filename: <name> ... end data" block per monitor -
+        the surrounding instrument/simulation header blocks aren't parsed
+        by mcplotloader.py at all, and are included purely so the file
+        reads like (and is compatible with expectations set by) a genuine
+        mccode.sim, for humans and any other McCode-aware tooling.
+
+        Returns the path written. """
+    filepath = os.path.join(outdir, filename)
+    now = datetime.datetime.now().strftime('%a %b %d %H:%M:%S %Y')
+    label_a = label_a or 'A'
+    label_b = label_b or 'B'
+
+    lines = []
+    lines.append('McCode diff simulation description file for %s.' % instrument)
+    lines.append('Date:    %s' % now)
+    lines.append('Program: mcplotdiff (McCode difference tool)')
+    lines.append('')
+    lines.append('begin instrument: %s' % instrument)
+    lines.append('  File: %s' % os.path.join(outdir, instrument))
+    lines.append('  Source: diff(%s, %s)' % (_sanitize(label_a), _sanitize(label_b)))
+    lines.append('  Trace_enabled: no')
+    lines.append('  Default_main: yes')
+    lines.append('  Embedded_runtime: yes')
+    lines.append('end instrument')
+    lines.append('')
+    lines.append('begin simulation: %s' % outdir)
+    lines.append('  Format: McCode with text headers')
+    lines.append('  URL: http://www.mccode.org')
+    lines.append('  Creator: mcplotdiff (McCode difference tool)')
+    lines.append('  Instrument: diff(%s, %s)' % (_sanitize(label_a), _sanitize(label_b)))
+    lines.append('  Ncount: 0')
+    lines.append('  Trace: no')
+    lines.append('  Param: a=%s b=%s' % (_sanitize(label_a), _sanitize(label_b)))
+    lines.append('end simulation')
+    lines.append('')
+
+    for data in diffs:
+        if isinstance(data, Data1D):
+            type_line = '  type: array_1d(%d)' % len(data.xvals)
+        elif isinstance(data, Data2D):
+            zshape = np.shape(data.zvals) if data.zvals else (0, 0)
+            type_line = '  type: array_2d(%d, %d)' % (zshape[0], zshape[1] if len(zshape) > 1 else 0)
+        else:
+            continue
+
+        lines.append('begin data')
+        lines.append('  Date: %s' % now)
+        lines.append(type_line)
+        lines.append('  component: %s' % _sanitize(data.component))
+        lines.append('  title: %s' % _sanitize(data.title))
+        try:
+            lines.append('  values: %s %s %s' % (_fmt(data.values[0]), _fmt(data.values[1]), _fmt(data.values[2])))
+        except Exception:
+            pass
+        # This is the one line mcplotloader.py's _get_filenames_from_mccodesim()
+        # actually looks for - it must match the real file written by
+        # write_mccode_dat()/write_all_mccode_dat() with the same prefix.
+        lines.append('  filename: %s' % (prefix + data.filename))
+        lines.append('end data')
+        lines.append('')
+
+    with open(filepath, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+
+    return filepath

--- a/tools/Python/mcplot/html/mcplotdiff-html.md.in
+++ b/tools/Python/mcplot/html/mcplotdiff-html.md.in
@@ -8,7 +8,7 @@
 
 # SYNOPSIS
 
-**@MCCODE_PREFIX@plotdiff-html** [-h] [-n] [-l] [--autosize] [--libpath [LIBPATH ...]] [-o OUTPUT] [-A LABEL_A] [-B LABEL_B] [-W WIDTH] [-H HEIGHT] a b
+**@MCCODE_PREFIX@plotdiff-html** [-h] [-n] [-D] [-l] [--autosize] [--libpath [LIBPATH ...]] [-o OUTPUT] [-A LABEL_A] [-B LABEL_B] [-W WIDTH] [-H HEIGHT] a b
 
 # DESCRIPTION
 
@@ -25,6 +25,16 @@ non-MPI results.
 file. Only monitors present in both `a` and `b`, with identical binning, are
 compared; monitors found in only one of the two inputs, or with mismatched
 binning, are skipped with a warning.
+
+By default, each difference dataset is also written out in standard McCode
+ASCII ("# comment header + data body") format alongside the HTML plots,
+with a `mccode.sim` index generated too (when comparing two simulation
+folders), so the output directory is itself a normal McCode simulation
+directory that can be reopened directly by
+**@MCCODE_PREFIX@plot-html**/**@MCCODE_PREFIX@plot-pyqtgraph**/**@MCCODE_PREFIX@plot-matplotlib**,
+or any other McCode-format-aware tool. Each generated HTML plot also links
+directly to its underlying `.dat` file. Pass `-D`/`--no-dat` to skip this and
+only produce the HTML plots.
 
 For 1D monitors, the difference curve is plotted with error bars computed
 from standard error propagation. For 2D monitors, since differences can be
@@ -45,6 +55,11 @@ same client-side plotting code as **@MCCODE_PREFIX@plot-html**.
 
 **-n, --nobrowse**
 :   do not open a webbrowser viewer
+
+**-D, --no-dat**
+:   do not write each difference dataset out in standard McCode ASCII
+    format (and skip the `mccode.sim` index in folder mode); by default
+    these files are written alongside the HTML plots
 
 **-l, --log**
 :   when comparing two single monitor files, also produce a log-style plot.

--- a/tools/Python/mcplot/html/mcplotdiff.py
+++ b/tools/Python/mcplot/html/mcplotdiff.py
@@ -114,15 +114,15 @@ def get_html(template_name, params, dat_basename=None):
     if dat_basename:
         # dat_basename is a relative path (same directory as the html page
         # itself), pointing at the McCode-format .dat file written by
-        # write_mccode_dat() (only present when --write-dat was given).
+        # write_mccode_dat() (absent only if --no-dat was given).
         text = text.replace("@DATAFILE@", dat_basename)
         text = text.replace("@DATALINK@", "Download difference data (McCode format): %s" % dat_basename)
     else:
-        # --write-dat wasn't requested, so there's genuinely no file to
-        # link to - keep the anchor inert rather than pointing at a
-        # basename that was never written to this directory.
+        # --no-dat was given, so there's genuinely no file to link to -
+        # keep the anchor inert rather than pointing at a basename that
+        # was never written to this directory.
         text = text.replace("@DATAFILE@", "#")
-        text = text.replace("@DATALINK@", "Diff mode (no physical datafile - rerun with --write-dat to generate one)")
+        text = text.replace("@DATALINK@", "Diff mode (no physical datafile - rerun without --no-dat to generate one)")
 
     logscalestr = "true" if logscale == True else "false"
     text = text.replace("@LOGSCALE@", logscalestr)
@@ -434,6 +434,12 @@ autosize = False
 def main(args):
     logging.basicConfig(level=logging.INFO)
 
+    # writing .dat/mccode.sim alongside the HTML plots is the default now
+    # that the HTML pages link to them properly (see get_html()) - -D/--no-dat
+    # opts back out, e.g. for a quick one-off comparison where the extra
+    # files aren't wanted.
+    write_dat = not args.no_dat
+
     global libpath
     if args.libpath:
         libpath = args.libpath[0] + "/"
@@ -485,7 +491,7 @@ def main(args):
     entries = []
     for data in diffs:
         dat_path = None
-        if args.write_dat:
+        if write_dat:
             dat_path = write_mccode_dat(data, outdir)
             print("Generated: %s" % dat_path)
         dat_basename = os.path.basename(dat_path) if dat_path else None
@@ -525,7 +531,7 @@ def main(args):
             browse(target)
         return
 
-    if args.write_dat:
+    if write_dat:
         # A mccode.sim index only makes sense for a multi-monitor output
         # directory (a lone diff .dat file has no "simulation directory"
         # to index) - lets `outdir` be opened directly as a proper McCode
@@ -548,10 +554,12 @@ if __name__ == '__main__':
     parser.add_argument('a', help='first simulation file or directory (the minuend, "a")')
     parser.add_argument('b', help='second simulation file or directory (the subtrahend, "b"); diff = a - b')
     parser.add_argument('-n', '--nobrowse', action='store_true', help='do not open a webbrowser viewer')
-    parser.add_argument('-D', '--write-dat', action='store_true',
-                         help='also write each difference dataset out in standard McCode ASCII '
-                              '("# comment header + data body") format, loadable back in by '
-                              'mcplot-html/-pyqtgraph/-matplotlib or any other McCode-format reader')
+    parser.add_argument('-D', '--no-dat', dest='no_dat', action='store_true',
+                         help='do not write each difference dataset out in standard McCode ASCII '
+                              '("# comment header + data body") format (default: written alongside '
+                              'the HTML plots, along with a mccode.sim index in folder mode, so the '
+                              'output directory can be reopened as a normal McCode simulation directory '
+                              'by mcplot-html/-pyqtgraph/-matplotlib or any other McCode-format reader)')
     parser.add_argument('-l', '--log', action='store_true',
                          help='also produce a log-scale plot when comparing two single monitor files '
                               '(folder-mode always produces both linear and log-style plots)')

--- a/tools/Python/mcplot/html/mcplotdiff.py
+++ b/tools/Python/mcplot/html/mcplotdiff.py
@@ -36,6 +36,7 @@ from mccodelib import mccode_config
 from mccodelib import mcplotdiffloader as diffloader
 from mccodelib.mcplotdiffloader import (
     path_base_name, default_labels, load_monitors, compute_diffs, find_original_plot,
+    write_mccode_dat, write_mccode_sim,
 )
 
 global WIDTH, HEIGHT
@@ -357,6 +358,10 @@ def write_index(outdir, entries, label_a, label_b):
             if fname_log:
                 basename_log = os.path.basename(fname_log)
                 outfile.write(f"<a href='{basename_log}' target=_blank>[ {basename_log} ]</a>\n")
+            dat_path = entry.get('dat')
+            if dat_path:
+                basename_dat = os.path.basename(dat_path)
+                outfile.write(f"<a href='{basename_dat}' download>[ {basename_dat} ]</a>\n")
             outfile.write("</span><br>\n")
             # links to the pre-existing mcplot-html plots of the two
             # original monitors, if they were found on disk
@@ -478,6 +483,11 @@ def main(args):
             # exactly like mcplot.py does for multi-monitor overviews
             f_log = plot_diff_single(data, outdir, True)
 
+        dat_path = None
+        if args.write_dat:
+            dat_path = write_mccode_dat(data, outdir)
+            print("Generated: %s" % dat_path)
+
         # locate any pre-existing mcplot-html plots for this monitor, so
         # we can link to the original a/b data alongside the diff plot
         a_lin, a_log = find_original_plot(dir_a, data.filename)
@@ -488,7 +498,7 @@ def main(args):
             print("Note: no existing mcplot-html output found for '%s' in '%s'" % (data.filename, args.b))
 
         entries.append({
-            'diff': f, 'diff_log': f_log,
+            'diff': f, 'diff_log': f_log, 'dat': dat_path,
             'a_lin': a_lin, 'a_log': a_log,
             'b_lin': b_lin, 'b_log': b_log,
         })
@@ -503,6 +513,17 @@ def main(args):
             browse(target)
         return
 
+    if args.write_dat:
+        # A mccode.sim index only makes sense for a multi-monitor output
+        # directory (a lone diff .dat file has no "simulation directory"
+        # to index) - lets `outdir` be opened directly as a proper McCode
+        # simulation directory (e.g. mcplot-html <outdir>/), via the
+        # standard mccode.sim-indexed loading path, rather than only via
+        # the folder-of-loose-files fallback.
+        sim_path = write_mccode_sim(diffs, outdir, label_a=label_a, label_b=label_b,
+                                     instrument='diff_%s_vs_%s' % (label_a, label_b))
+        print("Generated: %s" % sim_path)
+
     index_file = write_index(outdir, entries, label_a, label_b)
     print("Generated: %s" % index_file)
 
@@ -515,6 +536,10 @@ if __name__ == '__main__':
     parser.add_argument('a', help='first simulation file or directory (the minuend, "a")')
     parser.add_argument('b', help='second simulation file or directory (the subtrahend, "b"); diff = a - b')
     parser.add_argument('-n', '--nobrowse', action='store_true', help='do not open a webbrowser viewer')
+    parser.add_argument('-D', '--write-dat', action='store_true',
+                         help='also write each difference dataset out in standard McCode ASCII '
+                              '("# comment header + data body") format, loadable back in by '
+                              'mcplot-html/-pyqtgraph/-matplotlib or any other McCode-format reader')
     parser.add_argument('-l', '--log', action='store_true',
                          help='also produce a log-scale plot when comparing two single monitor files '
                               '(folder-mode always produces both linear and log-style plots)')

--- a/tools/Python/mcplot/html/mcplotdiff.py
+++ b/tools/Python/mcplot/html/mcplotdiff.py
@@ -107,11 +107,22 @@ def lookup_vec(cm, x):
 # html / json generation (mirrors mcplot.py's get_html/get_json_*)
 # ---------------------------------------------------------------------------
 
-def get_html(template_name, params, simfile):
+def get_html(template_name, params, dat_basename=None):
     text = open(os.path.join(os.path.dirname(__file__), template_name)).read()
     text = text.replace("@PARAMS@", params)
-    text = text.replace("@DATAFILE@", simfile)
-    text = text.replace("@DATALINK@", "Diff mode (no physical datafile)") # Nothing to link to  in diff-mode
+
+    if dat_basename:
+        # dat_basename is a relative path (same directory as the html page
+        # itself), pointing at the McCode-format .dat file written by
+        # write_mccode_dat() (only present when --write-dat was given).
+        text = text.replace("@DATAFILE@", dat_basename)
+        text = text.replace("@DATALINK@", "Download difference data (McCode format): %s" % dat_basename)
+    else:
+        # --write-dat wasn't requested, so there's genuinely no file to
+        # link to - keep the anchor inert rather than pointing at a
+        # basename that was never written to this directory.
+        text = text.replace("@DATAFILE@", "#")
+        text = text.replace("@DATALINK@", "Diff mode (no physical datafile - rerun with --write-dat to generate one)")
 
     logscalestr = "true" if logscale == True else "false"
     text = text.replace("@LOGSCALE@", logscalestr)
@@ -263,7 +274,7 @@ def browse(html_filepath):
 # per-monitor plot writers
 # ---------------------------------------------------------------------------
 
-def plot_diff_single(data, outdir, use_logscale):
+def plot_diff_single(data, outdir, use_logscale, dat_basename=None):
     """ Writes one diff monitor to an html file in outdir, mirroring
         mcplot.py's plotfunc_single. Returns the file path written. """
     global logscale
@@ -277,9 +288,9 @@ def plot_diff_single(data, outdir, use_logscale):
         os.remove(f)
 
     if isinstance(data, Data1D):
-        text = get_html('template_1d.html', get_params_str_1D(data), os.path.basename(data.filename))
+        text = get_html('template_1d.html', get_params_str_1D(data), dat_basename)
     elif isinstance(data, Data2D):
-        text = get_html('template_2d.html', get_params_str_2D_diff(data), os.path.basename(data.filename))
+        text = get_html('template_2d.html', get_params_str_2D_diff(data), dat_basename)
     else:
         return None
 
@@ -473,20 +484,21 @@ def main(args):
 
     entries = []
     for data in diffs:
-        f = plot_diff_single(data, outdir, False)
-        f_log = None
-        if single_input:
-            if args.log:
-                f_log = plot_diff_single(data, outdir, True)
-        else:
-            # folder mode: always produce both linear and log variants,
-            # exactly like mcplot.py does for multi-monitor overviews
-            f_log = plot_diff_single(data, outdir, True)
-
         dat_path = None
         if args.write_dat:
             dat_path = write_mccode_dat(data, outdir)
             print("Generated: %s" % dat_path)
+        dat_basename = os.path.basename(dat_path) if dat_path else None
+
+        f = plot_diff_single(data, outdir, False, dat_basename)
+        f_log = None
+        if single_input:
+            if args.log:
+                f_log = plot_diff_single(data, outdir, True, dat_basename)
+        else:
+            # folder mode: always produce both linear and log variants,
+            # exactly like mcplot.py does for multi-monitor overviews
+            f_log = plot_diff_single(data, outdir, True, dat_basename)
 
         # locate any pre-existing mcplot-html plots for this monitor, so
         # we can link to the original a/b data alongside the diff plot


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Minor AI-driven change: 
The html-based (directory-oriented) diff plotter now writes a mccode-style dataset using the diff data. Such ‘diff datasets’ can be plotted using the usual mcplot utils.

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

Extension of earlier claude prompts requesting to write the datasets in “mccode style”, i.e. a mccode.sim and “diff datasets”

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



