### PR TITLE
mcplotdiff-* reengineered to show %-difference in diff-plots

### DIFF
--- a/tools/Python/mccodelib/mcplotdiffloader.py
+++ b/tools/Python/mccodelib/mcplotdiffloader.py
@@ -72,15 +72,21 @@ def resolve_labels(paths, labels=None):
         "1" across many runs (e.g. differing only in an MPI parameter
         earlier in the path) - two or more labels would silently come out
         identical. When that happens - and only when *every* label was
-        auto-derived, an explicitly given label is never overridden - all
-        labels fall back to positional letters A, B, C, ... instead (not
-        just the colliding ones, to avoid a confusing half-named,
-        half-lettered result).
+        auto-derived, an explicitly given label is never overridden - every
+        label falls back to its own full input path instead (not just the
+        colliding ones, to avoid a confusing half-basename half-path
+        result), since that's always unambiguous and, unlike a bare
+        positional letter, still tells the reader which run is which
+        without needing to look anywhere else.
 
         Returns (labels, used_fallback) - used_fallback is True when the
-        letter fallback above was applied, i.e. the labels carry no
-        identifying information of their own; callers may want to show
-        the full paths somewhere else (e.g. a plot title) in that case. """
+        full-path fallback above was applied, i.e. the returned labels are
+        the raw input paths rather than short human-chosen or
+        basename-derived names; callers that want a guaranteed-compact
+        label regardless (e.g. for a legend swatch) may still want to use
+        positional letters purely for display in that case, while using
+        these labels themselves wherever the fuller identification is
+        useful (titles, filenames, etc). """
     n = len(paths)
     if labels is None:
         labels = [None] * n
@@ -95,7 +101,7 @@ def resolve_labels(paths, labels=None):
 
     used_fallback = False
     if all(auto_flags) and len(set(resolved)) < len(resolved):
-        resolved = _fallback_letters(n)
+        resolved = [p.rstrip('/\\') for p in paths]
         used_fallback = True
 
     return resolved, used_fallback
@@ -234,6 +240,29 @@ def load_monitors(path):
 # computing the difference datasets
 # ---------------------------------------------------------------------------
 
+def _pct_diff_str(Ia, Ib):
+    """ Percent difference in total intensity, A relative to B (matching
+        the "Diff = A - B" convention already used throughout this file),
+        formatted with an explicit sign, e.g. "+3.42%" or "-12.05%".
+
+        Relative to B specifically (not a symmetric A/B average) since B
+        is the natural reference point for a two-run comparison (e.g. 'is
+        my new run within X% of the old/reference one'), and that's
+        already how the diff itself (a - b) is signed. Falls back to a
+        plain absolute difference when B's total is zero, since a percent
+        change relative to zero isn't a meaningful number. """
+    try:
+        Ia = float(Ia)
+        Ib = float(Ib)
+    except Exception:
+        return 'N/A'
+    if Ib == 0:
+        if Ia == 0:
+            return '0% (both totals zero)'
+        return 'N/A (B total is zero; A-B = %s)' % _fmt(Ia - Ib)
+    return '%+.2f%%' % (100.0 * (Ia - Ib) / Ib)
+
+
 def diff_1d(key, a, b, label_a, label_b):
     if len(a.xvals) != len(b.xvals):
         print("Warning: skipping '%s' - differing number of bins (%d vs %d)"
@@ -272,7 +301,9 @@ def diff_1d(key, a, b, label_a, label_b):
         N = 0
     d.values = (I, Ierr, N)
     d.statistics = '%s: %s\n%s: %s' % (label_a, a.statistics, label_b, b.statistics)
-    d.title = ' - Diff (A - B), with:\n \nA=%s\nB=%s\n \n%s' % (label_a, label_b, a.title)
+    pct_str = _pct_diff_str(a.values[0], b.values[0])
+    d.diff_pct_str = pct_str
+    d.title = ' - Diff (A - B), with:\n \nA=%s\nB=%s\nDiff: %s\n \n%s' % (label_a, label_b, pct_str, a.title)
 
     return d
 
@@ -311,7 +342,9 @@ def diff_2d(key, a, b, label_a, label_b):
         N = 0
     d.values = (I, Ierr, N)
     d.statistics = '%s: %s\n%s: %s' % (label_a, a.statistics, label_b, b.statistics)
-    d.title = ' - Diff (A - B), with:\n \nA=%s\nB=%s\n \n%s' % (label_a, label_b, a.title)
+    pct_str = _pct_diff_str(a.values[0], b.values[0])
+    d.diff_pct_str = pct_str
+    d.title = ' - Diff (A - B), with:\n \nA=%s\nB=%s\nDiff: %s\n \n%s' % (label_a, label_b, pct_str, a.title)
 
     return d
 

--- a/tools/Python/mcplot/html/mccoplot.py
+++ b/tools/Python/mcplot/html/mccoplot.py
@@ -224,7 +224,7 @@ def _relhref(target, outdir):
 # overview index page
 # ---------------------------------------------------------------------------
 
-def write_index(outdir, entries, labels, path_note=None):
+def write_index(outdir, entries, labels):
     """ Writes an overview index.html with an iframe grid, in the same
         visual style as mcplotdiff.py's write_index().
 
@@ -232,9 +232,11 @@ def write_index(outdir, entries, labels, path_note=None):
           'coplot'     - path to the co-plot (linear) html page
           'coplot_log' - path to the co-plot (log) html page, or None
 
-        path_note, when given (see resolve_labels()'s used_fallback), is
-        shown under the header - labels are bare letters in that case,
-        carrying no identifying information of their own.
+        labels already carries full identification even when
+        resolve_labels() had to fall back (its basename-collision
+        fallback is each dataset's own full input path, not an
+        uninformative placeholder), so there's nothing further to show
+        beyond the identity_lines block below.
     """
     filename = os.path.join(outdir, "index.html")
     letters = _legend_letters(len(labels))
@@ -260,16 +262,13 @@ def write_index(outdir, entries, labels, path_note=None):
         outfile.write("  .iframe-wrap iframe { transform-origin: top left; display: block; }\n")
         outfile.write("  #sizecontrol { margin-bottom: 16px; font-size: 14px; }\n")
         outfile.write("  #sizecontrol input[type=range] { vertical-align: middle; margin: 0 8px; }\n")
-        outfile.write("  .pathnote { color: #666666; font-size: 13px; }\n")
         outfile.write("</style>\n")
         outfile.write("</head><body>\n")
         letters_summary = ' vs '.join(letters)
         outfile.write(f"<h1>Co-plots {letters_summary}:</h1>\n")
         identity_lines = '<br>'.join('%s=%s' % (letter, label) for letter, label in zip(letters, labels))
+        outfile.write(f"<h2>{identity_lines}</h2>\n")
         outfile.write(f"<p>Each panel overlays {len(labels)} datasets' monitor data on the same axes.</p>\n")
-        if path_note:
-            note_html = path_note.replace('\n', '<br>')
-            outfile.write(f"<p class='pathnote'>{note_html}</p>\n")
         outfile.write("<div id='sizecontrol'>\n")
         outfile.write("  <label for='sizeslider'>Figure size:</label>\n")
         outfile.write(f"  <input type='range' id='sizeslider' min='20' max='200' value='{init_pct}' step='5'>\n")
@@ -360,18 +359,14 @@ def main(args):
     labels, used_fallback = resolve_labels(paths, given_labels)
     colours = resolve_colours(len(paths), given_colours)
 
-    # When the auto-derived labels collided (e.g. several runs all ending
-    # in a plain ".../<instrument>/1/" folder) and resolve_labels() fell
-    # back to bare letters, those letters carry no identifying information
-    # on their own. path_note (shown on the overview index page) and
-    # identities (shown in each per-monitor figure's "A=.../B=.../..."
-    # block) both then use the full source paths instead - while the
-    # compact on-plot legend keeps just the letters either way.
-    path_note = None
+    # identities is what _title_for() shows in each per-monitor figure's
+    # "A=.../B=.../..." block: simply the resolved labels themselves -
+    # resolve_labels() already falls back to each dataset's full input
+    # path when the auto-derived labels would otherwise collide (e.g.
+    # several runs all ending in a plain ".../<instrument>/1/" folder), so
+    # there's nothing further to add here. The compact on-plot legend
+    # keeps just the letters regardless (see _legend_letters()).
     identities = labels
-    if used_fallback:
-        path_note = '\n'.join('%s: %s' % (lbl, p) for lbl, p in zip(labels, paths))
-        identities = paths
 
     # determine output directory - deliberately built from the actual
     # input paths (dirsafe_name), not the display labels: labels may
@@ -462,7 +457,7 @@ def main(args):
             browse(target)
         return
 
-    index_file = write_index(outdir, entries, labels, path_note=path_note)
+    index_file = write_index(outdir, entries, labels)
     print("Generated: %s" % index_file)
 
     if not args.nobrowse:

--- a/tools/Python/mcplot/html/mcplotdiff.py
+++ b/tools/Python/mcplot/html/mcplotdiff.py
@@ -324,10 +324,12 @@ def write_index(outdir, entries, label_a, label_b, path_a=None, path_b=None, use
 
         path_a/path_b/used_fallback come from default_labels(): when the
         auto-derived labels collided (e.g. two runs both ending in a plain
-        ".../<instrument>/1/" folder) and were replaced with bare "A"/"B",
-        used_fallback is True - in that case those bare letters carry no
-        identifying information on their own, so the full source paths are
-        shown as well.
+        ".../<instrument>/1/" folder), default_labels() falls back to using
+        each side's full input path as its label directly - so label_a/
+        label_b already carry full identification in that case, and
+        path_a/path_b/used_fallback are only kept here for backward
+        compatibility with existing callers; nothing further is shown for
+        them.
     """
     filename = os.path.join(outdir, "index.html")
 
@@ -351,18 +353,11 @@ def write_index(outdir, entries, label_a, label_b, path_a=None, path_b=None, use
         outfile.write("  .iframe-wrap iframe { transform-origin: top left; display: block; }\n")
         outfile.write("  #sizecontrol { margin-bottom: 16px; font-size: 14px; }\n")
         outfile.write("  #sizecontrol input[type=range] { vertical-align: middle; margin: 0 8px; }\n")
-        outfile.write("  .pathnote { color: #666666; font-size: 13px; }\n")
         outfile.write("</style>\n")
         outfile.write("</head><body>\n")
         outfile.write("<h1>Difference plots: A vs B</h1>\n")
         outfile.write(f"<h2>A={label_a}<br>B={label_b}</h2>\n")
         outfile.write(f"<p>diff.monitor = ({label_a}).monitor &minus; ({label_b}).monitor</p>\n")
-        if used_fallback and path_a and path_b:
-            # label_a/label_b are bare "A"/"B" here (see default_labels()),
-            # since the two source paths' basenames collided (e.g. both
-            # ended in ".../<instrument>/1/") - show the actual paths so
-            # the comparison is still identifiable.
-            outfile.write(f"<p class='pathnote'>A: {path_a}<br>B: {path_b}</p>\n")
         outfile.write("<div id='sizecontrol'>\n")
         outfile.write("  <label for='sizeslider'>Figure size:</label>\n")
         outfile.write(f"  <input type='range' id='sizeslider' min='20' max='200' value='{init_pct}' step='5'>\n")

--- a/tools/Python/mcplot/matplotlib/mccoplot.py
+++ b/tools/Python/mcplot/matplotlib/mccoplot.py
@@ -47,6 +47,23 @@ from mccodelib import mcplotdiffloader as diffloader
 from mccodelib import mccode_config
 
 
+def _legend_letters(n):
+    """ 'A', 'B', 'C', ... - the same compact, purely positional legend
+        markers the html/pyqtgraph co-plot tools use, deliberately
+        independent of `labels` itself: resolve_labels() now defaults to
+        each dataset's full input path when the auto-derived short names
+        would otherwise collide, which is exactly the information a
+        legend entry has no room for - keeping the legend on fixed,
+        compact letters regardless of how long the real labels are is
+        what avoids a repeat of the earlier issue where legend content
+        grew unpredictably. """
+    import string
+    letters = string.ascii_uppercase
+    if n <= len(letters):
+        return list(letters[:n])
+    return ['S%d' % i for i in range(n)]
+
+
 def _plot_coplot_panel(datas, labels, colours, i, n, log):
     ''' plot one overlaid N-dataset group into subplot i of n '''
     dims = plotfuncs._calc_panel_size(n)
@@ -80,24 +97,23 @@ def _plot_coplot_panel(datas, labels, colours, i, n, log):
     if log:
         ylabel = "log(" + d0.ylabel + ")"
 
-    for (x, y, yerr), label, colour in zip(series, labels, colours):
-        plotfuncs.pylab.errorbar(x, y, yerr, color=colour, label=label)
+    for (x, y, yerr), letter, colour in zip(series, _legend_letters(len(datas)), colours):
+        plotfuncs.pylab.errorbar(x, y, yerr, color=colour, label=letter)
 
     plotfuncs.pylab.xlabel(d0.xlabel, fontsize=fontsize, fontweight='bold')
     plotfuncs.pylab.ylabel(ylabel, fontsize=fontsize, fontweight='bold')
 
     # short title in an overview grid, fuller detail (matching d0.title and
-    # every dataset's I/statistics) once drilled down to a single panel -
-    # the same "verbose only at n==1" convention plotfuncs.plot_single_data
-    # uses for ordinary (non-coplot) monitors. For n==2, this produces
-    # exactly the same two-line stats block the original two-dataset-only
-    # version did.
+    # every dataset's identity/I/statistics) once drilled down to a single
+    # panel - the same "verbose only at n==1" convention
+    # plotfuncs.plot_single_data uses for ordinary (non-coplot) monitors.
     if verbose:
         try:
+            letters = _legend_letters(len(datas))
             lines = ['%s [%s]' % (d0.component, d0.filename), d0.title]
-            for data, label in zip(datas, labels):
-                lines.append('%s: I=%s Err=%s N=%s; %s' % (
-                    label, data.values[0], data.values[1], data.values[2], data.statistics))
+            for data, letter, label in zip(datas, letters, labels):
+                lines.append('%s=%s: I=%s Err=%s N=%s; %s' % (
+                    letter, label, data.values[0], data.values[1], data.values[2], data.statistics))
             title = '\n'.join(lines)
         except Exception:
             title = '%s [%s]' % (d0.component, d0.filename)
@@ -127,12 +143,12 @@ class McCoplotPlotter():
         primaries/secondaries to sweep through), click_cbs is simply empty
         once drilled down - only the back-navigation remains active. '''
 
-    def __init__(self, pairs, labels, colours, log, path_note=None):
+    def __init__(self, pairs, labels, colours, log, identity_note=None):
         self.pairs = pairs  # [(key, [data_0, ..., data_N-1]), ...]
         self.labels = labels
         self.colours = colours
         self.log = log
-        self.path_note = path_note
+        self.identity_note = identity_note
         self.current = None  # None = overview grid; else index into self.pairs
         self.event_dc_cid = None
 
@@ -174,19 +190,48 @@ class McCoplotPlotter():
             for i, (key, datas) in enumerate(visible)
         ]
 
-        fig.subplots_adjust(left=0.06, right=0.98, top=0.97, bottom=0.06,
-                             wspace=0.3, hspace=0.35)
+        if n == 1:
+            # Single-panel drill-down: the verbose title now includes one
+            # letter=label identity line per dataset (in addition to the
+            # existing component/filename/monitor-title/stats lines), so
+            # its height grows with how many datasets are co-plotted - a
+            # fixed top margin tuned for the old, shorter title clipped the
+            # top lines off the figure entirely once there were more than
+            # a couple of datasets. Scale the margin down (more headroom)
+            # as N grows; this is a rough heuristic; matches the
+            # established style of _title_wrap_width()'s own "good enough"
+            # character-width estimate rather than exact text measurement.
+            n_datasets = len(visible[0][1])
+            top = max(0.45, 0.95 - 0.045 * n_datasets)
+            fig.subplots_adjust(left=0.06, right=0.98, top=top, bottom=0.06,
+                                 wspace=0.3, hspace=0.35)
+        else:
+            fig.subplots_adjust(left=0.06, right=0.98, top=0.97, bottom=0.06,
+                                 wspace=0.3, hspace=0.35)
 
-        if self.path_note:
-            # labels are bare letters here (see resolve_labels()), since
-            # the source paths' basenames collided (e.g. all ending in
-            # ".../<instrument>/1/") - shown once as a figure-level title
-            # (matplotlib's actual "figure title" concept, distinct from
-            # each panel's own title) rather than repeated inside every
-            # panel, which would get cluttered across a multi-panel
-            # overview.
-            fig.suptitle(self.path_note, fontsize=9, y=0.998, va='top')
-            fig.subplots_adjust(top=0.90 if n == 1 else 0.92)
+        if self.identity_note and n > 1:
+            # The legend now always uses compact positional letters
+            # (_legend_letters()), never the real labels directly (which
+            # may now be a full input path - see resolve_labels()) - shown
+            # once as a figure-level title (matplotlib's actual "figure
+            # title" concept, distinct from each panel's own title) rather
+            # than repeated inside every panel's legend, which would get
+            # cluttered across a multi-panel overview.
+            #
+            # Only in the overview grid (n > 1), not the single-panel
+            # drill-down view: at n==1, _plot_coplot_panel()'s own verbose
+            # title already spells out the full letter=label mapping (plus
+            # per-dataset stats) inside the panel itself, so a suptitle
+            # here would be a redundant second copy of the same text - and,
+            # with both competing for the same cramped space above a
+            # single (2x-scaled) panel, they visibly overlapped.
+            suptitle_fontsize = 9
+            usable_w_in = fig_w * 0.95
+            avg_char_width_in = (suptitle_fontsize * 0.6) / 72.0
+            wrap_width = max(20, int(usable_w_in / avg_char_width_in))
+            wrapped_note = plotfuncs.textwrap.fill(self.identity_note, width=wrap_width)
+            fig.suptitle(wrapped_note, fontsize=suptitle_fontsize, y=0.998, va='top')
+            fig.subplots_adjust(top=0.92 if '\n' not in wrapped_note else 0.88)
 
         # Left-click on a panel drills into it (only meaningful in overview
         # mode - once already on a single panel there's nowhere further to
@@ -273,15 +318,14 @@ def main(args):
         labels, used_fallback = diffloader.resolve_labels(paths, given_labels)
         colours = diffloader.resolve_colours(len(paths), given_colours)
 
-        # When the auto-derived labels collided (e.g. several runs all
-        # ending in a plain ".../<instrument>/1/" folder) and
-        # resolve_labels() fell back to bare letters, those letters carry
-        # no identifying information on their own - show the full source
-        # paths as a figure-level suptitle instead, while the per-panel
-        # legend keeps just the letters.
-        path_note = None
-        if used_fallback:
-            path_note = "   ".join("%s: %s" % (lbl, p) for lbl, p in zip(labels, paths))
+        # Shown as a figure-level suptitle: the legend itself now always
+        # uses compact positional letters (_legend_letters()), never
+        # `labels` directly, so this "A=<label>" mapping is the only place
+        # (in the overview grid at least) that ties a legend entry back to
+        # which dataset it actually is - needed unconditionally now, not
+        # just when resolve_labels() had to fall back to full paths.
+        letters = _legend_letters(len(paths))
+        identity_note = "   ".join("%s=%s" % (letter, lbl) for letter, lbl in zip(letters, labels))
 
         monitors_list = []
         try:
@@ -315,7 +359,7 @@ def main(args):
         # use running many comparisons out of one working directory.
         plotfuncs.filenamebase = "coplot_" + "_vs_".join(diffloader.dirsafe_name(p) for p in paths)
 
-        plotter = McCoplotPlotter(pairs, labels, colours, log=args.log, path_note=path_note)
+        plotter = McCoplotPlotter(pairs, labels, colours, log=args.log, identity_note=identity_note)
 
         if (sys.platform == "linux" or sys.platform == "linux2") and args.html:
             # save to html and exit

--- a/tools/Python/mcplot/matplotlib/mcplotdiff.py
+++ b/tools/Python/mcplot/matplotlib/mcplotdiff.py
@@ -87,13 +87,12 @@ def main(args):
         plotfuncs.filenamebase = "diff_%s_vs_%s" % (
             diffloader.dirsafe_name(args.a), diffloader.dirsafe_name(args.b))
 
-        # If the auto-derived labels collided (e.g. two runs both ending in
-        # a plain ".../<instrument>/1/" folder) and default_labels() fell
-        # back to bare "A"/"B", those letters alone carry no identifying
-        # information - show the full source paths instead.
+        # label_a/label_b already carry full identification even when the
+        # auto-derived labels collided (e.g. two runs both ending in a
+        # plain ".../<instrument>/1/" folder) - default_labels() falls
+        # back to using each side's full input path as its label directly
+        # in that case, so there's nothing further to add here.
         sourcedir = 'diff: %s - %s' % (label_a, label_b)
-        if used_fallback:
-            sourcedir = 'diff: A: %s   B: %s' % (args.a, args.b)
         plotter = plotfuncs.McMatplotlibPlotter(sourcedir=sourcedir, log=args.log)
 
         if (sys.platform == "linux" or sys.platform == "linux2") and args.html:

--- a/tools/Python/mcplot/matplotlib/plotfuncs.py
+++ b/tools/Python/mcplot/matplotlib/plotfuncs.py
@@ -173,6 +173,8 @@ def plot_single_data(node, i, n, log):
         pylab.ylabel(ylabel, fontsize=fontsize, fontweight='bold')
         try:
             legend_text = '%s\nI = %s' % (data.component, data.values[0])
+            if hasattr(data, 'diff_pct_str'):
+                legend_text += '\nDiff: %s' % data.diff_pct_str
             if verbose:
                 legend_text = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:
@@ -228,6 +230,8 @@ def plot_single_data(node, i, n, log):
 
         try:
             legend_text = '%s\nI = %s' % (data.component, data.values[0])
+            if hasattr(data, 'diff_pct_str'):
+                legend_text += '\nDiff: %s' % data.diff_pct_str
             if verbose:
                 legend_text = '%s [%s]\n%s\nI = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -164,9 +164,7 @@ def plot_coplot_1D(datas, plt, labels, colours, log=False, legend=True, fontsize
     try:
         header = '%s [%s]' % (d0.component, d0.filename)
         if verbose:
-            letters = _legend_letters(len(datas))
-            identity_lines = '<br>'.join('%s=%s' % (letter, label) for letter, label in zip(letters, labels))
-            header = '%s [%s]<br>%s<br>%s' % (d0.component, d0.filename, identity_lines, d0.title)
+            header = '%s [%s]<br>%s' % (d0.component, d0.filename, d0.title)
     except Exception:
         header = '%s' % d0.component
     plt.setTitle(header)
@@ -317,26 +315,31 @@ class McCoplotPlotter():
         rowlen = max(1, int(math.sqrt(n * 1.61803398875)))
 
         row_offset = 0
-        if self.identity_note and n > 1:
+        if self.identity_note:
             # The legend now always uses compact positional letters
             # (_legend_letters()), never the real labels directly - this
             # header row is what maps each letter back to its actual
-            # dataset. One line per dataset (joined with <br>, the HTML
-            # line break pg.LabelItem's setHtml()-based rendering actually
-            # respects - a plain "\n" gets collapsed to a single space
-            # like any other HTML whitespace, so it wouldn't actually
-            # break the line), not all of them concatenated onto a single
-            # line: pg.GraphicsLayout sizes the header's grid column(s) to
-            # fit its text without wrapping, so one long joined line's
-            # minimum width would grow directly with N, while one line per
-            # dataset keeps the minimum driven by the longest *single*
-            # label instead.
+            # dataset, in every view (overview grid and single-panel
+            # drill-down alike). One line per dataset (joined with <br>,
+            # the HTML line break pg.LabelItem's setHtml()-based rendering
+            # actually respects - a plain "\n" gets collapsed to a single
+            # space like any other HTML whitespace, so it wouldn't
+            # actually break the line), not all of them concatenated onto
+            # a single line: pg.GraphicsLayout sizes the header's grid
+            # column(s) to fit its text without wrapping, so one long
+            # joined line's minimum width would grow directly with N,
+            # while one line per dataset keeps the minimum driven by the
+            # longest *single* label instead.
             #
-            # Only in the overview grid (n > 1), not the single-panel
-            # drill-down view: at n==1, plot_coplot_1D()'s own verbose
-            # header (see below) already spells out the same letter=label
-            # mapping inside the panel's own title, so this row would just
-            # be a redundant duplicate.
+            # Deliberately NOT embedded in plot_coplot_1D()'s own verbose
+            # single-panel title instead: PlotItem's native title row
+            # doesn't reliably auto-grow to fit multi-line HTML content
+            # (confirmed: it silently clips extra lines even when the
+            # window is otherwise plenty tall, and explicitly resizing the
+            # row via its own layout API had no effect either) the way a
+            # standalone GraphicsLayout.addLabel() item like this one
+            # does, so it's the only place that reliably shows the full
+            # mapping regardless of N.
             self.plot_layout.addLabel(self.identity_note, row=0, col=0, colspan=max(rowlen, 1))
             row_offset = 1
 

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -95,6 +95,23 @@ def get_help_string():
     return '\n'.join(helplines)
 
 
+def _legend_letters(n):
+    """ 'A', 'B', 'C', ... - the same compact, purely positional legend
+        markers the html co-plot tool uses (see its own _legend_letters()),
+        deliberately independent of `labels` itself: resolve_labels() now
+        defaults to each dataset's full input path when the auto-derived
+        short names would otherwise collide, which is exactly the
+        information a legend swatch has no room for - keeping the legend
+        on fixed, compact letters regardless of how long the real labels
+        are is what avoids a repeat of the earlier issue where a growing
+        legend increasingly covered the plotted data itself. """
+    import string
+    letters = string.ascii_uppercase
+    if n <= len(letters):
+        return list(letters[:n])
+    return ['S%d' % i for i in range(n)]
+
+
 def _legend_fontsize(n_datasets, base_fontsize):
     """ Legend text size, shrinking as the number of co-plotted datasets
         (not the number of panels/monitors in the grid - a separate
@@ -147,7 +164,9 @@ def plot_coplot_1D(datas, plt, labels, colours, log=False, legend=True, fontsize
     try:
         header = '%s [%s]' % (d0.component, d0.filename)
         if verbose:
-            header = '%s [%s]<br>%s' % (d0.component, d0.filename, d0.title)
+            letters = _legend_letters(len(datas))
+            identity_lines = '<br>'.join('%s=%s' % (letter, label) for letter, label in zip(letters, labels))
+            header = '%s [%s]<br>%s<br>%s' % (d0.component, d0.filename, identity_lines, d0.title)
     except Exception:
         header = '%s' % d0.component
     plt.setTitle(header)
@@ -170,15 +189,16 @@ def plot_coplot_1D(datas, plt, labels, colours, log=False, legend=True, fontsize
     # with the legend automatically, using the curve's own pen as the
     # swatch colour (no need for the "invisible dummy artist" trick
     # ordinary single-dataset plots use, since here every series is real
-    # and worth a legend entry). All names are bare labels ("A"/"B"/... or
-    # whatever was given) - deliberately symmetric, rather than one entry
-    # carrying the full component/filename/title block: ModLegend lays
-    # each entry out in its own row sized to that row's content, so a long
-    # multi-line entry next to short words renders visibly misaligned (the
-    # descriptive text lives in the panel's own title instead, via
-    # plt.setTitle() above).
-    for (x, y, e), label, colour in zip(series, labels, colours):
-        plt.plot(x, y, pen=colour, name=label)
+    # and worth a legend entry). Names are compact positional letters
+    # (_legend_letters()), not `labels` itself: resolve_labels() may now
+    # return each dataset's full input path as its label (when the
+    # auto-derived short names would otherwise collide), which is exactly
+    # the kind of long text a legend row has no room for - the real
+    # identity is mapped out in the panel's own title instead (see the
+    # verbose header above), where there's space for it.
+    letters = _legend_letters(len(datas))
+    for (x, y, e), letter, colour in zip(series, letters, colours):
+        plt.plot(x, y, pen=colour, name=letter)
 
     plt.setMenuEnabled(False)
     return plt.getViewBox()
@@ -196,12 +216,12 @@ class McCoplotPlotter():
         is live there. '''
 
     def __init__(self, pairs, labels, colours, invcanvas=False, title=None,
-                 path_note=None, filenamebase=None):
+                 identity_note=None, filenamebase=None):
         self.pairs = pairs  # [(key, [data_0, ..., data_N-1]), ...]
         self.labels = labels
         self.colours = colours
         self.log = False
-        self.path_note = path_note
+        self.identity_note = identity_note
         self.current = None  # None = overview grid; else index into self.pairs
         self.viewbox_list = []
         self.title = title if title is not None else ('coplot: %s' % ' vs '.join(labels))
@@ -275,21 +295,49 @@ class McCoplotPlotter():
         self._replot()
 
     def _render(self):
-        self.plot_layout.clear()
+        # Rebuilt from scratch each time, rather than clear()-ing and
+        # reusing the same GraphicsLayout: pg.GraphicsLayout.clear() proved
+        # unreliable specifically when the grid shape changes between
+        # renders (e.g. overview-with-header-row -> single-panel-without-
+        # one) - a stale item could still occupy a cell afterwards even
+        # though clear() completed without error. Recreating the layout
+        # object is a hard guarantee of a genuinely empty grid to build
+        # into, sidestepping whatever internal bookkeeping issue causes
+        # that. self.plot_layout.scene() below still resolves to the same
+        # persistent QGraphicsScene either way, since it's the
+        # GraphicsView's own scene (set via setCentralItem), not something
+        # owned by the layout object itself - so signal/event handling in
+        # _set_handlers() is unaffected by swapping the layout out.
+        self.plot_layout = pg.GraphicsLayout(border=None)
+        self.graphics_view.setCentralItem(self.plot_layout)
+        self.plot_layout.setContentsMargins(2, 2, 2, 2)
 
         visible = self._visible_pairs()
         n = len(visible)
         rowlen = max(1, int(math.sqrt(n * 1.61803398875)))
 
         row_offset = 0
-        if self.path_note:
-            # labels are bare letters here (see resolve_labels()), since
-            # the source paths' basenames collided (e.g. all ended in
-            # ".../<instrument>/1/") - shown here as an on-canvas header
-            # row (rather than only in the window title, which
-            # dumpfile_pqtg()'s scene export wouldn't capture) so the
-            # disambiguation survives into saved PNG/SVG exports too.
-            self.plot_layout.addLabel(self.path_note, row=0, col=0, colspan=max(rowlen, 1))
+        if self.identity_note and n > 1:
+            # The legend now always uses compact positional letters
+            # (_legend_letters()), never the real labels directly - this
+            # header row is what maps each letter back to its actual
+            # dataset. One line per dataset (joined with <br>, the HTML
+            # line break pg.LabelItem's setHtml()-based rendering actually
+            # respects - a plain "\n" gets collapsed to a single space
+            # like any other HTML whitespace, so it wouldn't actually
+            # break the line), not all of them concatenated onto a single
+            # line: pg.GraphicsLayout sizes the header's grid column(s) to
+            # fit its text without wrapping, so one long joined line's
+            # minimum width would grow directly with N, while one line per
+            # dataset keeps the minimum driven by the longest *single*
+            # label instead.
+            #
+            # Only in the overview grid (n > 1), not the single-panel
+            # drill-down view: at n==1, plot_coplot_1D()'s own verbose
+            # header (see below) already spells out the same letter=label
+            # mapping inside the panel's own title, so this row would just
+            # be a redundant duplicate.
+            self.plot_layout.addLabel(self.identity_note, row=0, col=0, colspan=max(rowlen, 1))
             row_offset = 1
 
         if n <= 2:
@@ -412,29 +460,16 @@ def main(args):
         labels, used_fallback = diffloader.resolve_labels(paths, given_labels)
         colours = diffloader.resolve_colours(len(paths), given_colours)
 
-        # When the auto-derived labels collided (e.g. several runs all
-        # ending in a plain ".../<instrument>/1/" folder) and
-        # resolve_labels() fell back to bare letters, those letters carry
-        # no identifying information on their own - show the full source
-        # paths as an on-canvas header row (see McCoplotPlotter._render())
-        # instead, while the per-panel legend keeps just the letters.
-        #
-        # One line per dataset (joined with <br>, the HTML line break
-        # pg.LabelItem's setHtml()-based rendering actually respects - a
-        # plain "\n" gets collapsed to a single space like any other HTML
-        # whitespace, so it wouldn't actually break the line), not all of
-        # them concatenated onto a single line: pg.GraphicsLayout sizes the
-        # header's grid column(s) to fit its text without wrapping, so one
-        # long joined line's minimum width grows directly with N - with
-        # enough datasets that minimum can exceed the window's actual
-        # width, at which point every panel's column is forced to that
-        # same minimum and can no longer be resized smaller, with the
-        # rightmost content simply clipped once the window is narrower
-        # than that floor.
-        path_note = None
-        title = 'coplot: %s' % ' vs '.join(labels)
-        if used_fallback:
-            path_note = "<br>".join("%s: %s" % (lbl, p) for lbl, p in zip(labels, paths))
+        # Shown as an on-canvas header row (see McCoplotPlotter._render())
+        # and in the window title: the legend itself now always uses
+        # compact positional letters (_legend_letters()), never `labels`
+        # directly, so this "A=<label>" mapping is the only place that
+        # ties a legend swatch back to which dataset it actually is -
+        # needed unconditionally now, not just when resolve_labels() had
+        # to fall back to full paths.
+        letters = _legend_letters(len(paths))
+        identity_note = "<br>".join("%s=%s" % (letter, lbl) for letter, lbl in zip(letters, labels))
+        title = 'coplot: %s' % identity_note.replace('<br>', '   ')
 
         monitors_list = []
         try:
@@ -458,7 +493,7 @@ def main(args):
                 print("  - %s (%s)" % (key, datas[0].component))
 
         plotter = McCoplotPlotter(pairs, labels, colours,
-                                   invcanvas=args.invcanvas, title=title, path_note=path_note,
+                                   invcanvas=args.invcanvas, title=title, identity_note=identity_note,
                                    filenamebase="coplot_" + "_vs_".join(diffloader.dirsafe_name(p) for p in paths))
         print(get_help_string())
         plotter.run()

--- a/tools/Python/mcplot/pyqtgraph/mcplotdiff.py
+++ b/tools/Python/mcplot/pyqtgraph/mcplotdiff.py
@@ -72,14 +72,12 @@ def main(args):
         # run pqtg frontend: reuse the ordinary plotfuncs.plot rendering
         # code, but start out on the diverging colour map (better suited to
         # signed difference data) and a window title that makes the a/b
-        # comparison explicit. If the auto-derived labels collided (e.g.
-        # two runs both ending in a plain ".../<instrument>/1/" folder) and
-        # default_labels() fell back to bare "A"/"B", those letters alone
-        # carry no identifying information - show the full source paths in
-        # the title instead.
+        # comparison explicit. label_a/label_b already carry full
+        # identification even when the auto-derived labels collided (e.g.
+        # two runs both ending in a plain ".../<instrument>/1/" folder) -
+        # default_labels() falls back to using each side's full input path
+        # as its label directly in that case.
         title = 'diff: %s - %s' % (label_a, label_b)
-        if used_fallback:
-            title = 'diff: A: %s   B: %s' % (args.a, args.b)
         plotter = pqtgfrontend.McPyqtgraphPlotter(
             graph, sourcedir=dir_a, plot_func=plotfuncs.plot, invcanvas=args.invcanvas,
             title=title,

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -158,6 +158,8 @@ def plot_Data1D(data, plt, log=False, fromzero=False, legend=True, icolormap=0, 
         # this construct reduces the requiremet for header data in Data1D, in case of an error during parsing of the string
         try:
             lname1 = '<center>%s<br>I = %s</center>' % (data.component, data.values[0])
+            if hasattr(data, 'diff_pct_str'):
+                lname1 = '<center>%s<br>I = %s<br>Diff: %s</center>' % (data.component, data.values[0], data.diff_pct_str)
             if verbose:
                 lname1 = '%s [%s]<br><br>%s<br><br>I = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:
@@ -324,6 +326,8 @@ def plot_Data2D(data, plt, log=False, legend=True, icolormap=0, verbose=False, f
 
         try:
             lname1 = '<center>%s<br>I = %s</center>' % (data.component, data.values[0])
+            if hasattr(data, 'diff_pct_str'):
+                lname1 = '<center>%s<br>I = %s<br>Diff: %s</center>' % (data.component, data.values[0], data.diff_pct_str)
             if verbose:
                 lname1 = '%s [%s]<br><br>%s<br><br>I = %s Err = %s N = %s; %s' % (data.component, data.filename, data.title, data.values[0], data.values[1], data.values[2], data.statistics)
         except:


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:
### Claude, prompts:
* In the diff-plotters I would like an indication of the difference in % between the two dataset monitors.
  * (Output was an intermediate, only partially useful result)
* These %-indications seems for now only visible in the html variant of the diff-plotter - please adapt the `pyqtgraph` and `matplotlib` variants also. Further, the default "labels" making it to the datasets are literal “A" and “B" - I would like these to rather by default use the paths / folder names.



--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



