### PR TITLE
New tools: mccoplot folder_A/ folder_B/ 

### DIFF
--- a/cmake/Modules/InstallMCCODE.cmake
+++ b/cmake/Modules/InstallMCCODE.cmake
@@ -415,7 +415,7 @@ macro(installMCCODE)
     install(PROGRAMS ${WORK}/support/${FLAVOR}-labenv.bat DESTINATION "${DEST_BINDIR}")
 
     # Python/Perl related batches special handling
-    foreach (name run.bat doc.bat test.bat viewtest.bat resplot.bat plot.bat plotdiff.bat display.bat gui.bat guistart.bat plot-pyqtgraph.bat plotdiff-pyqtgraph.bat plot-matplotlib.bat plotdiff-matplotlib.bat plot-matlab.bat plot-html.bat plotdiff-html.bat display-webgl.bat display-webgl-classic.bat display-pyqtgraph.bat display-cad.bat display-matplotlib.bat display-mantid.bat display-matlab.bat)
+    foreach (name run.bat doc.bat test.bat viewtest.bat resplot.bat plot.bat coplot.bat plotdiff.bat display.bat gui.bat guistart.bat plot-pyqtgraph.bat coplot-pyqtgraph.bat plotdiff-pyqtgraph.bat plot-matplotlib.bat coplot-matplotlib.bat plotdiff-matplotlib.bat plot-matlab.bat plot-html.bat coplot-html.bat plotdiff-html.bat display-webgl.bat display-webgl-classic.bat display-pyqtgraph.bat display-cad.bat display-matplotlib.bat display-mantid.bat display-matlab.bat)
       configure_file(
 	      cmake/support/run-scripts/${name}.in
 	      work/support/${MCCODE_PREFIX}${name}

--- a/cmake/support/run-scripts/coplot-html.bat.in
+++ b/cmake/support/run-scripts/coplot-html.bat.in
@@ -1,0 +1,4 @@
+@REM Isn't windows a lovely place???
+@set BINDIR=%~dp0
+@python -u %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\html\@MCCODE_PREFIX@coplot.py %*
+

--- a/cmake/support/run-scripts/coplot-matplotlib.bat.in
+++ b/cmake/support/run-scripts/coplot-matplotlib.bat.in
@@ -1,0 +1,7 @@
+@echo off
+@set BINDIR=%~dp0
+@CALL %BINDIR%\@FLAVOR@env.bat
+@SET PATH=%BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib;%PATH%
+@REM Isn't windows a lovely place???
+@python %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\matplotlib\@MCCODE_PREFIX@coplot.py %*
+@exit

--- a/cmake/support/run-scripts/coplot-pyqtgraph.bat.in
+++ b/cmake/support/run-scripts/coplot-pyqtgraph.bat.in
@@ -1,0 +1,4 @@
+@REM Isn't windows a lovely place???
+@set BINDIR=%~dp0
+@python -u %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\pyqtgraph\@MCCODE_PREFIX@coplot.py %*
+

--- a/cmake/support/run-scripts/coplot.bat.in
+++ b/cmake/support/run-scripts/coplot.bat.in
@@ -1,0 +1,4 @@
+@REM Isn't windows a lovely place???
+@set BINDIR=%~dp0
+@python -u %BINDIR%\@MCCODE_RELPATH_BINDIR2TOOLDIR@\Python\@MCCODE_PREFIX@plot\pyqtgraph\@MCCODE_PREFIX@coplot.py %*
+

--- a/tools/Python/mccodelib/mcplotdiffloader.py
+++ b/tools/Python/mccodelib/mcplotdiffloader.py
@@ -224,6 +224,59 @@ def compute_diffs(monitors_a, monitors_b, label_a, label_b):
     return diffs
 
 
+def match_1d_monitors(monitors_a, monitors_b, label_a, label_b):
+    """ Matches monitors present in both simulations by output filename,
+        the same way compute_diffs() does, but returns both original
+        Data1D objects for co-plotting/overlay instead of subtracting them.
+        Used by the mccoplot frontends (mcplot-coplot-html,
+        mcplot-coplot-matplotlib, ...).
+
+        Only 1D/1D matches with identical binning are kept; anything else
+        (a monitor present in only one side, a 2D monitor, a type
+        mismatch, or mismatched binning) is skipped with a warning -
+        overlaying two 2D images doesn't have an equally natural
+        single-plot representation, so that case is left to the diff
+        tools' diverging-colourmap image instead.
+
+        Returns an ordered list of (key, data_a, data_b). """
+    keys_a = set(monitors_a.keys())
+    keys_b = set(monitors_b.keys())
+
+    only_a = keys_a - keys_b
+    only_b = keys_b - keys_a
+    for k in sorted(only_a):
+        print("Warning: monitor '%s' present in '%s' only, skipping" % (k, label_a))
+    for k in sorted(only_b):
+        print("Warning: monitor '%s' present in '%s' only, skipping" % (k, label_b))
+
+    pairs = []
+    for key in [k for k in monitors_a.keys() if k in keys_b]:
+        a = monitors_a[key]
+        b = monitors_b[key]
+
+        if not (isinstance(a, Data1D) and isinstance(b, Data1D)):
+            if isinstance(a, Data2D) or isinstance(b, Data2D):
+                print("Warning: skipping '%s' - co-plotting only supports 1D monitors "
+                      "(got %s vs %s); try a diff tool for 2D comparisons"
+                      % (key, type(a).__name__, type(b).__name__))
+            else:
+                print("Warning: skipping '%s' - mismatched or unsupported monitor types" % key)
+            continue
+
+        if len(a.xvals) != len(b.xvals):
+            print("Warning: skipping '%s' - differing number of bins (%d vs %d)"
+                  % (key, len(a.xvals), len(b.xvals)))
+            continue
+
+        if a.component != b.component:
+            print("Warning: '%s' component name differs ('%s' vs '%s'), co-plotting anyway"
+                  % (key, a.component, b.component))
+
+        pairs.append((key, a, b))
+
+    return pairs
+
+
 def load_and_diff(path_a, path_b, label_a=None, label_b=None):
     """ Convenience one-shot: loads both simulations, resolves labels, and
         returns (diffs, dir_a, dir_b, label_a, label_b). """

--- a/tools/Python/mccodelib/mcplotdiffloader.py
+++ b/tools/Python/mccodelib/mcplotdiffloader.py
@@ -13,6 +13,7 @@ into any existing plot-graph-based frontend (e.g. the interactive
 pyqtgraph frontend in pqtgfrontend.py).
 '''
 import os
+import re
 import datetime
 
 import numpy as np
@@ -69,6 +70,42 @@ def default_labels(path_a, path_b, label_a=None, label_b=None):
         used_fallback = True
 
     return label_a, label_b, used_fallback
+
+
+def dirsafe_name(path):
+    """ Filesystem-safe slug of a full input path, for use in *output
+        directory/file* names.
+
+        This is deliberately separate from default_labels()'s short
+        display labels: those may legitimately collapse to bare "A"/"B"
+        when the basenames of two input paths collide (e.g. both
+        ".../<instrument>/1/") - fine for an on-screen legend, but if the
+        *output directory* name were built from those same collapsed
+        labels, every such comparison would land in the same
+        "..._A_vs_B" folder, clobbering previous runs. This uses the
+        input path as actually given (not just its basename), so distinct
+        source paths always produce distinct output directories - the
+        common case when batch/CI tooling runs many comparisons out of
+        the same working directory, each against a differently-timestamped
+        or differently-parameterised run.
+
+        Keeps the path as given (relative or absolute, whichever the
+        caller passed in) rather than resolving to an absolute path -
+        that matches what a human actually typed/expects to see, and
+        avoids dragging environment-specific absolute-path noise (e.g.
+        a CI runner's long checkout path) into every folder name. """
+    p = path.rstrip('/\\')
+    if p in ('', '.', '..'):
+        # degenerate case (e.g. someone ran the tool with '.' as one side) -
+        # fall back to the resolved directory's own basename instead of a
+        # bare, unhelpful "."
+        p = os.path.basename(os.path.abspath(path))
+    p = p.replace('\\', '/').replace('/', '_')
+    # collapse any remaining filesystem-unsafe characters
+    p = re.sub(r'[^\w\-.]', '_', p)
+    # tidy up repeated/leading/trailing underscores left by the above
+    p = re.sub(r'_+', '_', p).strip('_')
+    return p or 'unnamed'
 
 
 # ---------------------------------------------------------------------------

--- a/tools/Python/mccodelib/mcplotdiffloader.py
+++ b/tools/Python/mccodelib/mcplotdiffloader.py
@@ -37,14 +37,38 @@ def path_base_name(path):
 
 
 def default_labels(path_a, path_b, label_a=None, label_b=None):
-    ''' Resolves user-facing short labels for two simulation paths, falling
+    """ Resolves user-facing short labels for two simulation paths, falling
         back to the basename of each path if a label wasn't given
-        explicitly. '''
-    if not label_a:
+        explicitly.
+
+        A basename-only fallback collides for a common layout: results
+        stored as .../<instrument>/<testnb>/, where testnb is frequently
+        "1" on both sides (e.g. two runs differing only in an MPI
+        parameter earlier in the path) - both labels would silently come
+        out as "1", indistinguishable from each other. When that happens
+        (and only when *both* labels were auto-derived - an explicitly
+        given label is never overridden), falls back to literal "A"/"B"
+        instead.
+
+        Returns (label_a, label_b, used_fallback) - used_fallback is True
+        when the "A"/"B" fallback above was applied, i.e. the labels
+        carry no identifying information of their own; callers may want to
+        show the full paths somewhere (e.g. a plot title) in that case,
+        the way mcplotdiff/mccoplot's diff='A: <path>, B: <path>' style
+        note does. """
+    auto_a = not label_a
+    auto_b = not label_b
+    if auto_a:
         label_a = path_base_name(os.path.basename(os.path.abspath(path_a.rstrip('/'))))
-    if not label_b:
+    if auto_b:
         label_b = path_base_name(os.path.basename(os.path.abspath(path_b.rstrip('/'))))
-    return label_a, label_b
+
+    used_fallback = False
+    if auto_a and auto_b and label_a == label_b:
+        label_a, label_b = 'A', 'B'
+        used_fallback = True
+
+    return label_a, label_b, used_fallback
 
 
 # ---------------------------------------------------------------------------
@@ -279,12 +303,12 @@ def match_1d_monitors(monitors_a, monitors_b, label_a, label_b):
 
 def load_and_diff(path_a, path_b, label_a=None, label_b=None):
     """ Convenience one-shot: loads both simulations, resolves labels, and
-        returns (diffs, dir_a, dir_b, label_a, label_b). """
-    label_a, label_b = default_labels(path_a, path_b, label_a, label_b)
+        returns (diffs, dir_a, dir_b, label_a, label_b, used_fallback). """
+    label_a, label_b, used_fallback = default_labels(path_a, path_b, label_a, label_b)
     monitors_a, dir_a = load_monitors(path_a)
     monitors_b, dir_b = load_monitors(path_b)
     diffs = compute_diffs(monitors_a, monitors_b, label_a, label_b)
-    return diffs, dir_a, dir_b, label_a, label_b
+    return diffs, dir_a, dir_b, label_a, label_b, used_fallback
 
 
 # ---------------------------------------------------------------------------

--- a/tools/Python/mccodelib/mcplotdiffloader.py
+++ b/tools/Python/mccodelib/mcplotdiffloader.py
@@ -203,7 +203,7 @@ def diff_1d(key, a, b, label_a, label_b):
         N = 0
     d.values = (I, Ierr, N)
     d.statistics = '%s: %s\n%s: %s' % (label_a, a.statistics, label_b, b.statistics)
-    d.title = '\nDiff (%s - %s): %s' % (label_a, label_b, a.title)
+    d.title = ' - Diff (A - B), with:\n \nA=%s\nB=%s\n \n%s' % (label_a, label_b, a.title)
 
     return d
 

--- a/tools/Python/mcplot/html/CMakeLists.txt
+++ b/tools/Python/mcplot/html/CMakeLists.txt
@@ -101,8 +101,21 @@ install(
   RENAME "${P}plotdiff.py"
   )
 
+# Configure fallback script for the a-b co-plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccoplot.in" "${WORK}/${P}coplot-html" @ONLY)
+
+# Configure doc for the a-b co-plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccoplot-html.md.in" "${WORK}/${P}coplot-html.md" @ONLY)
+
+# Co-plotter script, including rename mc/mxcoplot
+install(
+  PROGRAMS "${PROJECT_SOURCE_DIR}/mccoplot.py"
+  DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+  RENAME "${P}coplot.py"
+  )
+
 # Other .py infrastructure
-foreach(NAME d3.v4.min.js template_1d.html template_2d.html plotfuncs.js)
+foreach(NAME d3.v4.min.js template_1d.html template_2d.html template_1d_coplot.html plotfuncs.js)
   install(
     FILES "${PROJECT_SOURCE_DIR}/${NAME}"
     DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
@@ -113,7 +126,7 @@ endforeach()
 # cmake Modules/MCUtil
 if(NOT WINDOWS)
   add_custom_target(
-    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot-html" "${WORK}/${P}plotdiff-html"
+    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot-html" "${WORK}/${P}plotdiff-html" "${WORK}/${P}coplot-html"
     )
 
   install(
@@ -145,6 +158,22 @@ if(NOT WINDOWS)
 
   install(
     FILES "${WORK}/${P}plotdiff-html.md"
+    DESTINATION "${DEST_DATADIR_DOC}"
+  )
+
+  install(
+    PROGRAMS ${PROJECT_SOURCE_DIR}/mccoplot.py
+    DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+    RENAME "${P}coplot.py"
+  )
+
+  install(
+    PROGRAMS "${WORK}/${P}coplot-html"
+    DESTINATION ${DEST_BINDIR}
+    )
+
+  install(
+    FILES "${WORK}/${P}coplot-html.md"
     DESTINATION "${DEST_DATADIR_DOC}"
   )
 

--- a/tools/Python/mcplot/html/mccoplot-html.md.in
+++ b/tools/Python/mcplot/html/mccoplot-html.md.in
@@ -1,0 +1,101 @@
+% @MCCODE_PREFIX@COPLOT-html(1)
+% @FLAVOR_UPPER@ @MCCODE_PARTICLE@ Ray Tracing Team
+% @MCCODE_DATE@
+
+# NAME
+
+**@MCCODE_PREFIX@coplot-html** - Co-plotting (overlaying) two @MCCODE_NAME@ simulation results' 1D monitors in a browser
+
+# SYNOPSIS
+
+**@MCCODE_PREFIX@coplot-html** [-h] [-n] [-l] [--autosize] [--libpath [LIBPATH ...]] [-o OUTPUT] [-A LABEL_A] [-B LABEL_B] [--colour-a COLOUR_A] [--colour-b COLOUR_B] [-W WIDTH] [-H HEIGHT] a b
+
+# DESCRIPTION
+
+The front-end **@MCCODE_PREFIX@coplot-html** is a companion to
+**@MCCODE_PREFIX@plotdiff-html**, sharing its command-line syntax and
+monitor-matching logic. Instead of computing and plotting the *difference*
+between two simulation results, **@MCCODE_PREFIX@coplot-html** overlays the
+two datasets on the same axes, for direct visual comparison of curve shape
+and position rather than the size of the gap between them.
+
+`a` and `b` may each be either a simulation output directory (as produced by
+`@MCCODE_PREFIX@run`, containing a `mccode.sim` file) or a single monitor
+data file. Monitors are matched between `a` and `b` by output filename,
+exactly as in **@MCCODE_PREFIX@plotdiff-html**.
+
+Only 1D monitors are supported. A monitor present in only one of the two
+inputs, or a monitor pair that isn't a matching 1D/1D pair (e.g. a 2D
+monitor, or mismatched binning), is skipped with a warning printed to the
+console; use **@MCCODE_PREFIX@plotdiff-html** for 2D comparisons, which
+supports those via a diverging colour-mapped difference image instead.
+
+This is the web/html co-plotting tool (in browser), and reuses the same
+client-side plotting code as **@MCCODE_PREFIX@plot-html**/**@MCCODE_PREFIX@plotdiff-html**
+(specifically, its Plot1D class's native multi-series overlay support).
+
+# OPTIONS
+
+**-h, --help**
+:   show this help message and exit
+
+**-n, --nobrowse**
+:   do not open a webbrowser viewer
+
+**-l, --log**
+:   when comparing two single monitor files, also produce a log-style plot.
+    (When comparing two simulation folders, both a linear and a log-style
+    plot are always produced for every monitor, just like
+    **@MCCODE_PREFIX@plotdiff-html**.)
+
+**--autosize**
+:   expand to window size on load
+
+**--libpath [LIBPATH ...]**
+:   js lib files path
+
+**-o OUTPUT, --output OUTPUT**
+:   specify output directory for the generated plots (default:
+    `coplot_<a>_vs_<b>` in the current directory)
+
+**-A LABEL_A, --label-a LABEL_A**
+:   short label used for simulation `a` in the legend/titles (default: the
+    basename of `a`)
+
+**-B LABEL_B, --label-b LABEL_B**
+:   short label used for simulation `b` in the legend/titles (default: the
+    basename of `b`)
+
+**--colour-a COLOUR_A**
+:   override the overlay colour used for `a` (default `#1f77b4`, blue)
+
+**--colour-b COLOUR_B**
+:   override the overlay colour used for `b` (default `#d62728`, red)
+
+**-W WIDTH, --width WIDTH**
+:   width of iframes
+
+**-H HEIGHT, --height HEIGHT**
+:   height of iframes
+
+# FILES
+
+/usr/share/@FLAVOR@/resources
+/usr/share/@FLAVOR@/tools/Python/mccodelib/mccode_config.json
+~/.@FLAVOR@/mccode_config.json
+http://www.@FLAVOR@.org
+
+# EXAMPLES
+
+Run the *Test_SX* example (Single crystal diffraction) twice with different parameters, and overlay a 1D monitor from each
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_a -n 1e7 TTH=13.4`
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_b -n 1e7 TTH=14.0`
+:   - `@MCCODE_PREFIX@coplot-html output_a output_b`
+
+# AUTHORS
+
+@MCCODE_NAME@ Team (@FLAVOR@.org)
+
+# SEE ALSO
+
+@FLAVOR@(1), @MCCODE_PREFIX@doc(1), @MCCODE_PREFIX@plot(1), @MCCODE_PREFIX@plot-html(1), @MCCODE_PREFIX@plotdiff-html(1), @MCCODE_PREFIX@run(1), @MCCODE_PREFIX@gui(1), @MCCODE_PREFIX@display(1)

--- a/tools/Python/mcplot/html/mccoplot.in
+++ b/tools/Python/mcplot/html/mccoplot.in
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Wrapper script for @P@coplot-html
+
+@MCCODE_BASH_STANDARD_PREAMBLE@
+
+TOOL="@P@coplot"
+UTILDIR="${MCCODE_TOOLDIR}/Python/@P@plot/html"
+
+
+#NB: miniconda should be installed next to the tool folder:
+if [ -d "${MCCODE_TOOLDIR}/../miniconda3" ]; then
+    source "${MCCODE_TOOLDIR}/../miniconda3/bin/activate" "${MCCODE_TOOLDIR}/../miniconda3"
+    export PATH=${MCCODE_TOOLDIR}/../miniconda3/bin/:$PATH
+fi
+
+canrun() {
+    if ! [ -x "${UTILDIR}/${TOOL}.py" ]; then
+        exit 127;
+    fi
+
+}
+
+if ( canrun ); then
+    python3 -u ${UTILDIR}/${TOOL}.py "$@"
+else
+    @FLAVOR@_errmsg Failed to run Python ${TOOL} - permissions or missing dependencies\?
+fi

--- a/tools/Python/mcplot/html/mccoplot.py
+++ b/tools/Python/mcplot/html/mccoplot.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+
+"""
+Co-plot (overlay) two McCode simulation results as HTML pages.
+
+This is a companion to mcplotdiff.py (mcplot-diff-html), sharing its
+command-line syntax and monitor-matching logic, but instead of subtracting
+diff.monN = a.monN - b.monN, mccoplot.py overlays a.monN and b.monN on the
+same axes for direct visual comparison ("does the curve shape/position
+still line up"), rather than the difference tool's "how big is the gap".
+
+Only 1D monitors are supported: a and b are matched by output filename
+(exactly like mcplotdiff.py), and any matched pair that isn't a 1D/1D match
+(a 2D monitor, or a type mismatch) is skipped with a warning - overlaying
+two 2D images doesn't have an equally natural single-plot representation,
+so that case is intentionally left to mcplotdiff.py's diverging-colourmap
+image instead.
+
+The monitor-loading/matching logic is shared with mcplotdiff.py via
+mccodelib.mcplotdiffloader; this script reuses the same client-side d3-based
+plotting code (plotfuncs.js) as mcplot.py / mcplot-html - specifically
+Plot1D's built-in multi-series support - via a dedicated
+template_1d_coplot.html.
+"""
+import argparse
+import logging
+import os
+import sys
+import json
+import subprocess
+
+from shutil import copyfile
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from mccodelib.mcplotloader import Data1D, Data2D
+from mccodelib import mccode_config
+from mccodelib.mcplotdiffloader import (
+    path_base_name, default_labels, load_monitors, find_original_plot,
+)
+
+global WIDTH, HEIGHT
+WIDTH = 1024
+HEIGHT = 768
+
+# Default overlay colours (A, B): a colourblind-friendly blue/red pair,
+# matching Plot1D's expected `colour` (British spelling) params field.
+COLOUR_A = '#1f77b4'
+COLOUR_B = '#d62728'
+
+
+# ---------------------------------------------------------------------------
+# matching monitors between the two simulations (1D only)
+# ---------------------------------------------------------------------------
+
+def match_1d_monitors(monitors_a, monitors_b, label_a, label_b):
+    """ Matches monitors present in both simulations by output filename,
+        the same way mcplotdiffloader.compute_diffs() does, but keeps both
+        original Data1D objects for overlay instead of subtracting them.
+
+        Only 1D/1D matches with identical binning are kept; anything else
+        (a monitor present in only one side, a 2D monitor, a type
+        mismatch, or mismatched binning) is skipped with a warning.
+        Returns an ordered list of (key, data_a, data_b). """
+    keys_a = set(monitors_a.keys())
+    keys_b = set(monitors_b.keys())
+
+    only_a = keys_a - keys_b
+    only_b = keys_b - keys_a
+    for k in sorted(only_a):
+        print("Warning: monitor '%s' present in '%s' only, skipping" % (k, label_a))
+    for k in sorted(only_b):
+        print("Warning: monitor '%s' present in '%s' only, skipping" % (k, label_b))
+
+    pairs = []
+    for key in [k for k in monitors_a.keys() if k in keys_b]:
+        a = monitors_a[key]
+        b = monitors_b[key]
+
+        if not (isinstance(a, Data1D) and isinstance(b, Data1D)):
+            if isinstance(a, Data2D) or isinstance(b, Data2D):
+                print("Warning: skipping '%s' - mccoplot only supports 1D monitors "
+                      "(got %s vs %s); try mcplotdiff-html for 2D comparisons"
+                      % (key, type(a).__name__, type(b).__name__))
+            else:
+                print("Warning: skipping '%s' - mismatched or unsupported monitor types" % key)
+            continue
+
+        if len(a.xvals) != len(b.xvals):
+            print("Warning: skipping '%s' - differing number of bins (%d vs %d)"
+                  % (key, len(a.xvals), len(b.xvals)))
+            continue
+
+        if a.component != b.component:
+            print("Warning: '%s' component name differs ('%s' vs '%s'), co-plotting anyway"
+                  % (key, a.component, b.component))
+
+        pairs.append((key, a, b))
+
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# html / json generation
+# ---------------------------------------------------------------------------
+
+def get_params_json(data, colour, title):
+    p = {
+        'w': WIDTH,
+        'h': HEIGHT,
+        'x': data.xvals,
+        'y': data.yvals,
+        'yerr': data.y_err_vals,
+        'xlabel': data.xlabel,
+        'ylabel': data.ylabel,
+        'title': title,
+        'colour': colour,
+    }
+    if autosize:
+        p['autosize'] = True
+    return json.dumps(p, indent=4)
+
+
+def _title_for(data, other_label, this_label):
+    try:
+        return '%s [%s]\n%s: %s\nI = %s Err = %s N = %s' % (
+            data.component, data.filename, this_label, data.title,
+            data.values[0], data.values[1], data.values[2])
+    except Exception:
+        return '%s\n[%s]' % (data.component, data.filename)
+
+
+def get_html(params_a_json, params_b_json, label_a, label_b, colour_a, colour_b,
+             dat_link_a=None, dat_link_b=None):
+    text = open(os.path.join(os.path.dirname(__file__), 'template_1d_coplot.html')).read()
+    text = text.replace("@PARAMS_A@", params_a_json)
+    text = text.replace("@PARAMS_B@", params_b_json)
+    text = text.replace("@LABEL_A@", label_a)
+    text = text.replace("@LABEL_B@", label_b)
+    text = text.replace("@COLOUR_A@", colour_a)
+    text = text.replace("@COLOUR_B@", colour_b)
+    text = text.replace("@DATALINK_A@", ('(<a href="%s" target=_blank>plot</a>)' % dat_link_a) if dat_link_a else '')
+    text = text.replace("@DATALINK_B@", ('(<a href="%s" target=_blank>plot</a>)' % dat_link_b) if dat_link_b else '')
+    logscalestr = "true" if logscale else "false"
+    text = text.replace("@LOGSCALE@", logscalestr)
+    text = text.replace("@LIBPATH@", libpath)
+    return text
+
+
+def browse(html_filepath):
+    try:
+        subprocess.Popen('%s %s' % (mccode_config.configuration['BROWSER'], html_filepath), shell=True)
+    except Exception as e:
+        raise Exception('Os-specific open browser: %s' % e.__str__())
+
+
+# ---------------------------------------------------------------------------
+# per-monitor plot writer
+# ---------------------------------------------------------------------------
+
+def coplot_single(key, data_a, data_b, outdir, use_logscale, label_a, label_b,
+                   colour_a, colour_b, dat_link_a=None, dat_link_b=None):
+    """ Writes one co-plot (overlaid a/b) monitor page to outdir. Returns
+        the file path written. """
+    global logscale
+    logscale = use_logscale
+
+    basename = 'coplot_' + path_base_name(data_a.filename)
+    fname = basename + ('_log.html' if use_logscale else '.html')
+    f = os.path.join(outdir, fname)
+
+    if os.path.exists(f):
+        os.remove(f)
+
+    title_a = _title_for(data_a, label_b, label_a)
+    params_a = get_params_json(data_a, colour_a, title_a)
+    params_b = get_params_json(data_b, colour_b, "")  # B's title isn't used (see template)
+
+    text = get_html(params_a, params_b, label_a, label_b, colour_a, colour_b,
+                     dat_link_a, dat_link_b)
+
+    with open(f, 'w') as fid:
+        fid.write(text)
+
+    return f
+
+
+def _relhref(target, outdir):
+    """ Relative link from outdir to target, using forward slashes so the
+        generated href works regardless of platform. """
+    if target is None:
+        return None
+    return os.path.relpath(target, start=outdir).replace(os.sep, '/')
+
+
+# ---------------------------------------------------------------------------
+# overview index page
+# ---------------------------------------------------------------------------
+
+def write_index(outdir, entries, label_a, label_b):
+    """ Writes an overview index.html with an iframe grid, in the same
+        visual style as mcplotdiff.py's write_index().
+
+        'entries' is a list of dicts, one per monitor, with keys:
+          'coplot'     - path to the co-plot (linear) html page
+          'coplot_log' - path to the co-plot (log) html page, or None
+    """
+    filename = os.path.join(outdir, "index.html")
+
+    gridgap = int(round(WIDTH * 0.05))
+    initial_scale = 0.5
+    init_w = WIDTH * initial_scale
+    init_h = HEIGHT * initial_scale
+    init_pct = int(round(initial_scale * 100))
+
+    with open(filename, 'w') as outfile:
+        outfile.write("<html><head>\n")
+        outfile.write(f"<title>Co-plots: {label_a} vs {label_b}</title>\n")
+        outfile.write("<style>\n")
+        outfile.write("  body { background-color: #e0e0e0; margin: 12px; font-family: sans-serif; }\n")
+        outfile.write(f"  .plotgrid {{ display: flex; flex-wrap: wrap; gap: {gridgap}px; }}\n")
+        outfile.write("  .plotcell { background-color: #ffffff; display: flex; flex-direction: column; align-items: flex-start; }\n")
+        outfile.write("  .plotcell iframe { border: none; }\n")
+        outfile.write("  .plotcell .links { margin-top: 4px; width: 100%; box-sizing: border-box; display: flex; flex-wrap: wrap; align-items: center; gap: 4px 12px; }\n")
+        outfile.write("  .iframe-wrap { overflow: hidden; border: 2px solid #b0b0b0; }\n")
+        outfile.write("  .iframe-wrap iframe { transform-origin: top left; display: block; }\n")
+        outfile.write("  #sizecontrol { margin-bottom: 16px; font-size: 14px; }\n")
+        outfile.write("  #sizecontrol input[type=range] { vertical-align: middle; margin: 0 8px; }\n")
+        outfile.write("</style>\n")
+        outfile.write("</head><body>\n")
+        outfile.write(f"<h1>Co-plots: {label_a} vs {label_b}</h1>\n")
+        outfile.write(f"<p>Each panel overlays ({label_a}).monitor and ({label_b}).monitor on the same axes.</p>\n")
+        outfile.write("<div id='sizecontrol'>\n")
+        outfile.write("  <label for='sizeslider'>Figure size:</label>\n")
+        outfile.write(f"  <input type='range' id='sizeslider' min='20' max='200' value='{init_pct}' step='5'>\n")
+        outfile.write(f"  <span id='sizevalue'>{init_pct}%</span>\n")
+        outfile.write("</div>\n")
+        outfile.write("<div class='plotgrid'>\n")
+        for entry in entries:
+            fname = entry['coplot']
+            fname_log = entry.get('coplot_log')
+            basename = os.path.basename(fname)
+            outfile.write(f"<div class='plotcell' data-base-w='{WIDTH}' style='width:{init_w}px;'>\n")
+            outfile.write(f"<div class='iframe-wrap' data-base-w='{WIDTH}' data-base-h='{HEIGHT}' style='width:{init_w}px;height:{init_h}px;'>\n")
+            outfile.write(f"<iframe src='{basename}' title='{basename}' width={WIDTH} height={HEIGHT} style='transform:scale({initial_scale});'></iframe>\n")
+            outfile.write("</div>\n")
+            outfile.write("<div class='links'>\n")
+            outfile.write(f"<a href='{basename}' target=_blank>[ {basename} ]</a>\n")
+            if fname_log:
+                basename_log = os.path.basename(fname_log)
+                outfile.write(f"<a href='{basename_log}' target=_blank>[ {basename_log} ]</a>\n")
+            outfile.write("</div>\n")
+            outfile.write("</div>\n")
+        outfile.write("</div>\n")
+        outfile.write("<script>\n")
+        outfile.write("  var slider = document.getElementById('sizeslider');\n")
+        outfile.write("  var sizevalue = document.getElementById('sizevalue');\n")
+        outfile.write("  var wraps = document.querySelectorAll('.iframe-wrap');\n")
+        outfile.write("  var cells = document.querySelectorAll('.plotcell');\n")
+        outfile.write("  slider.addEventListener('input', function() {\n")
+        outfile.write("    var scale = slider.value / 100;\n")
+        outfile.write("    sizevalue.textContent = slider.value + '%';\n")
+        outfile.write("    wraps.forEach(function(wrap) {\n")
+        outfile.write("      var bw = parseFloat(wrap.dataset.baseW);\n")
+        outfile.write("      var bh = parseFloat(wrap.dataset.baseH);\n")
+        outfile.write("      wrap.style.width = (bw * scale) + 'px';\n")
+        outfile.write("      wrap.style.height = (bh * scale) + 'px';\n")
+        outfile.write("      var fr = wrap.querySelector('iframe');\n")
+        outfile.write("      fr.style.transform = 'scale(' + scale + ')';\n")
+        outfile.write("    });\n")
+        outfile.write("    cells.forEach(function(cell) {\n")
+        outfile.write("      var bw = parseFloat(cell.dataset.baseW);\n")
+        outfile.write("      cell.style.width = (bw * scale) + 'px';\n")
+        outfile.write("    });\n")
+        outfile.write("  });\n")
+        outfile.write("</script>\n")
+        outfile.write("</body></html>\n")
+
+    return filename
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+logscale = False
+libpath = ""
+autosize = False
+
+
+def main(args):
+    logging.basicConfig(level=logging.INFO)
+
+    global libpath
+    if args.libpath:
+        libpath = args.libpath[0] + "/"
+    global autosize
+    if args.autosize:
+        autosize = True
+    global WIDTH
+    if args.width:
+        WIDTH = int(args.width[0])
+    global HEIGHT
+    if args.height:
+        HEIGHT = int(args.height[0])
+
+    colour_a = args.colour_a[0] if args.colour_a else COLOUR_A
+    colour_b = args.colour_b[0] if args.colour_b else COLOUR_B
+
+    label_a, label_b = default_labels(
+        args.a, args.b,
+        args.label_a[0] if args.label_a else None,
+        args.label_b[0] if args.label_b else None)
+
+    # determine output directory
+    if args.output:
+        outdir = args.output[0]
+    else:
+        outdir = "coplot_%s_vs_%s" % (label_a, label_b)
+    os.makedirs(outdir, exist_ok=True)
+
+    # copy js lib files locally if no lib path was specified
+    if libpath == "":
+        copyfile(os.path.join(os.path.dirname(__file__), 'd3.v4.min.js'), os.path.join(outdir, 'd3.v4.min.js'))
+        copyfile(os.path.join(os.path.dirname(__file__), 'plotfuncs.js'), os.path.join(outdir, 'plotfuncs.js'))
+
+    # load both simulations
+    try:
+        monitors_a, dir_a = load_monitors(args.a)
+        monitors_b, dir_b = load_monitors(args.b)
+    except Exception as e:
+        print('mccoplot loader: ' + e.__str__())
+        sys.exit(-1)
+
+    pairs = match_1d_monitors(monitors_a, monitors_b, label_a, label_b)
+
+    if len(pairs) == 0:
+        print("mccoplot: no matching 1D monitors found between '%s' and '%s', nothing to plot." % (args.a, args.b))
+        sys.exit(-1)
+
+    # single monitor case: just write one page (or a pair, if --log), like
+    # mcplotdiff.py does for a single monitor file input
+    single_input = os.path.isfile(args.a) and os.path.isfile(args.b)
+
+    entries = []
+    for key, data_a, data_b in pairs:
+        # link out to the pre-existing individual mcplot-html pages for
+        # each side, if they've already been generated, same as
+        # mcplotdiff.py does
+        a_lin, a_log = find_original_plot(dir_a, data_a.filename)
+        b_lin, b_log = find_original_plot(dir_b, data_b.filename)
+        dat_link_a = _relhref(a_lin, outdir)
+        dat_link_b = _relhref(b_lin, outdir)
+
+        f = coplot_single(key, data_a, data_b, outdir, False, label_a, label_b,
+                           colour_a, colour_b, dat_link_a, dat_link_b)
+        f_log = None
+        if single_input:
+            if args.log:
+                f_log = coplot_single(key, data_a, data_b, outdir, True, label_a, label_b,
+                                       colour_a, colour_b, dat_link_a, dat_link_b)
+        else:
+            # folder mode: always produce both linear and log variants,
+            # exactly like mcplotdiff.py does for multi-monitor overviews
+            f_log = coplot_single(key, data_a, data_b, outdir, True, label_a, label_b,
+                                   colour_a, colour_b, dat_link_a, dat_link_b)
+
+        entries.append({'coplot': f, 'coplot_log': f_log})
+        print("Generated: %s" % f)
+        if f_log:
+            print("Generated: %s" % f_log)
+
+    if single_input and len(entries) == 1:
+        target = entries[0]['coplot']
+        print("Generated: %s" % target)
+        if not args.nobrowse:
+            browse(target)
+        return
+
+    index_file = write_index(outdir, entries, label_a, label_b)
+    print("Generated: %s" % index_file)
+
+    if not args.nobrowse:
+        browse(index_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('a', help='first simulation file or directory')
+    parser.add_argument('b', help='second simulation file or directory, co-plotted alongside "a"')
+    parser.add_argument('-n', '--nobrowse', action='store_true', help='do not open a webbrowser viewer')
+    parser.add_argument('-l', '--log', action='store_true',
+                         help='also produce a log-scale plot when comparing two single monitor files '
+                              '(folder-mode always produces both linear and log-style plots)')
+    parser.add_argument('--autosize', action='store_true', help='expand to window size on load')
+    parser.add_argument('--libpath', nargs='*', help='js lib files path')
+    parser.add_argument('-o', '--output', nargs=1, help='specify output directory for the generated plots')
+    parser.add_argument('-A', '--label-a', nargs=1, help='short label used for simulation a in the legend/titles')
+    parser.add_argument('-B', '--label-b', nargs=1, help='short label used for simulation b in the legend/titles')
+    parser.add_argument('--colour-a', nargs=1, help='override the overlay colour used for a (default %s)' % COLOUR_A)
+    parser.add_argument('--colour-b', nargs=1, help='override the overlay colour used for b (default %s)' % COLOUR_B)
+    parser.add_argument('-W', '--width', nargs=1, help='width of iframes')
+    parser.add_argument('-H', '--height', nargs=1, help='height of iframes')
+    args = parser.parse_args()
+
+    main(args)

--- a/tools/Python/mcplot/html/mccoplot.py
+++ b/tools/Python/mcplot/html/mccoplot.py
@@ -36,7 +36,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from mccodelib.mcplotloader import Data1D, Data2D
 from mccodelib import mccode_config
 from mccodelib.mcplotdiffloader import (
-    path_base_name, default_labels, load_monitors, find_original_plot, match_1d_monitors,
+    path_base_name, default_labels, dirsafe_name, load_monitors, find_original_plot, match_1d_monitors,
 )
 
 global WIDTH, HEIGHT
@@ -287,11 +287,16 @@ def main(args):
     if used_fallback:
         path_note = "A: %s\nB: %s" % (args.a, args.b)
 
-    # determine output directory
+    # determine output directory - deliberately built from the actual
+    # input paths (dirsafe_name), not the display labels: label_a/label_b
+    # may legitimately collapse to bare "A"/"B" when their basenames
+    # collide (see default_labels()), which would otherwise put every such
+    # comparison in the same "coplot_A_vs_B" folder - a real problem for
+    # batch/CI use running many comparisons out of one working directory.
     if args.output:
         outdir = args.output[0]
     else:
-        outdir = "coplot_%s_vs_%s" % (label_a, label_b)
+        outdir = "coplot_%s_vs_%s" % (dirsafe_name(args.a), dirsafe_name(args.b))
     os.makedirs(outdir, exist_ok=True)
 
     # copy js lib files locally if no lib path was specified

--- a/tools/Python/mcplot/html/mccoplot.py
+++ b/tools/Python/mcplot/html/mccoplot.py
@@ -39,6 +39,12 @@ from mccodelib.mcplotdiffloader import (
     path_base_name, default_labels, dirsafe_name, load_monitors, find_original_plot, match_1d_monitors,
 )
 
+# The bare html-plotter (mcplot-html itself), imported directly rather than
+# shelled out to, so we can guarantee each source dataset's own per-monitor
+# pages (<monitor>.dat.html / <monitor>.dat_log.html) actually exist before
+# find_original_plot() goes looking for them below - see _ensure_html_plots().
+import mcplot
+
 global WIDTH, HEIGHT
 WIDTH = 1024
 HEIGHT = 768
@@ -102,6 +108,39 @@ def get_html(params_a_json, params_b_json, label_a, label_b, colour_a, colour_b,
     text = text.replace("@LOGSCALE@", logscalestr)
     text = text.replace("@LIBPATH@", libpath)
     return text
+
+
+def _ensure_html_plots(path):
+    """ Runs the bare mcplot-html plotter (mcplot.py's own main()) on
+        `path` with --nobrowse, so its per-monitor pages
+        (<monitor>.dat.html / <monitor>.dat_log.html, next to the monitor's
+        own .dat file) are guaranteed to exist before find_original_plot()
+        looks for them - rather than depending on the user having already
+        run mcplot-html on that source directory separately (which is what
+        made the "A (plot)" / "B (plot)" links unreliable before this).
+
+        Works for both a directory and a single monitor file, matching
+        whatever args.a/args.b themselves are - mcplot.py's own main()
+        already handles both cases the same way mccoplot.py's own inputs
+        do.
+
+        Deliberately non-fatal: the co-plot itself doesn't depend on these
+        extra pages existing, only the "view original A/B plot" links do,
+        so any failure here (e.g. the path doesn't parse as a McCode
+        result for some reason) is reported but doesn't abort the co-plot
+        run - mcplot.py's own main() calls quit() (SystemExit) on a loader
+        failure rather than raising, so that's caught explicitly too. """
+    mcplot_args = argparse.Namespace(
+        simulation=[path], nobrowse=True, log=False, autosize=False,
+        libpath=None, output=None, width=None, height=None,
+    )
+    try:
+        mcplot.main(mcplot_args)
+    except SystemExit:
+        print("Warning: could not generate mcplot-html pages for '%s' "
+              "(used for the A/B 'plot' links)" % path)
+    except Exception as e:
+        print("Warning: could not generate mcplot-html pages for '%s': %s" % (path, e))
 
 
 def browse(html_filepath):
@@ -311,6 +350,13 @@ def main(args):
     except Exception as e:
         print('mccoplot loader: ' + e.__str__())
         sys.exit(-1)
+
+    # Make sure each side's own ordinary mcplot-html pages actually exist,
+    # so the "A (plot)" / "B (plot)" links below have something real to
+    # point at, rather than depending on the user having separately run
+    # mcplot-html on these directories beforehand.
+    _ensure_html_plots(args.a)
+    _ensure_html_plots(args.b)
 
     pairs = match_1d_monitors(monitors_a, monitors_b, label_a, label_b)
 

--- a/tools/Python/mcplot/html/mccoplot.py
+++ b/tools/Python/mcplot/html/mccoplot.py
@@ -36,7 +36,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from mccodelib.mcplotloader import Data1D, Data2D
 from mccodelib import mccode_config
 from mccodelib.mcplotdiffloader import (
-    path_base_name, default_labels, load_monitors, find_original_plot,
+    path_base_name, default_labels, load_monitors, find_original_plot, match_1d_monitors,
 )
 
 global WIDTH, HEIGHT
@@ -47,57 +47,6 @@ HEIGHT = 768
 # matching Plot1D's expected `colour` (British spelling) params field.
 COLOUR_A = '#1f77b4'
 COLOUR_B = '#d62728'
-
-
-# ---------------------------------------------------------------------------
-# matching monitors between the two simulations (1D only)
-# ---------------------------------------------------------------------------
-
-def match_1d_monitors(monitors_a, monitors_b, label_a, label_b):
-    """ Matches monitors present in both simulations by output filename,
-        the same way mcplotdiffloader.compute_diffs() does, but keeps both
-        original Data1D objects for overlay instead of subtracting them.
-
-        Only 1D/1D matches with identical binning are kept; anything else
-        (a monitor present in only one side, a 2D monitor, a type
-        mismatch, or mismatched binning) is skipped with a warning.
-        Returns an ordered list of (key, data_a, data_b). """
-    keys_a = set(monitors_a.keys())
-    keys_b = set(monitors_b.keys())
-
-    only_a = keys_a - keys_b
-    only_b = keys_b - keys_a
-    for k in sorted(only_a):
-        print("Warning: monitor '%s' present in '%s' only, skipping" % (k, label_a))
-    for k in sorted(only_b):
-        print("Warning: monitor '%s' present in '%s' only, skipping" % (k, label_b))
-
-    pairs = []
-    for key in [k for k in monitors_a.keys() if k in keys_b]:
-        a = monitors_a[key]
-        b = monitors_b[key]
-
-        if not (isinstance(a, Data1D) and isinstance(b, Data1D)):
-            if isinstance(a, Data2D) or isinstance(b, Data2D):
-                print("Warning: skipping '%s' - mccoplot only supports 1D monitors "
-                      "(got %s vs %s); try mcplotdiff-html for 2D comparisons"
-                      % (key, type(a).__name__, type(b).__name__))
-            else:
-                print("Warning: skipping '%s' - mismatched or unsupported monitor types" % key)
-            continue
-
-        if len(a.xvals) != len(b.xvals):
-            print("Warning: skipping '%s' - differing number of bins (%d vs %d)"
-                  % (key, len(a.xvals), len(b.xvals)))
-            continue
-
-        if a.component != b.component:
-            print("Warning: '%s' component name differs ('%s' vs '%s'), co-plotting anyway"
-                  % (key, a.component, b.component))
-
-        pairs.append((key, a, b))
-
-    return pairs
 
 
 # ---------------------------------------------------------------------------

--- a/tools/Python/mcplot/html/mccoplot.py
+++ b/tools/Python/mcplot/html/mccoplot.py
@@ -70,13 +70,21 @@ def get_params_json(data, colour, title):
     return json.dumps(p, indent=4)
 
 
-def _title_for(data, other_label, this_label):
+def _title_for(data, other_label, this_label, path_note=None):
     try:
-        return '%s [%s]\n%s: %s\nI = %s Err = %s N = %s' % (
+        title = '%s [%s]\n%s: %s\nI = %s Err = %s N = %s' % (
             data.component, data.filename, this_label, data.title,
             data.values[0], data.values[1], data.values[2])
     except Exception:
-        return '%s\n[%s]' % (data.component, data.filename)
+        title = '%s\n[%s]' % (data.component, data.filename)
+    if path_note:
+        # label_a/label_b are bare "A"/"B" here (see default_labels()),
+        # since the two source paths' basenames collided (e.g. both ended
+        # in ".../<instrument>/1/") - the full paths are shown in the
+        # figure title instead, while the compact on-plot legend keeps
+        # just "A"/"B".
+        title = path_note + '\n' + title
+    return title
 
 
 def get_html(params_a_json, params_b_json, label_a, label_b, colour_a, colour_b,
@@ -108,7 +116,7 @@ def browse(html_filepath):
 # ---------------------------------------------------------------------------
 
 def coplot_single(key, data_a, data_b, outdir, use_logscale, label_a, label_b,
-                   colour_a, colour_b, dat_link_a=None, dat_link_b=None):
+                   colour_a, colour_b, dat_link_a=None, dat_link_b=None, path_note=None):
     """ Writes one co-plot (overlaid a/b) monitor page to outdir. Returns
         the file path written. """
     global logscale
@@ -121,7 +129,7 @@ def coplot_single(key, data_a, data_b, outdir, use_logscale, label_a, label_b,
     if os.path.exists(f):
         os.remove(f)
 
-    title_a = _title_for(data_a, label_b, label_a)
+    title_a = _title_for(data_a, label_b, label_a, path_note=path_note)
     params_a = get_params_json(data_a, colour_a, title_a)
     params_b = get_params_json(data_b, colour_b, "")  # B's title isn't used (see template)
 
@@ -146,13 +154,17 @@ def _relhref(target, outdir):
 # overview index page
 # ---------------------------------------------------------------------------
 
-def write_index(outdir, entries, label_a, label_b):
+def write_index(outdir, entries, label_a, label_b, path_note=None):
     """ Writes an overview index.html with an iframe grid, in the same
         visual style as mcplotdiff.py's write_index().
 
         'entries' is a list of dicts, one per monitor, with keys:
           'coplot'     - path to the co-plot (linear) html page
           'coplot_log' - path to the co-plot (log) html page, or None
+
+        path_note, when given (see default_labels()'s used_fallback), is
+        shown under the header - label_a/label_b are bare "A"/"B" in that
+        case, carrying no identifying information of their own.
     """
     filename = os.path.join(outdir, "index.html")
 
@@ -175,10 +187,14 @@ def write_index(outdir, entries, label_a, label_b):
         outfile.write("  .iframe-wrap iframe { transform-origin: top left; display: block; }\n")
         outfile.write("  #sizecontrol { margin-bottom: 16px; font-size: 14px; }\n")
         outfile.write("  #sizecontrol input[type=range] { vertical-align: middle; margin: 0 8px; }\n")
+        outfile.write("  .pathnote { color: #666666; font-size: 13px; }\n")
         outfile.write("</style>\n")
         outfile.write("</head><body>\n")
         outfile.write(f"<h1>Co-plots: {label_a} vs {label_b}</h1>\n")
         outfile.write(f"<p>Each panel overlays ({label_a}).monitor and ({label_b}).monitor on the same axes.</p>\n")
+        if path_note:
+            note_html = path_note.replace('\n', '<br>')
+            outfile.write(f"<p class='pathnote'>{note_html}</p>\n")
         outfile.write("<div id='sizecontrol'>\n")
         outfile.write("  <label for='sizeslider'>Figure size:</label>\n")
         outfile.write(f"  <input type='range' id='sizeslider' min='20' max='200' value='{init_pct}' step='5'>\n")
@@ -256,10 +272,20 @@ def main(args):
     colour_a = args.colour_a[0] if args.colour_a else COLOUR_A
     colour_b = args.colour_b[0] if args.colour_b else COLOUR_B
 
-    label_a, label_b = default_labels(
+    label_a, label_b, used_fallback = default_labels(
         args.a, args.b,
         args.label_a[0] if args.label_a else None,
         args.label_b[0] if args.label_b else None)
+
+    # When the auto-derived labels collided (e.g. two runs both ending in a
+    # plain ".../<instrument>/1/" folder) and default_labels() fell back
+    # to bare "A"/"B", those letters carry no identifying information on
+    # their own - show the full source paths in each figure's title (and
+    # the overview header) instead, while keeping the compact on-plot
+    # legend as just "A"/"B".
+    path_note = None
+    if used_fallback:
+        path_note = "A: %s\nB: %s" % (args.a, args.b)
 
     # determine output directory
     if args.output:
@@ -302,17 +328,17 @@ def main(args):
         dat_link_b = _relhref(b_lin, outdir)
 
         f = coplot_single(key, data_a, data_b, outdir, False, label_a, label_b,
-                           colour_a, colour_b, dat_link_a, dat_link_b)
+                           colour_a, colour_b, dat_link_a, dat_link_b, path_note=path_note)
         f_log = None
         if single_input:
             if args.log:
                 f_log = coplot_single(key, data_a, data_b, outdir, True, label_a, label_b,
-                                       colour_a, colour_b, dat_link_a, dat_link_b)
+                                       colour_a, colour_b, dat_link_a, dat_link_b, path_note=path_note)
         else:
             # folder mode: always produce both linear and log variants,
             # exactly like mcplotdiff.py does for multi-monitor overviews
             f_log = coplot_single(key, data_a, data_b, outdir, True, label_a, label_b,
-                                   colour_a, colour_b, dat_link_a, dat_link_b)
+                                   colour_a, colour_b, dat_link_a, dat_link_b, path_note=path_note)
 
         entries.append({'coplot': f, 'coplot_log': f_log})
         print("Generated: %s" % f)
@@ -326,7 +352,7 @@ def main(args):
             browse(target)
         return
 
-    index_file = write_index(outdir, entries, label_a, label_b)
+    index_file = write_index(outdir, entries, label_a, label_b, path_note=path_note)
     print("Generated: %s" % index_file)
 
     if not args.nobrowse:

--- a/tools/Python/mcplot/html/mcplotdiff.py
+++ b/tools/Python/mcplot/html/mcplotdiff.py
@@ -35,7 +35,7 @@ from mccodelib.mcplotloader import Data1D, Data2D
 from mccodelib import mccode_config
 from mccodelib import mcplotdiffloader as diffloader
 from mccodelib.mcplotdiffloader import (
-    path_base_name, default_labels, load_monitors, compute_diffs, find_original_plot,
+    path_base_name, default_labels, dirsafe_name, load_monitors, compute_diffs, find_original_plot,
     write_mccode_dat, write_mccode_sim,
 )
 
@@ -471,11 +471,16 @@ def main(args):
         args.label_a[0] if args.label_a else None,
         args.label_b[0] if args.label_b else None)
 
-    # determine output directory
+    # determine output directory - deliberately built from the actual
+    # input paths (dirsafe_name), not the display labels: label_a/label_b
+    # may legitimately collapse to bare "A"/"B" when their basenames
+    # collide (see default_labels()), which would otherwise put every such
+    # comparison in the same "diff_A_vs_B" folder - a real problem for
+    # batch/CI use running many comparisons out of one working directory.
     if args.output:
         outdir = args.output[0]
     else:
-        outdir = "diff_%s_vs_%s" % (label_a, label_b)
+        outdir = "diff_%s_vs_%s" % (dirsafe_name(args.a), dirsafe_name(args.b))
     os.makedirs(outdir, exist_ok=True)
 
     # copy js lib files locally if no lib path was specified

--- a/tools/Python/mcplot/html/mcplotdiff.py
+++ b/tools/Python/mcplot/html/mcplotdiff.py
@@ -308,7 +308,7 @@ def _relhref(target, outdir):
     return os.path.relpath(target, start=outdir).replace(os.sep, '/')
 
 
-def write_index(outdir, entries, label_a, label_b):
+def write_index(outdir, entries, label_a, label_b, path_a=None, path_b=None, used_fallback=False):
     """ Writes an overview index.html with an iframe grid, in the same visual
         style as mcplot.py's PNMultiple index page.
 
@@ -321,6 +321,13 @@ def write_index(outdir, entries, label_a, label_b):
           'b_lin'     - path to the pre-existing mcplot-html page for
                         simulation b's monitor (linear), or None
           'b_log'     - ... (log), or None
+
+        path_a/path_b/used_fallback come from default_labels(): when the
+        auto-derived labels collided (e.g. two runs both ending in a plain
+        ".../<instrument>/1/" folder) and were replaced with bare "A"/"B",
+        used_fallback is True - in that case those bare letters carry no
+        identifying information on their own, so the full source paths are
+        shown as well.
     """
     filename = os.path.join(outdir, "index.html")
 
@@ -344,11 +351,18 @@ def write_index(outdir, entries, label_a, label_b):
         outfile.write("  .iframe-wrap iframe { transform-origin: top left; display: block; }\n")
         outfile.write("  #sizecontrol { margin-bottom: 16px; font-size: 14px; }\n")
         outfile.write("  #sizecontrol input[type=range] { vertical-align: middle; margin: 0 8px; }\n")
+        outfile.write("  .pathnote { color: #666666; font-size: 13px; }\n")
         outfile.write("</style>\n")
         outfile.write("</head><body>\n")
         outfile.write("<h1>Difference plots:</h1>\n")
         outfile.write(f"<strong><ol type=\"A\"><li>{label_a} vs.</li><li>{label_b}</li></ol></strong>")
         outfile.write(f"<p>diff.monitor = ({label_a}).monitor &minus; ({label_b}).monitor</p>\n")
+        if used_fallback and path_a and path_b:
+            # label_a/label_b are bare "A"/"B" here (see default_labels()),
+            # since the two source paths' basenames collided (e.g. both
+            # ended in ".../<instrument>/1/") - show the actual paths so
+            # the comparison is still identifiable.
+            outfile.write(f"<p class='pathnote'>A: {path_a}<br>B: {path_b}</p>\n")
         outfile.write("<div id='sizecontrol'>\n")
         outfile.write("  <label for='sizeslider'>Figure size:</label>\n")
         outfile.write(f"  <input type='range' id='sizeslider' min='20' max='200' value='{init_pct}' step='5'>\n")
@@ -453,7 +467,7 @@ def main(args):
     if args.height:
         HEIGHT = int(args.height[0])
 
-    label_a, label_b = default_labels(
+    label_a, label_b, used_fallback = default_labels(
         args.a, args.b,
         args.label_a[0] if args.label_a else None,
         args.label_b[0] if args.label_b else None)
@@ -542,7 +556,8 @@ def main(args):
                                      instrument='diff_%s_vs_%s' % (label_a, label_b))
         print("Generated: %s" % sim_path)
 
-    index_file = write_index(outdir, entries, label_a, label_b)
+    index_file = write_index(outdir, entries, label_a, label_b,
+                              path_a=args.a, path_b=args.b, used_fallback=used_fallback)
     print("Generated: %s" % index_file)
 
     if not args.nobrowse:

--- a/tools/Python/mcplot/html/mcplotdiff.py
+++ b/tools/Python/mcplot/html/mcplotdiff.py
@@ -354,8 +354,7 @@ def write_index(outdir, entries, label_a, label_b, path_a=None, path_b=None, use
         outfile.write("  .pathnote { color: #666666; font-size: 13px; }\n")
         outfile.write("</style>\n")
         outfile.write("</head><body>\n")
-        outfile.write("<h1>Difference plots:</h1>\n")
-        outfile.write(f"<strong><ol type=\"A\"><li>{label_a} vs.</li><li>{label_b}</li></ol></strong>")
+        outfile.write("<h1>Difference plots: A vs B</h1>\n")
         outfile.write(f"<p>diff.monitor = ({label_a}).monitor &minus; ({label_b}).monitor</p>\n")
         if used_fallback and path_a and path_b:
             # label_a/label_b are bare "A"/"B" here (see default_labels()),

--- a/tools/Python/mcplot/html/template_1d_coplot.html
+++ b/tools/Python/mcplot/html/template_1d_coplot.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<head>
+  <script src="@LIBPATH@d3.v4.min.js"></script>
+  <script src="@LIBPATH@plotfuncs.js"></script>
+  <style>
+    .coplot-legend {
+      position: fixed;
+      top: 8px;
+      right: 12px;
+      font-family: sans-serif;
+      font-size: 13px;
+      background: rgba(255,255,255,0.85);
+      padding: 6px 10px;
+      border: 1px solid #ccc;
+      border-radius: 3px;
+      line-height: 1.6;
+    }
+    .coplot-legend .swatch {
+      display: inline-block;
+      width: 14px;
+      height: 3px;
+      margin-right: 6px;
+      vertical-align: middle;
+    }
+    .coplot-legend a { color: inherit; }
+  </style>
+</head>
+<body style="margin:0;overflow:hidden">
+<div class="coplot-legend">
+  <div><span class="swatch" style="background:@COLOUR_A@"></span>@LABEL_A@ @DATALINK_A@</div>
+  <div><span class="swatch" style="background:@COLOUR_B@"></span>@LABEL_B@ @DATALINK_B@</div>
+</div>
+<script>
+  var paramsA = @PARAMS_A@;
+  var paramsB = @PARAMS_B@;
+
+  // Plot1D's constructor only auto-scales its axes from the single dataset
+  // passed to it, so we construct with A, then extend the axis bounds to
+  // also cover B before adding B's series and forcing a redraw - otherwise
+  // B's curve could render partially (or fully) outside the visible axes
+  // if its range exceeds A's.
+  var plt = new Plot1D(paramsA, d3.select("body").append("svg"), logscale=@LOGSCALE@);
+
+  var posB = paramsB['y'].filter(function(v) { return v > 0; });
+  var yminB = posB.length ? Math.min.apply(null, posB) : plt.ymin;
+
+  plt.xmin = Math.min(plt.xmin, d3.min(paramsB['x']));
+  plt.xmax = Math.max(plt.xmax, d3.max(paramsB['x']));
+  plt.ymin = Math.min(plt.ymin, yminB);
+  plt.ymax = Math.max(plt.ymax, d3.max(paramsB['y']) * 1.05);
+
+  plt.plotOneMore(paramsB);
+  plt._draw_1d_axes(plt.hdl.wplt, plt.hdl.hplt, plt.xmin, plt.xmax, plt.ymin, plt.ymax, plt.hdl.axisGroup);
+
+  plt.rgstrMouseClickPlot( () => { console.log("click"); } );
+  plt.rgstrMouseCtrlClickPlot( () => { console.log("ctrl click"); } );
+  plt.rgstrMouseRClickPlot( () => { console.log("right click"); } );
+</script>
+</body>
+</html>

--- a/tools/Python/mcplot/matplotlib/CMakeLists.txt
+++ b/tools/Python/mcplot/matplotlib/CMakeLists.txt
@@ -100,6 +100,19 @@ install(
   RENAME "${P}plotdiff.py"
   )
 
+# Configure fallback script for the a-b co-plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccoplot.in" "${WORK}/${P}coplot-matplotlib" @ONLY)
+
+# Configure doc for the a-b co-plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccoplot-matplotlib.md.in" "${WORK}/${P}coplot-matplotlib.md" @ONLY)
+
+# Co-plotter script, including rename mc/mxcoplot
+install(
+  PROGRAMS "${PROJECT_SOURCE_DIR}/mccoplot.py"
+  DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+  RENAME "${P}coplot.py"
+  )
+
 # Other .py infrastructure
 # plotfuncs.py holds the shared, non-CLI plotting/interaction code used by
 # both mcplot.py and mcplotdiff.py; it is NOT renamed (unlike mcplot.py),
@@ -113,7 +126,7 @@ install(
 # cmake Modules/MCUtil
 if(NOT WINDOWS)
   add_custom_target(
-    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot-matplotlib" "${WORK}/${P}plotdiff-matplotlib"
+    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot-matplotlib" "${WORK}/${P}plotdiff-matplotlib" "${WORK}/${P}coplot-matplotlib"
     )
 
   install(
@@ -145,6 +158,22 @@ if(NOT WINDOWS)
 
   install(
     FILES "${WORK}/${P}plotdiff-matplotlib.md"
+    DESTINATION "${DEST_DATADIR_DOC}"
+  )
+
+  install(
+    PROGRAMS ${PROJECT_SOURCE_DIR}/mccoplot.py
+    DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+    RENAME "${P}coplot.py"
+  )
+
+  install(
+    PROGRAMS "${WORK}/${P}coplot-matplotlib"
+    DESTINATION ${DEST_BINDIR}
+    )
+
+  install(
+    FILES "${WORK}/${P}coplot-matplotlib.md"
     DESTINATION "${DEST_DATADIR_DOC}"
   )
 endif()

--- a/tools/Python/mcplot/matplotlib/mccoplot-matplotlib.md.in
+++ b/tools/Python/mcplot/matplotlib/mccoplot-matplotlib.md.in
@@ -1,0 +1,99 @@
+% @MCCODE_PREFIX@COPLOT-MATPLOTLIB(1)
+% @FLAVOR_UPPER@ @MCCODE_PARTICLE@ Ray Tracing Team
+% @MCCODE_DATE@
+
+# NAME
+
+**@MCCODE_PREFIX@coplot-matplotlib** - Co-plotting (overlaying) two @MCCODE_NAME@ simulation results' 1D monitors using Matplotlib
+
+# SYNOPSIS
+
+**@MCCODE_PREFIX@coplot-matplotlib** [-h] [-A LABEL_A] [-B LABEL_B] [--colour-a COLOUR_A] [--colour-b COLOUR_B] [-t] [--html] [--format FORMAT] [--output OUTPUT] [--log] [--backend BACKEND] a b
+
+# DESCRIPTION
+
+The front-end **@MCCODE_PREFIX@coplot-matplotlib** is a companion to
+**@MCCODE_PREFIX@plotdiff-matplotlib**, sharing its command-line syntax and
+monitor-matching logic. Instead of computing and plotting the *difference*
+between two simulation results, **@MCCODE_PREFIX@coplot-matplotlib**
+overlays the two datasets on the same axes, for direct visual comparison of
+curve shape and position rather than the size of the gap between them.
+
+`a` and `b` may each be either a simulation output directory (as produced by
+`@MCCODE_PREFIX@run`, containing a `mccode.sim` file) or a single monitor
+data file. Monitors are matched between `a` and `b` by output filename,
+exactly as in **@MCCODE_PREFIX@plotdiff-matplotlib**.
+
+Only 1D monitors are supported. A monitor present in only one of the two
+inputs, or a monitor pair that isn't a matching 1D/1D pair (e.g. a 2D
+monitor, or mismatched binning), is skipped with a warning printed to the
+console; use **@MCCODE_PREFIX@plotdiff-matplotlib** for 2D comparisons.
+
+This tool reuses the same Matplotlib panel-layout code (figure sizing,
+panel grid, font scaling, title wrapping) as **@MCCODE_PREFIX@plot-matplotlib**,
+applied to overlaid monitor pairs instead of single monitors. Each panel
+shows both curves with a draggable legend; unlike ordinary
+**@MCCODE_PREFIX@plot-matplotlib**, there is no click-based drill-down,
+since a co-plot panel is already the finest level of detail on offer.
+Keyboard shortcuts (log toggle, save PNG/PDF/SVG/JPG, quit, help) work as
+usual - see the shortcuts printed on startup.
+
+# OPTIONS
+
+**-h, --help**
+:   show this help message and exit
+
+**-A LABEL_A, --label-a LABEL_A**
+:   short label used for simulation `a` in the legend/titles (default: the
+    basename of `a`)
+
+**-B LABEL_B, --label-b LABEL_B**
+:   short label used for simulation `b` in the legend/titles (default: the
+    basename of `b`)
+
+**--colour-a COLOUR_A**
+:   override the overlay colour used for `a` (default `#1f77b4`, blue)
+
+**--colour-b COLOUR_B**
+:   override the overlay colour used for `b` (default `#d62728`, red)
+
+**-t, --test**
+:   print the matched monitor pairs before plotting
+
+**--html**
+:   save plot to html using mpld3 (linux only)
+
+**--format FORMAT**
+:   save plot to pdf/png/eps/svg... without bringing up window
+
+**--output OUTPUT**
+:   save plot to given file without bringing up window. Extension (e.g.
+    pdf/png/eps/svg) can be specified in the file name or `--format`
+
+**--log**
+:   initiate plot(s) with log of signal
+
+**--backend BACKEND**
+:   use non-default backend for matplotlib plot
+
+# FILES
+
+/usr/share/@FLAVOR@/resources
+/usr/share/@FLAVOR@/tools/Python/mccodelib/mccode_config.json
+~/.@FLAVOR@/mccode_config.json
+http://www.@FLAVOR@.org
+
+# EXAMPLES
+
+Run the *Test_SX* example (Single crystal diffraction) twice with different parameters, and overlay a 1D monitor from each
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_a -n 1e7 TTH=13.4`
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_b -n 1e7 TTH=14.0`
+:   - `@MCCODE_PREFIX@coplot-matplotlib output_a output_b`
+
+# AUTHORS
+
+@MCCODE_NAME@ Team (@FLAVOR@.org)
+
+# SEE ALSO
+
+@FLAVOR@(1), @MCCODE_PREFIX@doc(1), @MCCODE_PREFIX@plot(1), @MCCODE_PREFIX@plot-matplotlib(1), @MCCODE_PREFIX@plotdiff-matplotlib(1), @MCCODE_PREFIX@coplot-html(1), @MCCODE_PREFIX@run(1), @MCCODE_PREFIX@gui(1), @MCCODE_PREFIX@display(1)

--- a/tools/Python/mcplot/matplotlib/mccoplot.in
+++ b/tools/Python/mcplot/matplotlib/mccoplot.in
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Wrapper script for @P@coplot-matplotlib-py
+
+@MCCODE_BASH_STANDARD_PREAMBLE@
+
+TOOL="@P@coplot"
+UTILDIR="${MCCODE_TOOLDIR}/Python/@P@plot/matplotlib"
+
+
+#NB: miniconda should be installed next to the tool folder:
+if [ -d "${MCCODE_TOOLDIR}/../miniconda3" ]; then
+    source "${MCCODE_TOOLDIR}/../miniconda3/bin/activate" "${MCCODE_TOOLDIR}/../miniconda3"
+    export PATH=${MCCODE_TOOLDIR}/../miniconda3/bin/:$PATH
+fi
+
+canrun() {
+    if ! [ -x "${UTILDIR}/${TOOL}.py" ]; then
+        exit 127;
+    fi
+
+    modules="matplotlib numpy"
+    cmd=""
+    for name in ${modules}; do
+        cmd="${cmd}import ${name}; "
+    done
+    python3 -c "${cmd}"
+}
+
+if ( canrun ); then
+    python3 -u ${UTILDIR}/${TOOL}.py "$@"
+else
+    @FLAVOR@_errmsg Failed to run Python ${TOOL} - permissions or missing dependencies\?
+fi

--- a/tools/Python/mcplot/matplotlib/mccoplot.py
+++ b/tools/Python/mcplot/matplotlib/mccoplot.py
@@ -292,8 +292,15 @@ def main(args):
                 print("  - %s (%s)" % (key, data_a.component))
 
         # default base name for --format/--output dumps and for --html,
-        # since there's no single simulation file to derive it from
-        plotfuncs.filenamebase = "coplot_%s_vs_%s" % (label_a, label_b)
+        # since there's no single simulation file to derive it from -
+        # deliberately built from the actual input paths (dirsafe_name),
+        # not label_a/label_b: those may legitimately collapse to bare
+        # "A"/"B" when their basenames collide (see default_labels()),
+        # which would otherwise make every such comparison overwrite the
+        # same "coplot_A_vs_B.*" files - a real problem for batch/CI use
+        # running many comparisons out of one working directory.
+        plotfuncs.filenamebase = "coplot_%s_vs_%s" % (
+            diffloader.dirsafe_name(args.a), diffloader.dirsafe_name(args.b))
 
         plotter = McCoplotPlotter(pairs, label_a, label_b, colour_a, colour_b, log=args.log, path_note=path_note)
 

--- a/tools/Python/mcplot/matplotlib/mccoplot.py
+++ b/tools/Python/mcplot/matplotlib/mccoplot.py
@@ -51,6 +51,7 @@ def _plot_coplot_panel(data_a, data_b, i, n, log, label_a, label_b, colour_a, co
 
     fontsize = plotfuncs._panel_fontsize(n)
     title_fontsize = plotfuncs._title_fontsize(n)
+    verbose = (n == 1)
 
     xmin = data_a.xlimits[0]
     xmax = data_a.xlimits[1]
@@ -83,7 +84,20 @@ def _plot_coplot_panel(data_a, data_b, i, n, log, label_a, label_b, colour_a, co
     plotfuncs.pylab.xlabel(data_a.xlabel, fontsize=fontsize, fontweight='bold')
     plotfuncs.pylab.ylabel(ylabel, fontsize=fontsize, fontweight='bold')
 
-    title = '%s [%s]' % (data_a.component, data_a.filename)
+    # short title in an overview grid, fuller detail (matching data_a.title
+    # and both sides' I/statistics) once drilled down to a single panel -
+    # the same "verbose only at n==1" convention plotfuncs.plot_single_data
+    # uses for ordinary (non-coplot) monitors.
+    if verbose:
+        try:
+            title = '%s [%s]\n%s\n%s: I=%s Err=%s N=%s; %s\n%s: I=%s Err=%s N=%s; %s' % (
+                data_a.component, data_a.filename, data_a.title,
+                label_a, data_a.values[0], data_a.values[1], data_a.values[2], data_a.statistics,
+                label_b, data_b.values[0], data_b.values[1], data_b.values[2], data_b.statistics)
+        except Exception:
+            title = '%s [%s]' % (data_a.component, data_a.filename)
+    else:
+        title = '%s [%s]' % (data_a.component, data_a.filename)
     title = plotfuncs._wrap_title(title, plotfuncs._title_wrap_width(n, title_fontsize))
     plotfuncs.pylab.title(title, fontsize=title_fontsize, fontweight='bold')
 
@@ -95,53 +109,103 @@ def _plot_coplot_panel(data_a, data_b, i, n, log, label_a, label_b, colour_a, co
 
 
 class McCoplotPlotter():
-    ''' Minimal matplotlib co-plot frontend: renders a static grid of
-        overlaid (a, b) 1D monitor pairs. Deliberately has no click-based
-        drill-down (unlike McMatplotlibPlotter in plotfuncs.py) - a
-        co-plot panel is already the finest level of detail there is.
-        Keyboard shortcuts (log toggle / save / quit / help) are otherwise
-        identical, via plotfuncs.py's generic keypress()/print_help()/
-        dumpfile(), which don't depend on there being a plot graph. '''
+    ''' Matplotlib co-plot frontend: renders a grid of overlaid (a, b) 1D
+        monitor pairs, with the same overview <-> single-panel navigation
+        as ordinary mcplot-matplotlib/mcplotdiff-matplotlib (click a panel
+        to view it full-size; right-click, 'b', or back-navigate to
+        return), reusing plotfuncs.py's generic click()/keypress()/
+        print_help()/dumpfile() directly - none of those depend on there
+        being an actual plot graph, they just need a list of "click_cbs"
+        (one per currently-visible panel) and a "back_cb". Since a co-plot
+        pair has no further level of detail beyond the single-panel view
+        (unlike an ordinary monitor's plot graph, which can have further
+        primaries/secondaries to sweep through), click_cbs is simply empty
+        once drilled down - only the back-navigation remains active. '''
 
-    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, log):
+    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, log, path_note=None):
         self.pairs = pairs
         self.label_a = label_a
         self.label_b = label_b
         self.colour_a = colour_a
         self.colour_b = colour_b
         self.log = log
+        self.path_note = path_note
+        self.current = None  # None = overview grid; else index into self.pairs
+        self.event_dc_cid = None
 
     def _flip_log(self):
         self.log = not self.log
 
+    def _visible_pairs(self):
+        if self.current is None:
+            return self.pairs
+        return [self.pairs[self.current]]
+
+    def _show_overview(self):
+        self.current = None
+        self._replot()
+
+    def _show_single(self, idx):
+        self.current = idx
+        self._replot()
+
+    def _click_proxy(self, event):
+        ''' state-updating proxy for plotfuncs.click(), mirroring
+            McMatplotlibPlotter._click_proxy() '''
+        dc_cb = lambda: plotfuncs.pylab.disconnect(self.event_dc_cid)
+        plotfuncs.click(event, subplts=self.subplts, click_cbs=self.click_cbs,
+                         ctrl_cbs=[], back_cb=self._show_overview, dc_cb=dc_cb)
+
     def _keypress_proxy(self, event):
-        plotfuncs.keypress(event, back_cb=lambda: None, replot_cb=self._replot,
+        plotfuncs.keypress(event, back_cb=self._show_overview, replot_cb=self._replot,
                             togglelog_cb=self._flip_log)
 
     def _render(self):
-        n = len(self.pairs)
+        visible = self._visible_pairs()
+        n = len(visible)
         fig_w, fig_h = plotfuncs._figure_size(n)
         fig = plotfuncs.pylab.figure(figsize=(fig_w, fig_h))
 
-        for i, (key, data_a, data_b) in enumerate(self.pairs):
+        self.subplts = [
             _plot_coplot_panel(data_a, data_b, i, n, self.log,
                                 self.label_a, self.label_b, self.colour_a, self.colour_b)
+            for i, (key, data_a, data_b) in enumerate(visible)
+        ]
 
         fig.subplots_adjust(left=0.06, right=0.98, top=0.97, bottom=0.06,
                              wspace=0.3, hspace=0.35)
+
+        if self.path_note:
+            # label_a/label_b are bare "A"/"B" here (see default_labels()),
+            # since the two source paths' basenames collided (e.g. both
+            # ended in ".../<instrument>/1/") - shown once as a figure-
+            # level title (matplotlib's actual "figure title" concept,
+            # distinct from each panel's own title) rather than repeated
+            # inside every panel, which would get cluttered across a
+            # multi-panel overview.
+            fig.suptitle(self.path_note, fontsize=9, y=0.998, va='top')
+            fig.subplots_adjust(top=0.90 if n == 1 else 0.92)
+
+        # Left-click on a panel drills into it (only meaningful in overview
+        # mode - once already on a single panel there's nowhere further to
+        # go, so click_cbs is left empty and only right-click/'b' back-
+        # navigation remains live).
+        if self.current is None:
+            self.click_cbs = [lambda idx=i: self._show_single(idx) for i in range(n)]
+        else:
+            self.click_cbs = []
+
         return fig
 
     def _replot(self):
         plotfuncs.pylab.close()
         self._render()
+        self.event_dc_cid = plotfuncs.pylab.connect('button_press_event', self._click_proxy)
         plotfuncs.pylab.connect('key_press_event', self._keypress_proxy)
-        plotfuncs.pylab.draw()
 
     def plot(self):
         ''' render and show the interactive grid '''
-        plotfuncs.pylab.close()
-        self._render()
-        plotfuncs.pylab.connect('key_press_event', self._keypress_proxy)
+        self._replot()
         plotfuncs.pylab.show()
 
     def html(self, fileobj):
@@ -180,7 +244,17 @@ def main(args):
         from matplotlib import pylab
         plotfuncs.pylab = pylab
 
-        label_a, label_b = diffloader.default_labels(args.a, args.b, label_a, label_b)
+        label_a, label_b, used_fallback = diffloader.default_labels(args.a, args.b, label_a, label_b)
+
+        # When the auto-derived labels collided (e.g. two runs both ending
+        # in a plain ".../<instrument>/1/" folder) and default_labels()
+        # fell back to bare "A"/"B", those letters carry no identifying
+        # information on their own - show the full source paths as a
+        # figure-level suptitle instead, while the per-panel legend keeps
+        # just "A"/"B".
+        path_note = None
+        if used_fallback:
+            path_note = "A: %s   B: %s" % (args.a, args.b)
 
         try:
             monitors_a, dir_a = diffloader.load_monitors(args.a)
@@ -206,7 +280,7 @@ def main(args):
         # since there's no single simulation file to derive it from
         plotfuncs.filenamebase = "coplot_%s_vs_%s" % (label_a, label_b)
 
-        plotter = McCoplotPlotter(pairs, label_a, label_b, colour_a, colour_b, log=args.log)
+        plotter = McCoplotPlotter(pairs, label_a, label_b, colour_a, colour_b, log=args.log, path_note=path_note)
 
         if (sys.platform == "linux" or sys.platform == "linux2") and args.html:
             # save to html and exit

--- a/tools/Python/mcplot/matplotlib/mccoplot.py
+++ b/tools/Python/mcplot/matplotlib/mccoplot.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+'''
+matplotlib mccoplot frontend.
+
+This is a companion to mcplotdiff.py (mcplot-diff-matplotlib), sharing its
+command-line syntax and monitor-matching logic. Instead of computing and
+plotting the *difference* between two simulation results, mccoplot.py
+overlays the two datasets on the same axes, for direct visual comparison of
+curve shape and position rather than the size of the gap between them.
+
+Only 1D monitors are supported: a and b are matched by output filename via
+mccodelib.mcplotdiffloader.match_1d_monitors() (shared with the
+mcplot-coplot-html frontend), and any matched pair that isn't a 1D/1D match
+is skipped with a warning - overlaying two 2D images doesn't have an
+equally natural single-plot representation, so that case is left to the
+diff tools instead.
+
+Rendering reuses plotfuncs.py's panel-layout helpers (figure sizing, panel
+grid math, font scaling, title wrapping) - the same ones mcplot.py and
+mcplotdiff.py use - but with its own drawing/driver code, since a co-plot
+panel overlays two curves rather than showing one Data1D/Data2D from a plot
+graph. There's deliberately no click-based drill-down here (unlike ordinary
+mcplot-matplotlib): a co-plot panel is already the finest level of detail
+on offer, so there's nothing further to navigate into. Keyboard shortcuts
+(log toggle, save png/pdf/svg/jpg, quit, help) are otherwise identical,
+reusing plotfuncs.py's keypress()/print_help()/dumpfile() directly.
+'''
+import argparse
+import logging
+import os
+import sys
+import matplotlib
+import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+import plotfuncs
+
+from mccodelib import mcplotdiffloader as diffloader
+from mccodelib import mccode_config
+
+# Default overlay colours (a, b): a colourblind-friendly blue/red pair.
+COLOUR_A = '#1f77b4'
+COLOUR_B = '#d62728'
+
+
+def _plot_coplot_panel(data_a, data_b, i, n, log, label_a, label_b, colour_a, colour_b):
+    ''' plot one overlaid (a, b) pair into subplot i of n '''
+    dims = plotfuncs._calc_panel_size(n)
+    subplt = plotfuncs.pylab.subplot(dims[1], dims[0], i + 1)
+
+    fontsize = plotfuncs._panel_fontsize(n)
+    title_fontsize = plotfuncs._title_fontsize(n)
+
+    xmin = data_a.xlimits[0]
+    xmax = data_a.xlimits[1]
+    plotfuncs.pylab.xlim(xmin, xmax)
+
+    x = np.array(data_a.xvals).astype(float)
+    ya = np.array(data_a.yvals).astype(float)
+    yaerr = np.array(data_a.y_err_vals).astype(float)
+    yb = np.array(data_b.yvals).astype(float)
+    yberr = np.array(data_b.y_err_vals).astype(float)
+
+    ylabel = data_a.ylabel
+    if log:
+        def _tolog(y, yerr):
+            y = y.copy()
+            invalid = np.where(y <= 0)
+            valid = np.where(y > 0)
+            if len(valid[0]):
+                min_valid = np.min(y[valid])
+                y[invalid] = min_valid / 10
+            yerr = yerr / y
+            return np.log(y), yerr
+        ya, yaerr = _tolog(ya, yaerr)
+        yb, yberr = _tolog(yb, yberr)
+        ylabel = "log(" + data_a.ylabel + ")"
+
+    plotfuncs.pylab.errorbar(x, ya, yaerr, color=colour_a, label=label_a)
+    plotfuncs.pylab.errorbar(x, yb, yberr, color=colour_b, label=label_b)
+
+    plotfuncs.pylab.xlabel(data_a.xlabel, fontsize=fontsize, fontweight='bold')
+    plotfuncs.pylab.ylabel(ylabel, fontsize=fontsize, fontweight='bold')
+
+    title = '%s [%s]' % (data_a.component, data_a.filename)
+    title = plotfuncs._wrap_title(title, plotfuncs._title_wrap_width(n, title_fontsize))
+    plotfuncs.pylab.title(title, fontsize=title_fontsize, fontweight='bold')
+
+    leg = plotfuncs.pylab.legend(loc='upper left', fontsize=title_fontsize, framealpha=0.85,
+                                  handlelength=1.2, handletextpad=0.5, borderpad=0.4)
+    leg.set_draggable(True)
+
+    return subplt
+
+
+class McCoplotPlotter():
+    ''' Minimal matplotlib co-plot frontend: renders a static grid of
+        overlaid (a, b) 1D monitor pairs. Deliberately has no click-based
+        drill-down (unlike McMatplotlibPlotter in plotfuncs.py) - a
+        co-plot panel is already the finest level of detail there is.
+        Keyboard shortcuts (log toggle / save / quit / help) are otherwise
+        identical, via plotfuncs.py's generic keypress()/print_help()/
+        dumpfile(), which don't depend on there being a plot graph. '''
+
+    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, log):
+        self.pairs = pairs
+        self.label_a = label_a
+        self.label_b = label_b
+        self.colour_a = colour_a
+        self.colour_b = colour_b
+        self.log = log
+
+    def _flip_log(self):
+        self.log = not self.log
+
+    def _keypress_proxy(self, event):
+        plotfuncs.keypress(event, back_cb=lambda: None, replot_cb=self._replot,
+                            togglelog_cb=self._flip_log)
+
+    def _render(self):
+        n = len(self.pairs)
+        fig_w, fig_h = plotfuncs._figure_size(n)
+        fig = plotfuncs.pylab.figure(figsize=(fig_w, fig_h))
+
+        for i, (key, data_a, data_b) in enumerate(self.pairs):
+            _plot_coplot_panel(data_a, data_b, i, n, self.log,
+                                self.label_a, self.label_b, self.colour_a, self.colour_b)
+
+        fig.subplots_adjust(left=0.06, right=0.98, top=0.97, bottom=0.06,
+                             wspace=0.3, hspace=0.35)
+        return fig
+
+    def _replot(self):
+        plotfuncs.pylab.close()
+        self._render()
+        plotfuncs.pylab.connect('key_press_event', self._keypress_proxy)
+        plotfuncs.pylab.draw()
+
+    def plot(self):
+        ''' render and show the interactive grid '''
+        plotfuncs.pylab.close()
+        self._render()
+        plotfuncs.pylab.connect('key_press_event', self._keypress_proxy)
+        plotfuncs.pylab.show()
+
+    def html(self, fileobj):
+        ''' render and save to html using mpld3 '''
+        import mpld3
+        plotfuncs.pylab.close()
+        self._render()
+        mpld3.save_html(plotfuncs.pylab.gcf(), fileobj)
+
+
+def main(args):
+    ''' load and match two simulation results' 1D monitors, then hand the
+        resulting pairs to the matplotlib co-plot frontend above. '''
+    logging.basicConfig(level=logging.INFO)
+
+    # ensure keyboardinterrupt ctr-c
+    import signal
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    try:
+        label_a = args.label_a[0] if args.label_a else None
+        label_b = args.label_b[0] if args.label_b else None
+        colour_a = args.colour_a[0] if args.colour_a else COLOUR_A
+        colour_b = args.colour_b[0] if args.colour_b else COLOUR_B
+
+        if args.format or args.output:
+            matplotlib.use('template')
+
+        if args.backend:
+            try:
+                matplotlib.use(args.backend)
+            except Exception as e:
+                print('backend use error: ' + e.__str__())
+                return
+
+        from matplotlib import pylab
+        plotfuncs.pylab = pylab
+
+        label_a, label_b = diffloader.default_labels(args.a, args.b, label_a, label_b)
+
+        try:
+            monitors_a, dir_a = diffloader.load_monitors(args.a)
+            monitors_b, dir_b = diffloader.load_monitors(args.b)
+        except Exception as e:
+            print('mccoplot loader: ' + e.__str__())
+            plotfuncs.print_help(nogui=True)
+            quit()
+
+        pairs = diffloader.match_1d_monitors(monitors_a, monitors_b, label_a, label_b)
+
+        if len(pairs) == 0:
+            print("mccoplot: no matching 1D monitors found between '%s' and '%s', nothing to plot."
+                  % (args.a, args.b))
+            quit()
+
+        if args.test:
+            print("mccoplot: %d matched 1D monitor pair(s):" % len(pairs))
+            for key, data_a, data_b in pairs:
+                print("  - %s (%s)" % (key, data_a.component))
+
+        # default base name for --format/--output dumps and for --html,
+        # since there's no single simulation file to derive it from
+        plotfuncs.filenamebase = "coplot_%s_vs_%s" % (label_a, label_b)
+
+        plotter = McCoplotPlotter(pairs, label_a, label_b, colour_a, colour_b, log=args.log)
+
+        if (sys.platform == "linux" or sys.platform == "linux2") and args.html:
+            # save to html and exit
+            plotter.html(open('%s.html' % plotfuncs.filenamebase, 'w'))
+        else:
+            # display gui / prepare graphics dump
+            plotfuncs.print_help(nogui=True)
+            plotter.plot()
+
+        if args.output or args.format:
+            try:
+                plotfuncs.dumpfile(args.format, args.output)
+            except Exception as e:
+                print('dumpfile issue: ' + e.__str__())
+
+    except KeyboardInterrupt:
+        print('keyboard interrupt')
+    except Exception as e:
+        print('mccoplot error: %s' % e.__str__())
+        raise e
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('a', help='first simulation file or directory')
+    parser.add_argument('b', help='second simulation file or directory, co-plotted alongside "a"')
+    parser.add_argument('-A', '--label-a', nargs=1, help='short label used for simulation a in the legend/titles')
+    parser.add_argument('-B', '--label-b', nargs=1, help='short label used for simulation b in the legend/titles')
+    parser.add_argument('--colour-a', nargs=1, help='override the overlay colour used for a (default %s)' % COLOUR_A)
+    parser.add_argument('--colour-b', nargs=1, help='override the overlay colour used for b (default %s)' % COLOUR_B)
+    parser.add_argument('-t', '--test', action='store_true', default=False, help='print the matched monitor pairs before plotting')
+    parser.add_argument('--html', action='store_true', help='save plot to html using mpld3 (linux only)')
+    parser.add_argument('--format', dest='format', help='save plot to pdf/png/eps/svg... without bringing up window')
+    parser.add_argument('--output', nargs=1, dest='output', default=None,
+                         help='save plot to given file without bringing up window. Extension '
+                              '(e.g. pdf/png/eps/svg) can be specified in the file name or --format')
+    parser.add_argument('--log', action='store_true', help='initiate plot(s) with log of signal')
+    parser.add_argument('--backend', dest='backend', help='use non-default backend for matplotlib plot')
+
+    args = parser.parse_args()
+
+    mccode_config.load_config("user")
+
+    main(args)

--- a/tools/Python/mcplot/matplotlib/mccoplot.py
+++ b/tools/Python/mcplot/matplotlib/mccoplot.py
@@ -198,15 +198,30 @@ class McCoplotPlotter():
         return fig
 
     def _replot(self):
+        ''' Re-renders from scratch and re-enters the GUI event loop.
+
+            pylab.show() must be called again here, not just once from
+            plot() below - the SAME pattern plotfuncs.McMatplotlibPlotter.
+            plot_node() already uses for every click/keypress-triggered
+            redraw. Without it: _render() calls pylab.close() (destroying
+            the figure the original blocking show() call was watching) and
+            then creates a brand new figure via pylab.figure() - but with
+            no show() call for that new figure, many backends' blocking
+            event loop exits as soon as the figure count momentarily hits
+            zero, so the process falls straight through the original
+            show() and the new figure is never actually displayed. The
+            visible symptom is exactly what it looks like: any click
+            (drilling into a panel, going back, or even just toggling log
+            via 'l') appears to close the window outright. '''
         plotfuncs.pylab.close()
         self._render()
         self.event_dc_cid = plotfuncs.pylab.connect('button_press_event', self._click_proxy)
         plotfuncs.pylab.connect('key_press_event', self._keypress_proxy)
+        plotfuncs.pylab.show()
 
     def plot(self):
         ''' render and show the interactive grid '''
         self._replot()
-        plotfuncs.pylab.show()
 
     def html(self, fileobj):
         ''' render and save to html using mpld3 '''

--- a/tools/Python/mcplot/matplotlib/mcplotdiff.py
+++ b/tools/Python/mcplot/matplotlib/mcplotdiff.py
@@ -77,8 +77,15 @@ def main(args):
             PlotGraphPrint(graph)
 
         # default base name for --format/--output dumps and for --html,
-        # since there's no single simulation file to derive it from
-        plotfuncs.filenamebase = "diff_%s_vs_%s" % (label_a, label_b)
+        # since there's no single simulation file to derive it from -
+        # deliberately built from the actual input paths (dirsafe_name),
+        # not label_a/label_b: those may legitimately collapse to bare
+        # "A"/"B" when their basenames collide (see default_labels()),
+        # which would otherwise make every such comparison overwrite the
+        # same "diff_A_vs_B.*" files - a real problem for batch/CI use
+        # running many comparisons out of one working directory.
+        plotfuncs.filenamebase = "diff_%s_vs_%s" % (
+            diffloader.dirsafe_name(args.a), diffloader.dirsafe_name(args.b))
 
         # If the auto-derived labels collided (e.g. two runs both ending in
         # a plain ".../<instrument>/1/" folder) and default_labels() fell

--- a/tools/Python/mcplot/matplotlib/mcplotdiff.py
+++ b/tools/Python/mcplot/matplotlib/mcplotdiff.py
@@ -59,7 +59,7 @@ def main(args):
         plotfuncs.pylab = pylab
 
         try:
-            diffs, dir_a, dir_b, label_a, label_b = diffloader.load_and_diff(
+            diffs, dir_a, dir_b, label_a, label_b, used_fallback = diffloader.load_and_diff(
                 args.a, args.b, label_a, label_b)
         except Exception as e:
             print('mcplotdiff loader: ' + e.__str__())
@@ -80,8 +80,14 @@ def main(args):
         # since there's no single simulation file to derive it from
         plotfuncs.filenamebase = "diff_%s_vs_%s" % (label_a, label_b)
 
-        plotter = plotfuncs.McMatplotlibPlotter(
-            sourcedir='diff: %s - %s' % (label_a, label_b), log=args.log)
+        # If the auto-derived labels collided (e.g. two runs both ending in
+        # a plain ".../<instrument>/1/" folder) and default_labels() fell
+        # back to bare "A"/"B", those letters alone carry no identifying
+        # information - show the full source paths instead.
+        sourcedir = 'diff: %s - %s' % (label_a, label_b)
+        if used_fallback:
+            sourcedir = 'diff: A: %s   B: %s' % (args.a, args.b)
+        plotter = plotfuncs.McMatplotlibPlotter(sourcedir=sourcedir, log=args.log)
 
         if (sys.platform == "linux" or sys.platform == "linux2") and args.html:
             # save to html and exit

--- a/tools/Python/mcplot/pyqtgraph/CMakeLists.txt
+++ b/tools/Python/mcplot/pyqtgraph/CMakeLists.txt
@@ -101,6 +101,19 @@ install(
   RENAME "${P}plotdiff.py"
   )
 
+# Configure fallback script for the a-b co-plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccoplot.in" "${WORK}/${P}coplot-pyqtgraph" @ONLY)
+
+# Configure doc for the a-b co-plotter
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mccoplot-pyqtgraph.md.in" "${WORK}/${P}coplot-pyqtgraph.md" @ONLY)
+
+# Co-plotter script, including rename mc/mxcoplot
+install(
+  PROGRAMS "${PROJECT_SOURCE_DIR}/mccoplot.py"
+  DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+  RENAME "${P}coplot.py"
+  )
+
 # Other .py infrastructure
 foreach(NAME "mcdataclient.py"  "mcdataserver.py"  "mcdataservice.py" "plotfuncs.py")
   install(
@@ -113,7 +126,7 @@ endforeach()
 # cmake Modules/MCUtil
 if(NOT WINDOWS)
   add_custom_target(
-    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot" "${WORK}/${P}plotdiff-pyqtgraph"
+    "CREATE_${PROJECT_NAME}_SYMLINK" ALL DEPENDS "${WORK}/${P}plot" "${WORK}/${P}plotdiff-pyqtgraph" "${WORK}/${P}coplot-pyqtgraph"
     )
 
   install(
@@ -161,6 +174,28 @@ if(NOT WINDOWS)
 
   install(
     FILES "${WORK}/${P}plotdiff-pyqtgraph.md"
+    DESTINATION "${DEST_DATADIR_DOC}"
+  )
+
+  install(
+    PROGRAMS ${PROJECT_SOURCE_DIR}/mccoplot.py
+    DESTINATION "${DEST_TOOLDIR}/${TOOLS_NAME}"
+    RENAME "${P}coplot.py"
+  )
+
+  install(
+    PROGRAMS "${WORK}/${P}coplot-pyqtgraph"
+    DESTINATION ${DEST_BINDIR}
+  )
+
+  install(
+    PROGRAMS "${WORK}/${P}coplot-pyqtgraph"
+    DESTINATION ${DEST_BINDIR}
+    RENAME "${P}coplot"
+    )
+
+  install(
+    FILES "${WORK}/${P}coplot-pyqtgraph.md"
     DESTINATION "${DEST_DATADIR_DOC}"
   )
 

--- a/tools/Python/mcplot/pyqtgraph/mccoplot-pyqtgraph.md.in
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot-pyqtgraph.md.in
@@ -1,0 +1,85 @@
+% @MCCODE_PREFIX@COPLOT-PYQTGRAPH(1)
+% @FLAVOR_UPPER@ @MCCODE_PARTICLE@ Ray Tracing Team
+% @MCCODE_DATE@
+
+# NAME
+
+**@MCCODE_PREFIX@coplot-pyqtgraph** - Co-plotting (overlaying) two @MCCODE_NAME@ simulation results' 1D monitors interactively
+
+# SYNOPSIS
+
+**@MCCODE_PREFIX@coplot-pyqtgraph** [-h] [-A LABEL_A] [-B LABEL_B] [--colour-a COLOUR_A] [--colour-b COLOUR_B] [-t] [--invcanvas] a b
+
+# DESCRIPTION
+
+The front-end **@MCCODE_PREFIX@coplot-pyqtgraph** is a companion to
+**@MCCODE_PREFIX@plotdiff-pyqtgraph**, sharing its command-line syntax and
+monitor-matching logic. Instead of computing and plotting the *difference*
+between two simulation results, **@MCCODE_PREFIX@coplot-pyqtgraph** overlays
+the two datasets on the same axes, for direct visual comparison of curve
+shape and position rather than the size of the gap between them.
+
+`a` and `b` may each be either a simulation output directory (as produced by
+`@MCCODE_PREFIX@run`, containing a `mccode.sim` file) or a single monitor
+data file. Monitors are matched between `a` and `b` by output filename,
+exactly as in **@MCCODE_PREFIX@plotdiff-pyqtgraph**.
+
+Only 1D monitors are supported. A monitor present in only one of the two
+inputs, or a monitor pair that isn't a matching 1D/1D pair (e.g. a 2D
+monitor, or mismatched binning), is skipped with a warning printed to the
+console; use **@MCCODE_PREFIX@plotdiff-pyqtgraph** for 2D comparisons.
+
+Each panel overlays both curves with a draggable, coloured legend
+distinguishing `a` from `b`. Unlike ordinary **@MCCODE_PREFIX@plot-pyqtgraph**,
+there is no click-based drill-down here: a co-plot panel already overlays
+everything comparable for that monitor, so there is nothing further to
+navigate into. A small set of keyboard shortcuts remain (log toggle,
+save PNG/SVG, quit, help) - see the shortcuts printed on startup, or
+press F1/h in the plot window.
+
+# OPTIONS
+
+**-h, --help**
+:   show this help message and exit
+
+**-A LABEL_A, --label-a LABEL_A**
+:   short label used for simulation `a` in the legend/titles (default: the
+    basename of `a`)
+
+**-B LABEL_B, --label-b LABEL_B**
+:   short label used for simulation `b` in the legend/titles (default: the
+    basename of `b`)
+
+**--colour-a COLOUR_A**
+:   override the overlay colour used for `a` (default `#1f77b4`, blue)
+
+**--colour-b COLOUR_B**
+:   override the overlay colour used for `b` (default `#d62728`, red)
+
+**-t, --test**
+:   print the matched monitor pairs before plotting
+
+**--invcanvas**
+:   invert canvas background from black to white
+
+# FILES
+
+/usr/share/@FLAVOR@/resources
+/usr/share/@FLAVOR@/tools/Python/mccodelib/mccode_config.json
+~/.@FLAVOR@/mccode_config.json
+http://www.@FLAVOR@.org
+
+# EXAMPLES
+
+Run the *Test_SX* example (Single crystal diffraction) twice with different parameters, and overlay a 1D monitor from each
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_a -n 1e7 TTH=13.4`
+:   - `@MCCODE_PREFIX@run Test_SX.instr -d output_b -n 1e7 TTH=14.0`
+:   - `@MCCODE_PREFIX@coplot-pyqtgraph output_a output_b`
+
+# AUTHORS
+
+@MCCODE_NAME@ Team (@FLAVOR@.org)
+
+# SEE ALSO
+
+@FLAVOR@(1), @MCCODE_PREFIX@doc(1), @MCCODE_PREFIX@plot(1), @MCCODE_PREFIX@plot-pyqtgraph(1), @MCCODE_PREFIX@plotdiff-pyqtgraph(1), @MCCODE_PREFIX@coplot-html(1), @MCCODE_PREFIX@coplot-matplotlib(1), @MCCODE_PREFIX@run(1), @MCCODE_PREFIX@gui(1), @MCCODE_PREFIX@display(1)

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.in
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.in
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Wrapper script for @P@coplot-pyqtgraph-py
+
+@MCCODE_BASH_STANDARD_PREAMBLE@
+
+TOOL="@P@coplot"
+UTILDIR="${MCCODE_TOOLDIR}/Python/@P@plot/pyqtgraph"
+
+
+#NB: miniconda should be installed next to the tool folder:
+if [ -d "${MCCODE_TOOLDIR}/../miniconda3" ]; then
+    source "${MCCODE_TOOLDIR}/../miniconda3/bin/activate" "${MCCODE_TOOLDIR}/../miniconda3"
+    export PATH=${MCCODE_TOOLDIR}/../miniconda3/bin/:$PATH
+fi
+
+canrun() {
+    if ! [ -x "${UTILDIR}/${TOOL}.py" ]; then
+        exit 127;
+    fi
+
+    modules="pyqtgraph"
+    cmd=""
+    for name in ${modules}; do
+        cmd="${cmd}import ${name}; "
+    done
+    python3 -c "${cmd}"
+}
+
+if ( canrun ); then
+    python3 -u ${UTILDIR}/${TOOL}.py "$@"
+else
+    @FLAVOR@_errmsg Failed to run Python ${TOOL} - permissions or missing dependencies\?
+fi

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -44,6 +44,39 @@ from mccodelib import utils
 
 _Qt = QtCore.Qt
 
+
+# ---------------------------------------------------------------------------
+# Helpers for modifier / button comparison that work across Qt5 and Qt6,
+# copied from mccodelib.pqtgfrontend's convention (see there for details:
+# under Qt5 Qt.ControlModifier is an int, under Qt6 it's an enum member;
+# qtpy exposes them at the same attribute path, but comparing enum members
+# to ints with == raises a TypeError in Qt6, hence normalising to int).
+# ---------------------------------------------------------------------------
+
+def _int_mod(mod):
+    try:
+        return int(mod)
+    except (TypeError, ValueError):
+        return mod.value
+
+
+def _event_mods_int(event):
+    try:
+        return int(event.modifiers())
+    except (TypeError, ValueError):
+        return event.modifiers().value
+
+
+def _event_button_int(event):
+    try:
+        return int(event.button())
+    except (TypeError, ValueError):
+        return event.button().value
+
+
+_LEFT_BUTTON = _int_mod(_Qt.LeftButton)
+_RIGHT_BUTTON = _int_mod(_Qt.RightButton)
+
 # Default overlay colours (a, b): a colourblind-friendly blue/red pair.
 COLOUR_A = '#1f77b4'
 COLOUR_B = '#d62728'
@@ -57,6 +90,8 @@ def get_help_string():
     helplines.append('s              - save svg')
     helplines.append('l              - log toggle')
     helplines.append('F1/h           - help')
+    helplines.append('click          - display single panel')
+    helplines.append('right-click/b  - back to overview')
     return '\n'.join(helplines)
 
 
@@ -126,18 +161,26 @@ def plot_coplot_1D(data_a, data_b, plt, label_a, label_b, colour_a, colour_b,
 
 
 class McCoplotPlotter():
-    ''' Minimal pyqtgraph co-plot frontend: renders a static grid of
-        overlaid (a, b) 1D monitor pairs. Deliberately has no click-based
-        drill-down (unlike mccodelib.pqtgfrontend.McPyqtgraphPlotter) - a
-        co-plot panel is already the finest level of detail there is. '''
+    ''' pyqtgraph co-plot frontend: renders a grid of overlaid (a, b) 1D
+        monitor pairs, with the same overview <-> single-panel navigation
+        as ordinary mcplot-pyqtgraph (mccodelib.pqtgfrontend.McPyqtgraphPlotter):
+        click a panel to view it full-size; right-click or 'b' to return.
+        Since a co-plot pair has no further level of detail beyond the
+        single-panel view (unlike an ordinary monitor's plot graph, which
+        can have further primaries/secondaries to sweep through), a click
+        on the single panel itself is a no-op - only the back-navigation
+        is live there. '''
 
-    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, invcanvas=False, title=None):
+    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, invcanvas=False, title=None, path_note=None):
         self.pairs = pairs
         self.label_a = label_a
         self.label_b = label_b
         self.colour_a = colour_a
         self.colour_b = colour_b
         self.log = False
+        self.path_note = path_note
+        self.current = None  # None = overview grid; else index into self.pairs
+        self.viewbox_list = []
         self.title = title if title is not None else ('coplot: %s vs %s' % (label_a, label_b))
         self.filenamebase = 'coplot_%s_vs_%s' % (label_a, label_b)
 
@@ -149,8 +192,7 @@ class McCoplotPlotter():
 
     def run(self):
         self._create_window()
-        self._render()
-        self._set_keyhandler()
+        self._replot()
 
         exec_fn = getattr(self.app, "exec", None) or self.app.exec_
         sys.exit(exec_fn())
@@ -188,11 +230,36 @@ class McCoplotPlotter():
         self.main_window.raise_()
         self.main_window.activateWindow()
 
+    def _visible_pairs(self):
+        if self.current is None:
+            return self.pairs
+        return [self.pairs[self.current]]
+
+    def _show_overview(self):
+        self.current = None
+        self._replot()
+
+    def _show_single(self, idx):
+        self.current = idx
+        self._replot()
+
     def _render(self):
         self.plot_layout.clear()
 
-        n = len(self.pairs)
+        visible = self._visible_pairs()
+        n = len(visible)
         rowlen = max(1, int(math.sqrt(n * 1.61803398875)))
+
+        row_offset = 0
+        if self.path_note:
+            # label_a/label_b are bare "A"/"B" here (see default_labels()),
+            # since the two source paths' basenames collided (e.g. both
+            # ended in ".../<instrument>/1/") - shown here as an on-canvas
+            # header row (rather than only in the window title, which
+            # dumpfile_pqtg()'s scene export wouldn't capture) so the
+            # disambiguation survives into saved PNG/SVG exports too.
+            self.plot_layout.addLabel(self.path_note, row=0, col=0, colspan=max(rowlen, 1))
+            row_offset = 1
 
         if n <= 2:
             fontsize = 14
@@ -200,20 +267,66 @@ class McCoplotPlotter():
             fontsize = 10
         else:
             fontsize = 8
-        verbose = n <= 4
+        # verbose (fuller title/statistics) once drilled down to the single
+        # panel, matching McPyqtgraphPlotter's own n<=4 overview threshold
+        # for ordinary monitors, but here n==1 always means "single view"
+        # rather than "a small overview", so use that as the trigger.
+        verbose = (n == 1)
 
-        for i, (key, data_a, data_b) in enumerate(self.pairs):
+        self.viewbox_list = []
+        for i, (key, data_a, data_b) in enumerate(visible):
             plt = pg.PlotItem()
-            plot_coplot_1D(data_a, data_b, plt, self.label_a, self.label_b,
-                            self.colour_a, self.colour_b, log=self.log,
-                            fontsize=fontsize, verbose=verbose)
-            self.plot_layout.addItem(plt, i // rowlen, i % rowlen)
+            vb = plot_coplot_1D(data_a, data_b, plt, self.label_a, self.label_b,
+                                 self.colour_a, self.colour_b, log=self.log,
+                                 fontsize=fontsize, verbose=verbose)
+            self.viewbox_list.append(vb)
+            self.plot_layout.addItem(plt, row_offset + i // rowlen, i % rowlen)
+
+    def _get_plot_index(self, pos):
+        ''' Index of the viewbox containing scene-position pos, or -1.
+            Copied from pqtgfrontend.McPyqtgraphPlotter.get_plot_index(). '''
+        if not self.viewbox_list or pos is None:
+            return -1
+        for idx, viewbox in enumerate(self.viewbox_list):
+            topRight = viewbox.mapViewToScene(viewbox.viewRect().topRight())
+            bottomLeft = viewbox.mapViewToScene(viewbox.viewRect().bottomLeft())
+            rect = QtCore.QRectF()
+            rect.setTopRight(topRight)
+            rect.setBottomLeft(bottomLeft)
+            if rect.contains(pos):
+                return idx
+        return -1
+
+    def _click_handler(self, event):
+        if _event_mods_int(event) != 0:
+            return  # no ctrl/alt-click concept for co-plot (no "sweep")
+
+        btn = _event_button_int(event)
+        try:
+            idx = self._get_plot_index(event.scenePos())
+        except AttributeError:
+            return
+        if idx < 0:
+            return
+
+        if btn == _LEFT_BUTTON and self.current is None:
+            # only meaningful in overview mode - the single view has
+            # nowhere further to drill into
+            self._show_single(idx)
+        elif btn == _RIGHT_BUTTON and self.current is not None:
+            self._show_overview()
 
     def _show_help(self):
         prefix = "mc" if mccode_config.configuration["MCCODE"] == "mcstas" else "mx"
         QtWidgets.QMessageBox.about(self.main_window, prefix + 'coplot-pyqtgraph', get_help_string())
 
-    def _set_keyhandler(self):
+    def _set_handlers(self):
+        try:
+            self.plot_layout.scene().sigMouseClicked.disconnect()
+        except TypeError:
+            pass
+        self.plot_layout.scene().sigMouseClicked.connect(self._click_handler)
+
         K = _Qt
         savefile_cb = lambda fmt: utils.dumpfile_pqtg(
             scene=self.plot_layout.scene(), filenamebase=self.filenamebase, format=fmt)
@@ -224,15 +337,22 @@ class McCoplotPlotter():
                 QtWidgets.QApplication.quit()
             elif key == K.Key_L:
                 self.log = not self.log
-                self._render()
+                self._replot()
             elif key == K.Key_P:
                 savefile_cb('png')
             elif key == K.Key_S or key == 83:  # 83 == ord('s')
                 savefile_cb('svg')
+            elif key == K.Key_B:
+                if self.current is not None:
+                    self._show_overview()
             elif key in (K.Key_F1, K.Key_H):
                 self._show_help()
 
         self.plot_layout.scene().keyPressEvent = key_handler
+
+    def _replot(self):
+        self._render()
+        self._set_handlers()
 
 
 def main(args):
@@ -250,7 +370,19 @@ def main(args):
         colour_a = args.colour_a[0] if args.colour_a else COLOUR_A
         colour_b = args.colour_b[0] if args.colour_b else COLOUR_B
 
-        label_a, label_b = diffloader.default_labels(args.a, args.b, label_a, label_b)
+        label_a, label_b, used_fallback = diffloader.default_labels(args.a, args.b, label_a, label_b)
+
+        # When the auto-derived labels collided (e.g. two runs both ending
+        # in a plain ".../<instrument>/1/" folder) and default_labels()
+        # fell back to bare "A"/"B", those letters carry no identifying
+        # information on their own - show the full source paths as an
+        # on-canvas header row (see McCoplotPlotter._render()) and in the
+        # window title, while the per-panel legend keeps just "A"/"B".
+        path_note = None
+        title = 'coplot: %s vs %s' % (label_a, label_b)
+        if used_fallback:
+            path_note = "A: %s   B: %s" % (args.a, args.b)
+            title = 'coplot: %s' % path_note
 
         try:
             monitors_a, dir_a = diffloader.load_monitors(args.a)
@@ -272,8 +404,7 @@ def main(args):
                 print("  - %s (%s)" % (key, data_a.component))
 
         plotter = McCoplotPlotter(pairs, label_a, label_b, colour_a, colour_b,
-                                   invcanvas=args.invcanvas,
-                                   title='coplot: %s vs %s' % (label_a, label_b))
+                                   invcanvas=args.invcanvas, title=title, path_note=path_note)
         print(get_help_string())
         plotter.run()
 

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -123,7 +123,13 @@ def plot_coplot_1D(data_a, data_b, plt, label_a, label_b, colour_a, colour_b,
     xmax = max(np.max(x_a), np.max(x_b))
     plt.setXRange(xmin, xmax, padding=0)
 
-    plt.setTitle(" ")
+    try:
+        header = '%s [%s]' % (data_a.component, data_a.filename)
+        if verbose:
+            header = '%s [%s]<br>%s' % (data_a.component, data_a.filename, data_a.title)
+    except Exception:
+        header = '%s' % data_a.component
+    plt.setTitle(header)
     plt.getAxis('bottom').setLabel(data_a.xlabel)
     plt.getAxis('left').setLabel(data_a.ylabel)
 
@@ -139,21 +145,19 @@ def plot_coplot_1D(data_a, data_b, plt, label_a, label_b, colour_a, colour_b,
         plt.legend = plotfuncs.ModLegend(offset=(-1, 1), text_size='%spt' % str(fontsize))
         plt.legend.setParentItem(plt.vb)
 
-    try:
-        header = '%s [%s]' % (data_a.component, data_a.filename)
-        if verbose:
-            header = '%s [%s]<br>%s' % (data_a.component, data_a.filename, data_a.title)
-    except Exception:
-        header = '%s' % data_a.component
-    name_a = '<b>%s</b><br>%s' % (header, label_a)
-
     # actual curves, plotted with an explicit pen per series - since
     # plt.legend is already set, plot(..., name=...) registers each curve
     # with the legend automatically, using the curve's own pen as the
     # swatch colour (no need for the "invisible dummy artist" trick
     # ordinary single-dataset plots use, since here both series are real
-    # and worth a legend entry each).
-    plt.plot(x_a, y_a, pen=colour_a, name=name_a)
+    # and worth a legend entry each). Both names are bare labels
+    # ("A"/"B" or whatever was given) - deliberately symmetric, rather
+    # than one side carrying the full component/filename/title block:
+    # ModLegend lays each entry out in its own row sized to that row's
+    # content, so a long multi-line entry next to a single short word
+    # rendered visibly misaligned (the descriptive text now lives in the
+    # panel's own title instead, via plt.setTitle() above).
+    plt.plot(x_a, y_a, pen=colour_a, name=label_a)
     plt.plot(x_b, y_b, pen=colour_b, name=label_b)
 
     plt.setMenuEnabled(False)

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -175,7 +175,8 @@ class McCoplotPlotter():
         on the single panel itself is a no-op - only the back-navigation
         is live there. '''
 
-    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, invcanvas=False, title=None, path_note=None):
+    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, invcanvas=False, title=None,
+                 path_note=None, filenamebase=None):
         self.pairs = pairs
         self.label_a = label_a
         self.label_b = label_b
@@ -186,7 +187,15 @@ class McCoplotPlotter():
         self.current = None  # None = overview grid; else index into self.pairs
         self.viewbox_list = []
         self.title = title if title is not None else ('coplot: %s vs %s' % (label_a, label_b))
-        self.filenamebase = 'coplot_%s_vs_%s' % (label_a, label_b)
+        # deliberately NOT derived from label_a/label_b here: those may
+        # legitimately collapse to bare "A"/"B" when their basenames
+        # collide (see default_labels()), which would make every such
+        # comparison overwrite the same "coplot_A_vs_B.*" export files -
+        # a real problem for batch/CI use running many comparisons out of
+        # one working directory. Callers should pass the dirsafe_name()-
+        # based name explicitly; this fallback only exists for callers
+        # that don't care (e.g. quick interactive use, direct construction).
+        self.filenamebase = filenamebase if filenamebase is not None else ('coplot_%s_vs_%s' % (label_a, label_b))
 
         self.app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv)
 
@@ -408,7 +417,9 @@ def main(args):
                 print("  - %s (%s)" % (key, data_a.component))
 
         plotter = McCoplotPlotter(pairs, label_a, label_b, colour_a, colour_b,
-                                   invcanvas=args.invcanvas, title=title, path_note=path_note)
+                                   invcanvas=args.invcanvas, title=title, path_note=path_note,
+                                   filenamebase="coplot_%s_vs_%s" % (
+                                       diffloader.dirsafe_name(args.a), diffloader.dirsafe_name(args.b)))
         print(get_help_string())
         plotter.run()
 

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+'''
+pyqtgraph mccoplot frontend.
+
+This is a companion to mcplotdiff.py (mcplot-diff-pyqtgraph), sharing its
+command-line syntax and monitor-matching logic. Instead of computing and
+plotting the *difference* between two simulation results, mccoplot.py
+overlays the two datasets on the same axes, for direct visual comparison of
+curve shape and position rather than the size of the gap between them.
+
+Only 1D monitors are supported: a and b are matched by output filename via
+mccodelib.mcplotdiffloader.match_1d_monitors() (shared with the
+mcplot-coplot-html and mcplot-coplot-matplotlib frontends), and any matched
+pair that isn't a 1D/1D match is skipped with a warning.
+
+Unlike ordinary mcplot-pyqtgraph (mccodelib.pqtgfrontend.McPyqtgraphPlotter),
+there is no click-based drill-down here: a co-plot panel already overlays
+everything comparable for that monitor, so there's nothing further to
+navigate into. This script therefore builds its own minimal static-grid
+window rather than reusing McPyqtgraphPlotter, though it follows the same
+qtpy-based conventions (so the same code runs under PyQt5/PyQt6/PySide2/
+PySide6) and reuses plotfuncs.ModLegend for the on-plot legend.
+'''
+import argparse
+import logging
+import os
+import sys
+import math
+
+import numpy as np
+import pyqtgraph as pg
+
+# qtpy normalises Qt5/Qt6/PySide2/PySide6 into a single API, same as
+# mccodelib.pqtgfrontend.
+from qtpy import QtCore, QtWidgets
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+import plotfuncs
+
+from mccodelib import mcplotdiffloader as diffloader
+from mccodelib import mccode_config
+from mccodelib import utils
+
+_Qt = QtCore.Qt
+
+# Default overlay colours (a, b): a colourblind-friendly blue/red pair.
+COLOUR_A = '#1f77b4'
+COLOUR_B = '#d62728'
+
+
+def get_help_string():
+    helplines = []
+    helplines.append('')
+    helplines.append('q              - quit')
+    helplines.append('p              - save png')
+    helplines.append('s              - save svg')
+    helplines.append('l              - log toggle')
+    helplines.append('F1/h           - help')
+    return '\n'.join(helplines)
+
+
+def plot_coplot_1D(data_a, data_b, plt, label_a, label_b, colour_a, colour_b,
+                    log=False, legend=True, fontsize=10, verbose=False):
+    ''' overlay data_a and data_b (both Data1D) into the pyqtgraph PlotItem plt '''
+    x_a = np.array(data_a.xvals).astype(float)
+    y_a = np.array(data_a.yvals).astype(float)
+    e_a = np.array(data_a.y_err_vals).astype(float)
+    x_b = np.array(data_b.xvals).astype(float)
+    y_b = np.array(data_b.yvals).astype(float)
+    e_b = np.array(data_b.y_err_vals).astype(float)
+
+    if log:
+        def _tolog(y):
+            nonzeros = np.where(y > 0)[0]
+            if len(nonzeros) > 0:
+                y = y.copy()
+                y[y <= 0] = np.min(y[nonzeros]) / 10
+                return y, True
+            return y, False
+        y_a, ok_a = _tolog(y_a)
+        y_b, ok_b = _tolog(y_b)
+        plt.setLogMode(y=(ok_a or ok_b))
+    else:
+        plt.setLogMode(y=False)
+
+    xmin = min(np.min(x_a), np.min(x_b))
+    xmax = max(np.max(x_a), np.max(x_b))
+    plt.setXRange(xmin, xmax, padding=0)
+
+    plt.setTitle(" ")
+    plt.getAxis('bottom').setLabel(data_a.xlabel)
+    plt.getAxis('left').setLabel(data_a.ylabel)
+
+    beam_a = (x_a[1] - x_a[0]) * 0.5 if len(x_a) > 1 else 0
+    beam_b = (x_b[1] - x_b[0]) * 0.5 if len(x_b) > 1 else 0
+
+    # TODO (same as plotfuncs.plot_Data1D): no error bars in log mode
+    if not log:
+        plt.addItem(pg.ErrorBarItem(x=x_a, y=y_a, height=e_a, beam=beam_a, pen=colour_a))
+        plt.addItem(pg.ErrorBarItem(x=x_b, y=y_b, height=e_b, beam=beam_b, pen=colour_b))
+
+    if legend:
+        plt.legend = plotfuncs.ModLegend(offset=(-1, 1), text_size='%spt' % str(fontsize))
+        plt.legend.setParentItem(plt.vb)
+
+    try:
+        header = '%s [%s]' % (data_a.component, data_a.filename)
+        if verbose:
+            header = '%s [%s]<br>%s' % (data_a.component, data_a.filename, data_a.title)
+    except Exception:
+        header = '%s' % data_a.component
+    name_a = '<b>%s</b><br>%s' % (header, label_a)
+
+    # actual curves, plotted with an explicit pen per series - since
+    # plt.legend is already set, plot(..., name=...) registers each curve
+    # with the legend automatically, using the curve's own pen as the
+    # swatch colour (no need for the "invisible dummy artist" trick
+    # ordinary single-dataset plots use, since here both series are real
+    # and worth a legend entry each).
+    plt.plot(x_a, y_a, pen=colour_a, name=name_a)
+    plt.plot(x_b, y_b, pen=colour_b, name=label_b)
+
+    plt.setMenuEnabled(False)
+    return plt.getViewBox()
+
+
+class McCoplotPlotter():
+    ''' Minimal pyqtgraph co-plot frontend: renders a static grid of
+        overlaid (a, b) 1D monitor pairs. Deliberately has no click-based
+        drill-down (unlike mccodelib.pqtgfrontend.McPyqtgraphPlotter) - a
+        co-plot panel is already the finest level of detail there is. '''
+
+    def __init__(self, pairs, label_a, label_b, colour_a, colour_b, invcanvas=False, title=None):
+        self.pairs = pairs
+        self.label_a = label_a
+        self.label_b = label_b
+        self.colour_a = colour_a
+        self.colour_b = colour_b
+        self.log = False
+        self.title = title if title is not None else ('coplot: %s vs %s' % (label_a, label_b))
+        self.filenamebase = 'coplot_%s_vs_%s' % (label_a, label_b)
+
+        self.app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv)
+
+        if invcanvas:
+            pg.setConfigOption('background', 'w')
+            pg.setConfigOption('foreground', 'k')
+
+    def run(self):
+        self._create_window()
+        self._render()
+        self._set_keyhandler()
+
+        exec_fn = getattr(self.app, "exec", None) or self.app.exec_
+        sys.exit(exec_fn())
+
+    def _create_window(self):
+        helpmessage = QtWidgets.QLabel()
+        helpmessage.setText("Press 'h' for app shortcuts.")
+
+        statusbar = QtWidgets.QStatusBar()
+        statusbar.addWidget(helpmessage)
+
+        self.main_window = QtWidgets.QMainWindow()
+        self.graphics_view = pg.GraphicsView(self.main_window)
+        self.main_window.setCentralWidget(self.graphics_view)
+        self.main_window.setStatusBar(statusbar)
+        self.main_window.setWindowTitle(self.title)
+
+        # Screen size - primaryScreen() is available in Qt 5.6+ and Qt 6
+        screen = QtWidgets.QApplication.primaryScreen()
+        if screen is not None:
+            rect = screen.size()
+        else:
+            # Very old Qt5 fallback
+            rect = QtWidgets.QApplication.desktop().screenGeometry()
+
+        w = int(0.7 * rect.width())
+        h = int(0.7 * rect.height())
+        self.main_window.resize(w, h)
+
+        self.plot_layout = pg.GraphicsLayout(border=None)
+        self.graphics_view.setCentralItem(self.plot_layout)
+        self.plot_layout.setContentsMargins(2, 2, 2, 2)
+
+        self.main_window.show()
+        self.main_window.raise_()
+        self.main_window.activateWindow()
+
+    def _render(self):
+        self.plot_layout.clear()
+
+        n = len(self.pairs)
+        rowlen = max(1, int(math.sqrt(n * 1.61803398875)))
+
+        if n <= 2:
+            fontsize = 14
+        elif n <= 16:
+            fontsize = 10
+        else:
+            fontsize = 8
+        verbose = n <= 4
+
+        for i, (key, data_a, data_b) in enumerate(self.pairs):
+            plt = pg.PlotItem()
+            plot_coplot_1D(data_a, data_b, plt, self.label_a, self.label_b,
+                            self.colour_a, self.colour_b, log=self.log,
+                            fontsize=fontsize, verbose=verbose)
+            self.plot_layout.addItem(plt, i // rowlen, i % rowlen)
+
+    def _show_help(self):
+        prefix = "mc" if mccode_config.configuration["MCCODE"] == "mcstas" else "mx"
+        QtWidgets.QMessageBox.about(self.main_window, prefix + 'coplot-pyqtgraph', get_help_string())
+
+    def _set_keyhandler(self):
+        K = _Qt
+        savefile_cb = lambda fmt: utils.dumpfile_pqtg(
+            scene=self.plot_layout.scene(), filenamebase=self.filenamebase, format=fmt)
+
+        def key_handler(ev):
+            key = ev.key()
+            if key == K.Key_Q:
+                QtWidgets.QApplication.quit()
+            elif key == K.Key_L:
+                self.log = not self.log
+                self._render()
+            elif key == K.Key_P:
+                savefile_cb('png')
+            elif key == K.Key_S or key == 83:  # 83 == ord('s')
+                savefile_cb('svg')
+            elif key in (K.Key_F1, K.Key_H):
+                self._show_help()
+
+        self.plot_layout.scene().keyPressEvent = key_handler
+
+
+def main(args):
+    ''' load and match two simulation results' 1D monitors, then hand the
+        resulting pairs to the pyqtgraph co-plot frontend above. '''
+    logging.basicConfig(level=logging.INFO)
+
+    # ensure keyboardinterrupt ctr-c
+    import signal
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    try:
+        label_a = args.label_a[0] if args.label_a else None
+        label_b = args.label_b[0] if args.label_b else None
+        colour_a = args.colour_a[0] if args.colour_a else COLOUR_A
+        colour_b = args.colour_b[0] if args.colour_b else COLOUR_B
+
+        label_a, label_b = diffloader.default_labels(args.a, args.b, label_a, label_b)
+
+        try:
+            monitors_a, dir_a = diffloader.load_monitors(args.a)
+            monitors_b, dir_b = diffloader.load_monitors(args.b)
+        except Exception as e:
+            print('mccoplot loader: ' + e.__str__())
+            quit()
+
+        pairs = diffloader.match_1d_monitors(monitors_a, monitors_b, label_a, label_b)
+
+        if len(pairs) == 0:
+            print("mccoplot: no matching 1D monitors found between '%s' and '%s', nothing to plot."
+                  % (args.a, args.b))
+            quit()
+
+        if args.test:
+            print("mccoplot: %d matched 1D monitor pair(s):" % len(pairs))
+            for key, data_a, data_b in pairs:
+                print("  - %s (%s)" % (key, data_a.component))
+
+        plotter = McCoplotPlotter(pairs, label_a, label_b, colour_a, colour_b,
+                                   invcanvas=args.invcanvas,
+                                   title='coplot: %s vs %s' % (label_a, label_b))
+        print(get_help_string())
+        plotter.run()
+
+    except KeyboardInterrupt:
+        print('keyboard interrupt')
+    except Exception as e:
+        print('mccoplot error: %s' % e.__str__())
+        raise e
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('a', help='first simulation file or directory')
+    parser.add_argument('b', help='second simulation file or directory, co-plotted alongside "a"')
+    parser.add_argument('-A', '--label-a', nargs=1, help='short label used for simulation a in the legend/titles')
+    parser.add_argument('-B', '--label-b', nargs=1, help='short label used for simulation b in the legend/titles')
+    parser.add_argument('--colour-a', nargs=1, help='override the overlay colour used for a (default %s)' % COLOUR_A)
+    parser.add_argument('--colour-b', nargs=1, help='override the overlay colour used for b (default %s)' % COLOUR_B)
+    parser.add_argument('-t', '--test', action='store_true', default=False, help='print the matched monitor pairs before plotting')
+    parser.add_argument('--invcanvas', action='store_true', help='invert canvas background from black to white')
+    args = parser.parse_args()
+
+    mccode_config.load_config("user")
+
+    main(args)

--- a/tools/Python/mcplot/pyqtgraph/mcplotdiff.py
+++ b/tools/Python/mcplot/pyqtgraph/mcplotdiff.py
@@ -53,7 +53,7 @@ def main(args):
         label_b = args.label_b[0] if args.label_b else None
 
         try:
-            diffs, dir_a, dir_b, label_a, label_b = diffloader.load_and_diff(
+            diffs, dir_a, dir_b, label_a, label_b, used_fallback = diffloader.load_and_diff(
                 args.a, args.b, label_a, label_b)
         except Exception as e:
             print('mcplotdiff loader: ' + e.__str__())
@@ -72,10 +72,17 @@ def main(args):
         # run pqtg frontend: reuse the ordinary plotfuncs.plot rendering
         # code, but start out on the diverging colour map (better suited to
         # signed difference data) and a window title that makes the a/b
-        # comparison explicit.
+        # comparison explicit. If the auto-derived labels collided (e.g.
+        # two runs both ending in a plain ".../<instrument>/1/" folder) and
+        # default_labels() fell back to bare "A"/"B", those letters alone
+        # carry no identifying information - show the full source paths in
+        # the title instead.
+        title = 'diff: %s - %s' % (label_a, label_b)
+        if used_fallback:
+            title = 'diff: A: %s   B: %s' % (args.a, args.b)
         plotter = pqtgfrontend.McPyqtgraphPlotter(
             graph, sourcedir=dir_a, plot_func=plotfuncs.plot, invcanvas=args.invcanvas,
-            title='diff: %s - %s' % (label_a, label_b),
+            title=title,
             icolormap=plotfuncs.get_colormap_index('diverging'))
         print(pqtgfrontend.get_help_string())
         plotter.runplot()

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -76,6 +76,11 @@ class ModLegend(pg.LegendItem):
         self.layout.setContentsMargins(0, 0, 0, 0)
         row = self.layout.rowCount()
         self.items.append((sample, label))
+        # sample (the colour swatch icon) was being constructed but never
+        # actually placed into the layout - only the text label was, so no
+        # colour swatch was ever visible, regardless of how many legend
+        # entries or curves were involved.
+        self.layout.addItem(sample, row, 0)
         self.layout.addItem(label, row, 1)
         self.updateSize()
 

--- a/tools/Python/mctest/mcviewtest.py
+++ b/tools/Python/mctest/mcviewtest.py
@@ -372,10 +372,12 @@ def run_normal_mode(testdir, reflabel, nodiff=False, diffmax=300, diffall=True, 
     text = open(join(dirname(__file__), "main.template")).read()
     html = jinja2.Template(text).render(hrow=hrow, rows=rows, header=get_header_lst(refmeta))
 
-    datetime = testdir.split("/")[-1]
-    ofile = "%s_output.html" % datetime
+    # Platform-independent ofile (ensures correct behaviour of mcviewtest and opens browser also on Windows, 
+    # irrespective of 'testdir' given as '.' or no inputs)
+    ofile = os.path.join(testdir, "%s_output.html" % os.path.basename(os.path.normpath(testdir)))
     print("writing ofile: %s" % ofile)
     open(ofile, "w").write(html)
+    return ofile
 
 def run_interactive_mode(testroot):
     ''' a simple utility for deleting useless test directories '''
@@ -436,11 +438,11 @@ def main(args):
         if args.diffworkers:
             diffworkers = int(args.diffworkers[0])
         diffall = not args.diff_errors_only
-        run_normal_mode(testdir, reflabel, nodiff=args.nodiff, diffmax=diffmax,
+        ofile = run_normal_mode(testdir, reflabel, nodiff=args.nodiff, diffmax=diffmax,
                         diffall=diffall, diffworkers=diffworkers)
 
     if not args.nobrowse:
-        subprocess.Popen('%s %s' % (mccode_config.configuration['BROWSER'], os.path.join(testdir,os.path.basename(testdir) +'_output.html')), shell=True)
+        subprocess.Popen('%s %s' % (mccode_config.configuration['BROWSER'], ofile), shell=True)
         quit()
 
 


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

New tools to allow co-plotting 1D curves from two similar datasets. Supplements the mcplot and mcplotdiff tools.

Comes in 3 flavours:
* mccoplot-html
* mccoplot-pyqtgraph (aka mccoplot)
* mccoplot-matplotlib

Style of usage / plotting etc. similar to the other tools.

A few consequence-edits to the diffplotters due to the new incoming tools.

Tools have been tested functional across variant as well as operating system. Some minor tweaks still incoming, especially for the HTML tools.

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

Continuation of earlier Claude session for mcplotdiff etc.

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



