### PR TITLE
Fix spillover-issue in --strict mode

### DIFF
--- a/tools/Python/mctest/mctest.py
+++ b/tools/Python/mctest/mctest.py
@@ -317,10 +317,9 @@ def mccode_test(branchdir, testdir, limitinstrs=None, instrfilter=None, compfilt
     else:
         logging.info("c-lint'ing instruments [seconds]...")
 
-    noexample=False
     for test in tests:
         if strict and test.testnb==0:
-            noexample=True
+            logging.info("!! No test(s) found in %s !!" % test.instrname)
             anyfailed=True
             num_noexample = num_noexample + 1
             pass
@@ -406,7 +405,7 @@ def mccode_test(branchdir, testdir, limitinstrs=None, instrfilter=None, compfilt
     logging.info("Running tests / getting status...")
     runfailed=False
     for test in tests:
-        if strict and noexample:
+        if strict and test.testnb==0:
             runfailed = True
             formatstr = "%-" + "%ds: FAILURE: tool in --strict mode and instrument includes no %%%%Example: line(s)!" % (maxnamelen+1)
             logging.info(formatstr % test.instrname)


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Trying to use mctest in a new CI solution, @tkittel found that one instrument without `%Example` would trigger failure on all.

Issue was misuse of a semi-global variable instead of using identification by `test.testnb==0`

--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



