### PR TITLE
Fix for compilation failure ESS/MCPL instrument, openacc

### DIFF
--- a/mcstas-comps/examples/ESS/ESS_butterfly_MCPL_test/ESS_butterfly_MCPL_test.instr
+++ b/mcstas-comps/examples/ESS/ESS_butterfly_MCPL_test/ESS_butterfly_MCPL_test.instr
@@ -94,7 +94,6 @@ DECLARE %{
   double DeltaX,DeltaZ;
   char MCPLfile[128];
   char FILTERfile[128];
-  int Divisions;
 %}
 
 USERVARS %{
@@ -107,6 +106,7 @@ USERVARS %{
   double Eneutron;
   double T0;
   double L0;
+  int Divisions;
 %}
 
 INITIALIZE


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Divisons must be USERVAR to function with openacc
(fix for compilation failure, https://new-nightly.mcstas.org/todays-datafiles/McStas_8GPU_openacc_mpi_x_8_1e7_Linux_20260813_0001_07_1e7/ESS_butterfly_MCPL_test/compile_stdout.txt)

--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing** instrument file
  * [x] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [x] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [x] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



