### PR TITLE
[Ref] move static comparison out of hot TRACE path

### DIFF
--- a/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
+++ b/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
@@ -138,7 +138,7 @@ INITIALIZE
     activate_gauss = 1;
     width = 0.01;
   } else {
-    fprintf (stderr, "ERROR(%s): Unsupported parameter value sample=\"%s\".\n", NAME_CURRENT_COMP, sample);
+    fprintf (stderr, "Unsupported instrument parameter value sample=\"%s\".\n", sample);
     exit (-1);
   }
 

--- a/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
+++ b/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/Test_inhomogenous_process.instr
@@ -82,6 +82,7 @@ DECLARE
 %{
   double E_i;
   double eps;
+  int is_thin;
   int activate_inc;
   int activate_inho;
   int activate_inho_linear;
@@ -101,6 +102,7 @@ INITIALIZE
 
   E_i = 25.3;
 
+  is_thin = 0;
   activate_inc = 0;
   activate_inho = 0;
   activate_inc_linear = 0;
@@ -109,7 +111,9 @@ INITIALIZE
   activate_phonon = 0;
   rot_samples = 0;
 
-  if (!strcmp("union_inc", sample)){
+  if (!strcmp("thin", sample)){
+    is_thin = 1;
+  } else if (!strcmp("union_inc", sample)){
     activate_inc = 1;
   } else if (!strcmp("union_inho", sample)){
     activate_inho = 1;
@@ -120,7 +124,6 @@ INITIALIZE
   } else if (!strcmp("inc_and_inho", sample)){
     activate_inc_and_inho_linear = 1;
   } else if (!strcmp("phonon", sample)){
-    
     activate_phonon = 1;
   } else if (!strcmp("inc_trans", sample)) {
     rot_samples = 90;
@@ -134,6 +137,9 @@ INITIALIZE
     rot_samples = 90;
     activate_gauss = 1;
     width = 0.01;
+  } else {
+    fprintf (stderr, "ERROR(%s): Unsupported parameter value sample=\"%s\".\n", NAME_CURRENT_COMP, sample);
+    exit (-1);
   }
 
 %}
@@ -191,7 +197,7 @@ COMPONENT box_sample = Incoherent(
     zdepth=thick,
     sigma_inc = 5.08,
     sigma_abs = 5.08
-) WHEN (!str_comp((const char*)"thin", (const char*)sample))
+) WHEN (is_thin)
 AT (0, 0, 0) RELATIVE arm_sample
 ROTATED (0, 0, 0) RELATIVE arm_sample
 


### PR DESCRIPTION
## Do not perform string comparison in `WHEN` statement
The comparison of a static string against a string valued instrument parameter is constant over the lifetime of a simulation. 
Comparing it once per simulated ray is unnecessary and can be 

--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
Linux

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing** instrument file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [x] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My PR is meant to fix a specific, existing issue
  * [x] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [ ] Explanation is added in free form text above or below the checklist

--------------

Fixes #2590 