### PR TITLE
Plottable mccode.dat in NeXus scan case

### DIFF
--- a/tools/Python/mccodelib/mcplotloader.py
+++ b/tools/Python/mccodelib/mcplotloader.py
@@ -623,13 +623,24 @@ def is_sweepfolder(args):
 
 
 def is_broken_sweepfolder(args):
-    ''' not implemented (returns trivial answer) '''
-    return False
-
-
-def is_sweep_data_present(args):
-    ''' not implemented '''
-    raise Exception('is_sweep_data_present has not been implemented.')
+    ''' A sweep/scan directory that has mccode.dat (the combined scan-curve
+        file written by mcrun's Scanner/Scanner_split/Optimizer - see
+        tools/Python/mcrun/optimisation.py) but is missing mccode.sim -
+        e.g. because only mccode.dat was kept or shared on its own, or the
+        per-scan-step subfolders and their individual monitor files were
+        cleaned up/never transferred. is_sweepfolder() (checked just
+        before this in the flowchart) already requires BOTH files to be
+        present for the full, richer sweep view (load_sweep(), with its
+        per-step secondary drill-down) - reaching this function means that
+        check already failed, so finding mccode.dat here specifically
+        means mccode.sim must be the one missing. mccode.dat is
+        self-describing via its own '#'-prefixed header, though (see
+        _load_multiplot_1D_lst()), so the overlaid sweep curves themselves
+        can still be recovered and plotted even without mccode.sim or any
+        of the underlying per-monitor detector files - see
+        load_sweep_dat_only(). '''
+    d = args['directory']
+    return isfile(join(d, 'mccode.dat'))
 
 
 def is_mccodesim_w_monitors(args):
@@ -705,7 +716,6 @@ def test_decfuncs(simfile):
     print('is_monitorfile:            %s' % str(is_monitorfile(args)))
     print('is_sweepfolder:            %s' % str(is_sweepfolder(args)))
     print('is_broken_sweepfolder:     %s' % str(is_broken_sweepfolder(args)))
-    #print('is_sweep_data_present:    %s' % str(is_sweep_data_present(args))) # should not be called until implemented
     print('is_mccodesim_w_monitors:   %s' % str(is_mccodesim_w_monitors(args)))
     print('has_datfile:               %s' % str(has_datfile(args)))
     print('has_multiple_datfiles:     %s' % str(has_multiple_datfiles(args)))
@@ -853,6 +863,45 @@ def load_sweep_c(args):
     raise Exception('load_sweep_c is not implemented.')
 
 
+def load_sweep_dat_only(args):
+    ''' Fallback for a sweep/scan directory that has mccode.dat (the
+        combined scan-curve file) but not mccode.sim and/or the
+        underlying per-step subfolders and monitor files - see
+        is_broken_sweepfolder(). mccode.dat is self-describing via its own
+        '#'-prefixed header (component/filename/title/xvars/xlimits/
+        variables/yvars - the same fields build_header() in
+        tools/Python/mcrun/optimisation.py writes), so
+        _load_multiplot_1D_lst() can parse it directly with no other
+        input at all.
+
+        Only builds the root+primary levels (mirroring load_simulation()/
+        load_monitor_folder()'s two-level graphs): an overview showing
+        every monitor's sweep curve overlaid, and a primary per-monitor
+        drill-down to see just that one curve. There deliberately are no
+        secondaries here - load_sweep()'s secondary level lets you drill
+        further into an individual scan step's own raw monitor data
+        (loaded from that step's own subfolder+mccode.sim), which simply
+        doesn't exist in this fallback - only the combined sweep curves
+        do. Leaving secondaries as the default empty list is a normal,
+        supported plot-graph state (matching how a PNSingle leaf node, or
+        load_simulation()'s single-level case, has none either), not an
+        incomplete/degraded one - frontends already handle it as "nothing
+        further to click into" rather than an error. '''
+    d = args['directory']
+    f_dat = join(d, 'mccode.dat')
+
+    data_handle_lst_sweep1D = _load_multiplot_1D_lst(f_dat)
+    root = PNMultiple(data_handle_lst_sweep1D)
+
+    primnodes_lst = []
+    for data_handle in data_handle_lst_sweep1D:
+        primnode = PNSingle(data_handle)
+        primnodes_lst.append(primnode)
+    root.set_primaries(primnodes_lst)
+
+    return root
+
+
 def load_monitor_folder(args):
     # assume simfile is folder with multiple dat files
     d = args['directory']
@@ -892,8 +941,7 @@ class McCodeDataLoader():
         exit_term_case1  = FCNTerminal(key = "case1",  fct = load_monitor)
         exit_term_case2  = FCNTerminal(key = "case2",  fct = load_simulation)
         exit_term_case3  = FCNTerminal(key = "case3",  fct = load_sweep)
-        exit_term_case3b = FCNTerminal(key = "case3b", fct = throw_error)
-        exit_term_case3c = FCNTerminal(key = "case3c", fct = throw_error)
+        exit_term_case3fallback = FCNTerminal(key = "case3-fallback", fct = load_sweep_dat_only)
         exit_term_case4  = FCNTerminal(key = "case4",  fct = load_monitor_folder)
 
         # decision nodes (assembled in backwards order)
@@ -906,11 +954,8 @@ class McCodeDataLoader():
         dec_ismccodesimwmonitors = FCNDecisionBool(fct = is_mccodesim_w_monitors,
                                                    node_T = exit_term_case2,
                                                    node_F = dec_hasdatfile)
-        dec_datafolderspresent   = FCNDecisionBool(fct = is_sweep_data_present,
-                                                   node_T = exit_term_case3b,
-                                                   node_F = exit_term_case3c)
         dec_isbrokensweep        = FCNDecisionBool(fct = is_broken_sweepfolder,
-                                                   node_T = dec_datafolderspresent,
+                                                   node_T = exit_term_case3fallback,
                                                    node_F = dec_ismccodesimwmonitors)
         dec_issweepfolder        = FCNDecisionBool(fct = is_sweepfolder,
                                                    node_T = exit_term_case3,

--- a/tools/Python/mccodelib/mcplotloader.py
+++ b/tools/Python/mccodelib/mcplotloader.py
@@ -502,7 +502,7 @@ def _load_sweep_monitors(rootdir):
         dirsignature = (dirname, mnames)
         for f in fnames:
             # NOTE: this will attempt to load all files except for mccode.sim
-            if f not in mnames and f != 'mccode.sim' and f != 'mcstas.sim':
+            if f not in mnames and f != 'mccode.sim':
                 mnames.append(f)
         arg.append(dirsignature)
 
@@ -512,16 +512,35 @@ def _load_sweep_monitors(rootdir):
         walkfunc(subdirtuple, root, files)
     del subdirtuple[0] # remove root dir
     subdirs = [t[0] for t in subdirtuple]
-    # get the right order of subdirs by recreating them a little bit
-    subdirs = [join(dirname(subdirs[i]), str(i)) for i in range(len(subdirs))] # sortalpha(subdirs)
+    # Sort by the REAL, actual numeric folder name (e.g. "0", "1", "3",
+    # "4" - numerically, not alphabetically, since alphabetical sort would
+    # put "10" before "2") - rather than the previous approach of
+    # renaming every subdir BY ITS POSITION in os.walk()'s traversal order
+    # (`join(dirname(subdirs[i]), str(i))`). That renaming assumed
+    # scan-step subfolders are always named consecutively with no gaps,
+    # which no longer holds now that a failed scan step's subfolder is
+    # deliberately never created (mcrun's Scanner.run()/Scanner_split now
+    # tolerate individual failed points rather than aborting the whole
+    # scan - see tools/Python/mcrun/optimisation.py). A gap used to
+    # silently rename every subfolder from that point on to a DIFFERENT,
+    # wrong path, misattributing each remaining step's data to the wrong
+    # index - surfacing as anything from wrong data to the "list index
+    # out of range" this caused (a later step's own mccode.sim declaring
+    # fewer monitors than the one it got misaligned with expected).
+    try:
+        subdirs = sorted(subdirs, key=lambda p: int(basename(p)))
+    except ValueError:
+        # Subfolder names aren't purely numeric for some reason - fall
+        # back to a plain alphabetical ordering rather than crashing
+        # outright (matches this function's previous fallback comment,
+        # "sortalpha(subdirs)", which was never actually reachable before).
+        subdirs = sorted(subdirs)
 
     # get the monitor ordering right by snooping the '  filename:' labels out of the scan point file 0/mccode.sim
     def get_subdir_monitors(subdir):
         mons = []
         if exists(join(subdir, 'mccode.sim')):
             indexfile='mccode.sim'
-        elif exists(join(subdir, 'mccode.sim')):
-            indexfile='mcstas.sim'
         else:
             return
 
@@ -544,7 +563,28 @@ def _load_sweep_monitors(rootdir):
 
     monitors_by_subdir = []
     for s in subdirs:
-        monitors_by_subdir.append(get_subdir_monitors(s))
+        mons = get_subdir_monitors(s)
+        if mons is not None:
+            monitors_by_subdir.append(mons)
+        else:
+            # A discovered subfolder without a usable mccode.sim inside it
+            # - e.g. a step that crashed partway through writing its own
+            # output, after the subfolder itself was created but before
+            # mccode.sim was written. Skip it here rather than letting a
+            # None entry propagate into monitors_by_subdir and crash the
+            # indexing below; load_sweep()'s own root/secondary
+            # length-mismatch check further down already warns (rather
+            # than crashing) if this ever leaves the secondary monitor
+            # count out of sync with mccode.dat's row count.
+            print("_load_sweep_monitors: skipping subdir %s (no valid mccode.sim found)" % s)
+
+    if not monitors_by_subdir:
+        # No subfolder had usable data at all (e.g. every scan step
+        # failed) - return no secondary monitors rather than crashing on
+        # monitors_by_subdir[0] below. load_sweep() still has the root
+        # sweep curves from mccode.dat either way; it just won't have a
+        # per-step drill-down to offer.
+        return []
 
     # notice that columns and rows are swapped, so we get to use a
     # list-of-lists data structure, with rows the same monitor
@@ -599,7 +639,7 @@ def has_filename(args):
 def is_mccodesim_or_mccodedat(args):
     f = args['simfile']
     f_name = basename(f)
-    return (f_name == 'mccode.sim' or f_name == 'mcstas.sim' or f_name == 'mccode.dat') and isfile(f)
+    return (f_name == 'mccode.sim' or f_name == 'mccode.dat') and isfile(f)
 
 
 def is_monitorfile(args):
@@ -649,8 +689,6 @@ def is_mccodesim_w_monitors(args):
     # checks mccode.sim existence
     if isfile(join(d, 'mccode.sim')):
         indexfile='mccode.sim'
-    elif isfile(join(d, 'mcstas.sim')):
-        indexfile='mcstas.sim'
     else:
         return False
 
@@ -661,8 +699,6 @@ def is_mccodesim_w_monitors(args):
     datfiles = glob.glob(join(d, '*'))
     if 'mccode.sim' in datfiles: 
         datfiles.remove('mccode.sim')
-    if 'mcstas.sim' in datfiles: 
-        datfiles.remove('mcstas.sim')
     if 'mccode.dat' in datfiles: 
         datfiles.remove('mccode.dat')
     return len(datfiles) > 0
@@ -675,8 +711,6 @@ def has_datfile(args):
     datfiles = glob.glob(join(d, '*'))
     if 'mccode.sim' in datfiles: 
         datfiles.remove('mccode.sim')
-    if 'mcstas.sim' in datfiles: 
-        datfiles.remove('mcstas.sim')
     if 'mccode.dat' in datfiles: 
         datfiles.remove('mccode.dat')
     if len(datfiles) > 0:
@@ -696,8 +730,6 @@ def has_multiple_datfiles(args):
     datfiles = glob.glob(join(d, '*'))
     if 'mccode.sim' in datfiles:
         datfiles.remove('mccode.sim')
-    if 'mcstas.sim' in datfiles:
-        datfiles.remove('mcstas.sim')
     if 'mccode.dat' in datfiles:
         datfiles.remove('mccode.dat')
     for f in datfiles:
@@ -743,8 +775,6 @@ def load_simulation(args):
     # load monitor data handles
     if isfile(join(d, 'mccode.sim')):
         indexfile='mccode.sim'
-    elif isfile(join(d, 'mcstas.sim')):
-        indexfile='mcstas.sim'
     else:
         indexfile=''
     data_lst = _load_data_from_mcfiles(_get_filenames_from_mccodesim(join(d, indexfile)))
@@ -764,8 +794,6 @@ def load_simulation(args):
 def load_sweep(args):
     d = args['directory']
     f_dat = join(d, 'mccode.dat')
-    if isfile(join(d, 'mcstas.sim')):
-        f_dat = join(d, 'mcstas.sim')
 
     # load primary data_handle, 1D sweep values
     data_handle_lst_sweep1D = _load_multiplot_1D_lst(f_dat)

--- a/tools/Python/mccodelib/mcplotloader.py
+++ b/tools/Python/mccodelib/mcplotloader.py
@@ -564,19 +564,21 @@ def _load_sweep_monitors(rootdir):
     monitors_by_subdir = []
     for s in subdirs:
         mons = get_subdir_monitors(s)
-        if mons is not None:
+        if mons:
             monitors_by_subdir.append(mons)
         else:
-            # A discovered subfolder without a usable mccode.sim inside it
-            # - e.g. a step that crashed partway through writing its own
-            # output, after the subfolder itself was created but before
-            # mccode.sim was written. Skip it here rather than letting a
-            # None entry propagate into monitors_by_subdir and crash the
+            # A discovered subfolder without usable monitor data - either
+            # no mccode.sim at all (get_subdir_monitors() returns None),
+            # or a mccode.sim that exists but has zero "begin data" blocks
+            # (returns [] - e.g. the simulation crashed after writing its
+            # header but before writing monitor results
+            # Either way, skip it here rather than letting an empty (or
+            # None) entry propagate into monitors_by_subdir and crash the
             # indexing below; load_sweep()'s own root/secondary
             # length-mismatch check further down already warns (rather
             # than crashing) if this ever leaves the secondary monitor
             # count out of sync with mccode.dat's row count.
-            print("_load_sweep_monitors: skipping subdir %s (no valid mccode.sim found)" % s)
+            print("_load_sweep_monitors: skipping subdir %s (no usable monitor data found)" % s)
 
     if not monitors_by_subdir:
         # No subfolder had usable data at all (e.g. every scan step

--- a/tools/Python/mcplot/matplotlib/mcplot.py
+++ b/tools/Python/mcplot/matplotlib/mcplot.py
@@ -45,6 +45,19 @@ def main(args):
             if (h5file):
                 if not os.path.isabs(h5file):
                     h5file = os.path.join(os.getcwd(),h5file)
+                # A NeXus-format scan (as opposed to a single simulation)
+                # also writes a scan-summary mccode.dat alongside
+                # mccode.h5. If it's there, also spawn a separate,
+                # independent instance of this same mcplot variant pointed
+                # directly at mccode.dat, running in the background
+                # alongside the HDFVIEW.
+                datfile = os.path.join(os.path.dirname(h5file), 'mccode.dat')
+                if os.path.isfile(datfile):
+                    try:
+                        print('Also spawning %s on %s' % (os.path.basename(__file__), datfile))
+                        subprocess.Popen([sys.executable, os.path.abspath(__file__), datfile])
+                    except Exception as e:
+                        print('Could not launch a second mcplot instance on ' + datfile + ': ' + e.__str__())
                 try:
                     cmd = mccode_config.configuration['HDFVIEW'] + ' ' + h5file
                     print('Spawning ' + mccode_config.configuration['HDFVIEW'])

--- a/tools/Python/mcplot/pyqtgraph/mcplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mcplot.py
@@ -43,6 +43,19 @@ def main(args):
             if (h5file):
                 if not os.path.isabs(h5file):
                     h5file = os.path.join(os.getcwd(),h5file)
+                # A NeXus-format scan (as opposed to a single simulation)
+                # also writes a scan-summary mccode.dat alongside
+                # mccode.h5. If it's there, also spawn a separate,
+                # independent instance of this same mcplot variant pointed
+                # directly at mccode.dat, running in the background
+                # alongside the HDFVIEW.
+                datfile = os.path.join(os.path.dirname(h5file), 'mccode.dat')
+                if os.path.isfile(datfile):
+                    try:
+                        print('Also spawning %s on %s' % (os.path.basename(__file__), datfile))
+                        subprocess.Popen([sys.executable, os.path.abspath(__file__), datfile])
+                    except Exception as e:
+                        print('Could not launch a second mcplot instance on ' + datfile + ': ' + e.__str__())
                 try:
                     cmd = mccode_config.configuration['HDFVIEW'] + ' ' + h5file
                     print('Spawning ' + mccode_config.configuration['HDFVIEW'])

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -52,12 +52,12 @@ def build_checker(accept, msg='Invalid value'):
     return checker
 
 
-def add_mcrun_options(parser):
+def add_mcrun_cogen_options(parser):
     ''' Add option group for McRun options to parser '''
 
     # McRun options
-    opt = OptionGroup(parser, '%s options' % (mccode_config.configuration["MCRUN"]))
-    add = opt.add_option
+    cogenopt = OptionGroup(parser, '%s code-generation + main options' % (mccode_config.configuration["MCRUN"]))
+    add = cogenopt.add_option
 
     add('-c', '--force-compile',
         action='store_true',
@@ -87,91 +87,6 @@ def add_mcrun_options(parser):
         metavar='D3',
         help='Set extra -D args (implies -c)')
 
-    add('-p', '--param',
-        metavar='FILE',
-        help='Read parameters from file FILE')
-
-    add('-N', '--numpoints',
-        metavar='NP',
-        help='Set number of scan points. A single integer applies the same '
-             'point count to every scanned parameter (the default, and the '
-             'only valid form without -M). With -M/--multi, a comma-separated '
-             'list (e.g. -N=5,10,20) instead gives each scanned parameter its '
-             'own point count, in the same order the parameters are listed '
-             'on the command line. Not needed at all for a parameter given as '
-             '"min:delta:max" (see the usage line above) - the point count is '
-             'computed from the requested bin width instead.')
-
-    add('--seeds',
-        metavar='SEEDS',
-        help='Set range of seeds to scan (each must be: SEED != 0)')
-
-    add('-L', '--list',
-        action='store_true',
-        help='Use a fixed list of points for scanning, walking every scanned '
-             'parameter\'s list together in lockstep (all lists must then be '
-             'the same length). Combine with -M/--multi instead to take the '
-             'cartesian product of each parameter\'s own list (lists may then '
-             'have different lengths). A parameter given as "min:delta:max" '
-             '(see the usage line above) is expanded into its own explicit '
-             'list of equidistant points and can be freely mixed with other, '
-             'explicitly-listed parameters (e.g. a list of filenames) under -L.')
-
-    add('-M', '--multi',
-        action='store_true',
-        help='Run a multi-dimensional scan (the cartesian product of every '
-             'scanned parameter\'s own points, rather than walking them all '
-             'in lockstep). Combine with -L/--list (each parameter\'s '
-             'explicit list can then have a different length) or give -N '
-             'a comma-separated list (see -N/--numpoints) for per-parameter '
-             'point counts.')
-
-    add("--scan_split",
-        type=int,
-        metavar="scan_split",
-        help='Scan by parallelising steps as individual cpu threads. Initialise by number of wanted threads (e.g. your number of cores).')
-
-    add('--autoplot',
-        action='store_true',
-        help='Open plotter on generated dataset')
-
-    add('--invcanvas',
-        action='store_true',
-        help='Forward request for inverted canvas to plotter')
-
-    add('--autoplotter',
-        action='store',
-        type=str,
-        help='Specify the plotter used with --autoplot')
-
-    add('--embed',
-        action='store_true', default=True,
-        help='Store copy of instrument file in output directory')
-
-    # Multiprocessing
-    add('--mpi',
-        metavar='NB_CPU',
-        help='Spread simulation over NB_CPU machines using MPI')
-
-    # Accellerator-support
-    add('--openacc',
-        action='store_true', default=False,
-        help='parallelize using openacc')
-
-    add('--funnel',
-        action='store_true', default=False,
-        help='funneling simulation flow, e.g. for mixed CPU/GPU')
-
-    add('--machines',
-        metavar='machines',
-        help='Defines path of MPI machinefile to use in parallel mode')
-
-    # Optimisation
-    add('--optimise-file',
-        metavar='FILE',
-        help='Store scan results in FILE '
-             '(defaults to: "mccode.dat")')
-
     add('--no-cflags',
         action='store_true', default=False,
         help='Disable optimising compiler flags for faster compilation')
@@ -182,20 +97,62 @@ def add_mcrun_options(parser):
 
     add('--verbose',
         action='store_true', default=False,
-        help='Enable verbose output')
+        help='Enable verbose output during code-generation and simulation')
 
-    add('--write-user-config',
-        action='store_true', default=False,
-        help='Generate a user config file')
+    add('-p', '--param',
+        metavar='FILE',
+        help='Forward parameters from file FILE to Instrument ')
+    parser.add_option_group(cogenopt)
 
-    add('--edit-user-config',
-        action='store_true', default=False,
-        help='Generate and edit user config file in EDITOR')
+def add_mcrun_adv_options(parser):
 
-    
-    add('--override-config',
-        metavar='PATH', default=False,
-        help='Load config file from specific dir')
+    scanopt = OptionGroup(parser, 'Parameter scan options')
+    add = scanopt.add_option
+
+    add('-N', '--numpoints',
+        metavar='NP',
+        help='Set number of scan points. Two input modes available: '
+             ' 1) A single integer applies the same point count to every '
+             '   scanned parameter (default, and only valid form without -M)'
+             ' 2) Together with -M/--multi, a comma-separated list '
+             '   (e.g. -N=5,10,20) gives each scanned parameter its '
+             '   own point count, in the order in which parameters are listed '
+             '   on the command line. If a parameter is given as par="min:delta:max"'
+             '   the point count is instead computed from the requiested bin width.')
+
+    add('-L', '--list',
+        action='store_true',
+        help='Use list-mode scanning. Multiple input modes avavailble: '
+             ' 1) If multiple lists (of identical length) are given (and -M is '
+             '    not requested) the lists are scanned together in lockstep.'
+             ' 2) Combined with -M/--multi, the cartesian product of each '
+             '   parameter\'s own list is used to set up a multidimensional '
+             '   \'grid\' scan (lists may have different lengths)'
+             ' 3) Any parameter given as "min:delta:max" is expanded into its '
+             '   own explicit list of equidistant points and mey be freely mixed '
+             '   with other, explicitly-listed parameters '
+             '   (e.g. a list of filenames) under -L.')
+
+    add('-M', '--multi',
+        action='store_true',
+        help='Run a multi-dimensional scan (cartesian product of every '
+             'scanned parameter\'s points, rather than a co-linear scan). '
+             'Combine with -L/--list or give -N as a comma-separated list '
+             '(see -N/--numpoints). ')
+
+    add("--scan_split",
+        type=int,
+        metavar="scan_split",
+        help='Scan by parallelising steps as individual cpu threads. Initialise by number of wanted threads (e.g. your number of cores).')
+
+    add('--seeds',
+        metavar='SEEDS',
+        help='Set range of seeds to scan (each must be: SEED != 0)')
+    parser.add_option_group(scanopt)
+
+    optopt = OptionGroup(parser, 'Optimization options')
+    add = optopt.add_option
+   # Optimisation
 
     add('--optimize',
         action='store_true', default=False,
@@ -255,7 +212,10 @@ def add_mcrun_options(parser):
         nargs=1,
         default="",
     )
-
+    add('--optimise-file',
+        metavar='FILE',
+        help='Store scan results in FILE '
+             '(defaults to: "mccode.dat")')
     #    --optimize-maxiter maxiter  max iter of optimization
     #    --tol tol          tolerance criteria to end the optimization
     #    --method method    Method to maximize the intensity in ['nelder-mead', 'powell', 'cg', 'bfgs', 'newton-cg', 'l-bfgs-b', 'tnc', 'cobyla', 'slsqp', 'trust-constr', 'dogleg', 'trust-ncg', 'trust-exact', 'trust-krylov']
@@ -264,6 +224,76 @@ def add_mcrun_options(parser):
     #                       https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html?highlight=minimize
     #    --minimize         choose to minimize the function if needed
     #    --monitor monitor  monitor name
+    parser.add_option_group(optopt)
+
+    plotopt = OptionGroup(parser, 'Autoplot options')
+    add = plotopt.add_option
+
+    add('--autoplot',
+        action='store_true',
+        help='Open plotter on generated dataset')
+
+    add('--invcanvas',
+        action='store_true',
+        help='Forward request for inverted canvas to plotter')
+
+    add('--autoplotter',
+        action='store',
+        type=str,
+        help='Specify the plotter used with --autoplot')
+    parser.add_option_group(plotopt)
+
+    mpiopt = OptionGroup(parser, 'MPI options')
+    add = mpiopt.add_option
+
+    # Multiprocessing
+    add('--mpi',
+        metavar='NB_CPU',
+        help='Spread simulation over NB_CPU machines using MPI')
+
+    add('--machines',
+        metavar='machines',
+        help='Defines path of MPI machinefile to use in parallel mode')
+    parser.add_option_group(mpiopt)
+
+    accopt = OptionGroup(parser, 'OpenACC options')
+    add = accopt.add_option
+    # Accellerator-support
+    add('--openacc',
+        action='store_true', default=False,
+        help='parallelize using openacc')
+
+    add('--funnel',
+        action='store_true', default=False,
+        help='funneling simulation flow, e.g. for mixed CPU/GPU')
+    
+    add('--vecsize',
+        metavar='VECSIZE', default='',
+        help='vector length in OpenACC parallel scenarios')
+
+    add('--numgangs',
+        metavar='NUMGANGS', default='',
+        help='number of \'gangs\' in OpenACC parallel scenarios')
+
+    add('--gpu_innerloop',
+        metavar='INNERLOOP', default='',
+        help='Maximum particles in an OpenACC kernel run. (If INNERLOOP is smaller than ncount we repeat)')
+    parser.add_option_group(accopt)
+
+    othopt = OptionGroup(parser, 'Config- options')
+    add = othopt.add_option
+
+    add('--write-user-config',
+        action='store_true', default=False,
+        help='Generate a user config file')
+
+    add('--edit-user-config',
+        action='store_true', default=False,
+        help='Generate and edit user config file in EDITOR')
+
+    add('--override-config',
+        metavar='PATH', default=False,
+        help='Load config file from specific dir')
 
     cfg_items = ['bindir','libdir','resourcedir','tooldir']
     cfg_items_prettyprint =   '"%s", and "%s"'%('", "'.join(cfg_items[:-1]),cfg_items[-1])
@@ -272,14 +302,14 @@ def add_mcrun_options(parser):
         help="Print selected cfg item and exit (paths are resolved and absolute). Allowed values are %s."%cfg_items_prettyprint
     )
 
-    parser.add_option_group(opt)
+    parser.add_option_group(othopt)
 
 
 def add_mcstas_options(parser):
     ''' Add option group for McStas options to parser '''
 
-    opt = OptionGroup(parser, 'Instrument options')
-    add = opt.add_option
+    instropt = OptionGroup(parser, 'Instrument options')
+    add = instropt.add_option
 
     # Misc options
     check_seed = build_checker(lambda seed: seed != 0,
@@ -309,6 +339,24 @@ def add_mcstas_options(parser):
         add('-g', '--gravitation', '--gravity',
             action='store_true', default=False,
             help='Enable gravitation for all trajectories')
+
+    # Information
+    add('-i', '--info',
+        action='store_true', default=False,
+        help='Detailed instrument information')
+
+    add('--list-parameters', action='store_true', default=False,
+        help='Print the instrument parameters to standard out')
+
+    add('--meta-list', action='store_true', default=False, help='Print all metadata defining component names')
+    add('--meta-defined', default=None, help="Print metadata names for component, or indicate if component:name exists")
+    add('--meta-type', default=None, help="Print metadata type for component:name")
+    add('--meta-data', default=None, help="Print metadata for component:name")
+            
+    parser.add_option_group(instropt)
+
+    outputopt = OptionGroup(parser, 'Output options')
+    add = outputopt.add_option
 
     # Data options
     dir_exists = lambda path: isdir(abspath(path))
@@ -359,36 +407,11 @@ def add_mcstas_options(parser):
         metavar='BUFSIZ', default=mccode_config.configuration["NDBUFFERSIZE"],
         help='Monitor_nD list/buffer-size (defaults to '+mccode_config.configuration["NDBUFFERSIZE"]+')')
 
-    add('--vecsize',
-        metavar='VECSIZE', default='',
-        help='vector length in OpenACC parallel scenarios')
+    add('--embed',
+        action='store_true', default=True,
+        help='Store copy of instrument file in output directory')
 
-    add('--numgangs',
-        metavar='NUMGANGS', default='',
-        help='number of \'gangs\' in OpenACC parallel scenarios')
-
-    add('--gpu_innerloop',
-        metavar='INNERLOOP', default='',
-        help='Maximum particles in an OpenACC kernel run. (If INNERLOOP is smaller than ncount we repeat)')
-
-    add('--no-output-files',
-        action='store_true', default=False,
-        help='Do not write any data files')
-
-    # Information
-    add('-i', '--info',
-        action='store_true', default=False,
-        help='Detailed instrument information')
-
-    add('--list-parameters', action='store_true', default=False,
-        help='Print the instrument parameters to standard out')
-
-    add('--meta-list', action='store_true', default=False, help='Print all metadata defining component names')
-    add('--meta-defined', default=None, help="Print metadata names for component, or indicate if component:name exists")
-    add('--meta-type', default=None, help="Print metadata type for component:name")
-    add('--meta-data', default=None, help="Print metadata for component:name")
-
-    parser.add_option_group(opt)
+    parser.add_option_group(outputopt)
 
 
 def expand_options(options):
@@ -588,8 +611,9 @@ def main():
              'params={val|min,max|min:delta:max|min,guess,max}...')
     parser = OptionParser(usage, version=mccode_config.configuration['MCCODE_VERSION'])
 
-    add_mcrun_options(parser)
+    add_mcrun_cogen_options(parser)
     add_mcstas_options(parser)
+    add_mcrun_adv_options(parser)
 
     # Parse options
     (options, args) = parser.parse_args()

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -474,9 +474,17 @@ def get_parameters(options):
         if '=' in param:
             key, value = param.split('=', 1)
             interval = value.split(',')
+            # Protect against trailing (or doubled) commas (empty-string entries
+            n_before = len(interval)
+            interval = [v for v in interval if v != '']
+            if len(interval) != n_before:
+                LOG.warning('Ignoring %d empty value(s) in parameter "%s" '
+                            '(check for a trailing or doubled comma)', n_before - len(interval), key)
             # When just one point is present, fix as constant
             if len(interval) == 1:
-                fixed_params[key] = value
+                fixed_params[key] = interval[0]
+            elif len(interval) == 0:
+                LOG.warning('Ignoring parameter "%s": no values left after removing empty entries', key)
             else:
                 LOG.debug('interval[%s]: %s', key, interval)
                 intervals[key] = interval

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -118,18 +118,18 @@ def add_mcrun_adv_options(parser):
              '   (e.g. -N=5,10,20) gives each scanned parameter its '
              '   own point count, in the order in which parameters are listed '
              '   on the command line. If a parameter is given as par="min:delta:max"'
-             '   the point count is instead computed from the requiested bin width.')
+             '   the point count is instead computed from the requested bin width.')
 
     add('-L', '--list',
         action='store_true',
-        help='Use list-mode scanning. Multiple input modes avavailble: '
+        help='Use list-mode scanning. Multiple input modes available: '
              ' 1) If multiple lists (of identical length) are given (and -M is '
              '    not requested) the lists are scanned together in lockstep.'
              ' 2) Combined with -M/--multi, the cartesian product of each '
              '   parameter\'s own list is used to set up a multidimensional '
              '   \'grid\' scan (lists may have different lengths)'
              ' 3) Any parameter given as "min:delta:max" is expanded into its '
-             '   own explicit list of equidistant points and mey be freely mixed '
+             '   own explicit list of equidistant points and may be freely mixed '
              '   with other, explicitly-listed parameters '
              '   (e.g. a list of filenames) under -L.')
 

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -112,7 +112,10 @@ def add_mcrun_options(parser):
              'parameter\'s list together in lockstep (all lists must then be '
              'the same length). Combine with -M/--multi instead to take the '
              'cartesian product of each parameter\'s own list (lists may then '
-             'have different lengths).')
+             'have different lengths). A parameter given as "min:delta:max" '
+             '(see the usage line above) is expanded into its own explicit '
+             'list of equidistant points and can be freely mixed with other, '
+             'explicitly-listed parameters (e.g. a list of filenames) under -L.')
 
     add('-M', '--multi',
         action='store_true',
@@ -512,17 +515,33 @@ def get_parameters(options):
                         'to scan - use a fixed value "%s=%s" instead.' % (key, a, key, a))
                 # Rounds to the nearest point count that covers [a, b] as
                 # closely as possible to the requested delta - the actual
-                # step size (recomputed from a, b, and this rounded N, the
-                # same way every other equidistant scan already works via
-                # LinearInterval/MultiInterval.from_range()) will usually
-                # differ very slightly from delta itself, since [a, b]
-                # isn't guaranteed to be an exact multiple of delta and
-                # both endpoints are always included.
+                # step size will usually differ very slightly from delta
+                # itself, since [a, b] isn't guaranteed to be an exact
+                # multiple of delta and both endpoints are always included.
                 n_points = max(2, round(abs(b - a) / abs(delta)) + 1)
-                intervals[key] = [str(a), str(b)]
-                equidistant_numpoints[key] = n_points
-                LOG.debug('interval[%s]: %s (a:delta:b syntax, delta=%s -> %d points)',
-                          key, intervals[key], delta, n_points)
+                step = (b - a) / (n_points - 1)
+                if options.list:
+                    # -L is active: a:delta:b conceptually already IS a
+                    # list of equidistant points, so expand it into the
+                    # full explicit list here and let it flow through the
+                    # exact same -L/-M machinery as any other explicit
+                    # list (e.g. an accompanying filename list) - no
+                    # special-casing needed anywhere else for this case.
+                    intervals[key] = [str(a + i * step) for i in range(n_points)]
+                    LOG.debug('interval[%s]: %s (a:delta:b syntax, expanded to %d explicit points for -L)',
+                              key, intervals[key], n_points)
+                else:
+                    # -L not given: keep the [a, b] endpoint pair, with the
+                    # point count tracked separately - main()'s normal
+                    # -N/-M machinery (LinearInterval/MultiInterval
+                    # .from_range()) already knows how to turn an
+                    # endpoint pair plus a point count into the same
+                    # equidistant points, without needing them written out
+                    # explicitly here.
+                    intervals[key] = [str(a), str(b)]
+                    equidistant_numpoints[key] = n_points
+                    LOG.debug('interval[%s]: %s (a:delta:b syntax, delta=%s -> %d points)',
+                              key, intervals[key], delta, n_points)
                 continue
 
             interval = value.split(',')
@@ -669,20 +688,14 @@ def main():
     if options.list and options.seeds:
         raise OptionValueError('--seeds cannot be used with --list')
 
-    # The "a:delta:b" syntax (see get_parameters()) already determines its
-    # own equidistant point count for whichever parameter(s) use it - it
-    # doesn't mix with -L (a fundamentally different, explicit-list scan
-    # mode; intervals[key] would be a [min, max] pair from a:delta:b, not
-    # an explicit list of values, regardless of what else is being
-    # scanned). An explicit -N is only actually redundant/conflicting when
-    # EVERY scanned parameter already gets its point count from a:delta:b
-    # - a scan mixing a:delta:b with a plain "min,max" parameter still
-    # legitimately needs -N to say how many points THAT one should have
+    # An explicit -N is only actually redundant/conflicting when EVERY
+    # scanned parameter already gets its point count from "a:delta:b"
+    # syntax (see get_parameters()) without -L active (with -L, a:delta:b
+    # expands directly into an explicit list in intervals[key], so
+    # equidistant_numpoints stays empty and this check can't fire at all).
+    # A scan mixing a:delta:b with a plain "min,max" parameter still
+    # legitimately needs -N to say how many points that one should have
     # (see the "mixed" branch below).
-    if equidistant_numpoints and options.list:
-        raise OptionValueError(
-            'The "a:delta:b" syntax (used for %s) specifies an equidistant scan and cannot be '
-            'combined with -L/--list.' % ', '.join(equidistant_numpoints))
     if equidistant_numpoints and options.numpoints and len(equidistant_numpoints) == len(intervals):
         raise OptionValueError(
             'The "a:delta:b" syntax (used for %s) already determines its own point count for every '

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -98,7 +98,9 @@ def add_mcrun_options(parser):
              'only valid form without -M). With -M/--multi, a comma-separated '
              'list (e.g. -N=5,10,20) instead gives each scanned parameter its '
              'own point count, in the same order the parameters are listed '
-             'on the command line.')
+             'on the command line. Not needed at all for a parameter given as '
+             '"min:delta:max" (see the usage line above) - the point count is '
+             'computed from the requested bin width instead.')
 
     add('--seeds',
         metavar='SEEDS',
@@ -469,10 +471,60 @@ def get_parameters(options):
     ''' Get fixed and scan/optimise parameters '''
     fixed_params = {}
     intervals = {}
+    # Per-key point counts implied by the "a:delta:b" syntax below - kept
+    # separate from intervals (which only ever holds the [a, b] endpoints,
+    # matching every other scan mode's shape) so main() can tell which
+    # parameters had an explicit point count baked into their own syntax,
+    # as opposed to needing one supplied via -N.
+    equidistant_numpoints = {}
 
     for param in options.params:
         if '=' in param:
             key, value = param.split('=', 1)
+
+            # "par=a:delta:b" - an equidistant scan specified by its bin
+            # width (delta) rather than an explicit point count: mcrun
+            # computes how many points are needed to cover [a, b] in steps
+            # of (approximately - see rounding below) delta, rather than
+            # the user needing to work out -N by hand. Checked before the
+            # comma-based interval parsing below, since a colon can never
+            # appear in a numeric value/list, so a colon anywhere in the
+            # value unambiguously means this syntax was intended.
+            if ':' in value:
+                parts = value.split(':')
+                if len(parts) != 3:
+                    raise OptionValueError(
+                        'Parameter "%s" uses "a:delta:b" syntax but has %d colon-separated part(s) '
+                        '(expected exactly 3: start:delta:stop): "%s"' % (key, len(parts), value))
+                try:
+                    a, delta, b = (float(p) for p in parts)
+                except ValueError:
+                    raise OptionValueError(
+                        'Parameter "%s" uses "a:delta:b" syntax but not all three parts are numbers: "%s"'
+                        % (key, value))
+                if delta == 0:
+                    raise OptionValueError(
+                        'Parameter "%s" uses "a:delta:b" syntax with delta=0, which would need '
+                        'infinitely many points: "%s"' % (key, value))
+                if a == b:
+                    raise OptionValueError(
+                        'Parameter "%s" uses "a:delta:b" syntax with a == b (%s), so there is nothing '
+                        'to scan - use a fixed value "%s=%s" instead.' % (key, a, key, a))
+                # Rounds to the nearest point count that covers [a, b] as
+                # closely as possible to the requested delta - the actual
+                # step size (recomputed from a, b, and this rounded N, the
+                # same way every other equidistant scan already works via
+                # LinearInterval/MultiInterval.from_range()) will usually
+                # differ very slightly from delta itself, since [a, b]
+                # isn't guaranteed to be an exact multiple of delta and
+                # both endpoints are always included.
+                n_points = max(2, round(abs(b - a) / abs(delta)) + 1)
+                intervals[key] = [str(a), str(b)]
+                equidistant_numpoints[key] = n_points
+                LOG.debug('interval[%s]: %s (a:delta:b syntax, delta=%s -> %d points)',
+                          key, intervals[key], delta, n_points)
+                continue
+
             interval = value.split(',')
             # Protect against trailing (or doubled) commas (empty-string entries
             n_before = len(interval)
@@ -490,7 +542,7 @@ def get_parameters(options):
                 intervals[key] = interval
         else:
             LOG.warning('Ignoring invalid parameter: "%s"', param)
-    return (fixed_params, intervals)
+    return (fixed_params, intervals, equidistant_numpoints)
 
 
 def find_instr_file(instr):
@@ -514,7 +566,7 @@ def main():
 
     # Add options
     usage = ('usage: %prog [-cpnN] Instr [-sndftgahi] '
-             'params={val|min,max|min,guess,max}...')
+             'params={val|min,max|min:delta:max|min,guess,max}...')
     parser = OptionParser(usage, version=mccode_config.configuration['MCCODE_VERSION'])
 
     add_mcrun_options(parser)
@@ -589,7 +641,7 @@ def main():
     mcstas = McStas(options.instr)
     mcstas.prepare(options)
 
-    (fixed_params, intervals) = get_parameters(options)
+    (fixed_params, intervals, equidistant_numpoints) = get_parameters(options)
     # Add --seeds as an 'interval', to allow scanning simulation seed
     if options.seeds:
         intervals['--seed']=options.seeds.split(',')
@@ -616,6 +668,25 @@ def main():
     # Can't both do list and --seeds scanning
     if options.list and options.seeds:
         raise OptionValueError('--seeds cannot be used with --list')
+
+    # The "a:delta:b" syntax (see get_parameters()) already determines its
+    # own equidistant point count for whichever parameter(s) use it - it
+    # doesn't mix with -L (a fundamentally different, explicit-list scan
+    # mode; intervals[key] would be a [min, max] pair from a:delta:b, not
+    # an explicit list of values, regardless of what else is being
+    # scanned). An explicit -N is only actually redundant/conflicting when
+    # EVERY scanned parameter already gets its point count from a:delta:b
+    # - a scan mixing a:delta:b with a plain "min,max" parameter still
+    # legitimately needs -N to say how many points THAT one should have
+    # (see the "mixed" branch below).
+    if equidistant_numpoints and options.list:
+        raise OptionValueError(
+            'The "a:delta:b" syntax (used for %s) specifies an equidistant scan and cannot be '
+            'combined with -L/--list.' % ', '.join(equidistant_numpoints))
+    if equidistant_numpoints and options.numpoints and len(equidistant_numpoints) == len(intervals):
+        raise OptionValueError(
+            'The "a:delta:b" syntax (used for %s) already determines its own point count for every '
+            'scanned parameter, so an explicit -N/--numpoints is redundant here.' % ', '.join(equidistant_numpoints))
 
     # Parse -N/--numpoints (a plain string now, not auto-int'd by optparse -
     # see add_mcrun_options()): with -M/--multi it may be a comma-separated
@@ -689,6 +760,56 @@ def main():
         for n in numpoints_list:
             total *= n
         options.numpoints = total
+
+    elif equidistant_numpoints:
+        # "a:delta:b" syntax: each such parameter already has its own
+        # point count computed in get_parameters(), independent of -N/-M.
+        if len(equidistant_numpoints) == len(intervals):
+            # Every scanned parameter uses a:delta:b.
+            distinct_n = set(equidistant_numpoints.values())
+            if options.multi:
+                # -M: cartesian product, each dimension keeping its own
+                # delta-derived point count - identical in spirit to
+                # -N=a,b,c,... + -M above, just sourced from delta instead.
+                interval_points = MultiInterval.from_range(equidistant_numpoints, intervals)
+                total = 1
+                for n in equidistant_numpoints.values():
+                    total *= n
+                options.numpoints = total
+            elif len(distinct_n) == 1:
+                # No -M, but every parameter's delta happens to imply the
+                # same point count anyway - a perfectly ordinary co-linear
+                # scan, so there's no need to force the user to add -M.
+                options.numpoints = distinct_n.pop()
+                interval_points = LinearInterval.from_range(options.numpoints, intervals)
+            else:
+                raise OptionValueError(
+                    'Parameter(s) %s use "a:delta:b" syntax with different resulting point counts (%s) - '
+                    'add -M/--multi to scan them independently (a cartesian product), or use matching '
+                    'delta values for a co-linear scan.' % (
+                        ', '.join(equidistant_numpoints),
+                        ', '.join('%s=%d' % (k, v) for k, v in equidistant_numpoints.items())))
+        else:
+            # Mixed: some parameters use a:delta:b, others a plain min,max
+            # (no delta) that still needs a point count from somewhere.
+            missing = [k for k in intervals if k not in equidistant_numpoints]
+            if not options.multi:
+                raise OptionValueError(
+                    'Parameter(s) %s use "a:delta:b" syntax alongside plain interval(s) %s - add '
+                    '-M/--multi to scan them independently, or use "a:delta:b" for every scanned '
+                    'parameter.' % (', '.join(equidistant_numpoints), ', '.join(missing)))
+            if options.numpoints is None:
+                raise OptionValueError(
+                    'Parameter(s) %s need a point count - use "a:delta:b" syntax for them too, or '
+                    'supply a plain -N value.' % ', '.join(missing))
+            full_numpoints_dict = dict(equidistant_numpoints)
+            for k in missing:
+                full_numpoints_dict[k] = options.numpoints
+            interval_points = MultiInterval.from_range(full_numpoints_dict, intervals)
+            total = 1
+            for n in full_numpoints_dict.values():
+                total *= n
+            options.numpoints = total
 
     else:
         scan = options.multi or options.numpoints

--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -403,6 +403,10 @@ def add_mcstas_options(parser):
             help='Flag to attempt inclusion of XML-based IDF when --format=NeXus '
                  '(format list obtained from <instr>.%s -h)' % mccode_config.platform["EXESUFFIX"])
 
+    add('--no-output-files',
+        action='store_true', default=False,
+        help='Do not write any data files')
+
     add('--bufsiz',
         metavar='BUFSIZ', default=mccode_config.configuration["NDBUFFERSIZE"],
         help='Monitor_nD list/buffer-size (defaults to '+mccode_config.configuration["NDBUFFERSIZE"]+')')

--- a/tools/Python/mcrun/optimisation.py
+++ b/tools/Python/mcrun/optimisation.py
@@ -17,6 +17,37 @@ except:
 LOG = getLogger('optimisation')
 
 
+def _list_scan_xlimits(lst):
+    """ Computes the (xmin, xmax) header hint for an -L/--list scan's
+        first scanned parameter, matching whatever will actually end up
+        plotted as that parameter's x-values.
+
+        A genuinely numeric list (the common case, e.g. -L lambda=2,3)
+        uses its own real min/max - this MUST match resolve_scan_value()'s
+        numeric passthrough for the actual per-point column written into
+        mccode.dat, since the matplotlib frontend's plot_single_data()
+        uses this value directly via pylab.xlim(xmin, xmax) to set the
+        visible axis range. 
+
+        A non-numeric list (e.g. -L filename=Na2Ca3Al2F14.laz,...) uses
+        the 0-based index range (0..N-1) instead, matching
+        resolve_scan_value()'s own index-substitution fallback for that
+        case - a literal min()/max() of the raw strings would be
+        lexicographic and meaningless there anyway. """
+    try:
+        numeric_vals = [float(v) for v in lst]
+        return min(numeric_vals), max(numeric_vals)
+    except (TypeError, ValueError):
+        # Non-numeric: resolve_scan_value() substitutes each value with
+        # its own 0-based index within intervals[key]
+        # (list(intervals[key]).index(value)), so the matching range is
+        # (0, len(lst)-1) - NOT (1, len(lst)), which would itself clip the
+        # first data point (plotted at x=0) outside the visible axis, the
+        # same class of bug this function exists to avoid for the numeric
+        # case above.
+        return 0, len(lst) - 1
+
+
 def build_header(options, params, intervals, detectors):
     template = """
 # Instrument-source: '%(instr)s'
@@ -44,8 +75,7 @@ def build_header(options, params, intervals, detectors):
     xvars = ', '.join(hdrparams)
     lst = intervals[list(params)[0]]
     if options.list:
-        xmin=1
-        xmax=len(lst)
+        xmin, xmax = _list_scan_xlimits(lst)
     else:
         xmin = min(lst)
         xmax = max(lst)
@@ -132,16 +162,16 @@ end data
     # TODO: figure out correct scan type
     numpoints = 1 if options.optimize else options.numpoints
 
-    # -L list scan: use the position (1..N) within the list, matching
-    # build_header()'s existing convention for -L scans above - meaningful
-    # for a non-numeric list (e.g. filenames), where a literal min()/max()
-    # of the raw strings would be lexicographic and essentially
-    # meaningless, and harmless for a numeric one (the actual per-point
-    # values are written into mccode.dat itself; this is just the
-    # header's overall axis-range hint). Equidistant (-N/-M, non-list)
-    # scans are untouched, keeping their existing min()/max() behaviour.
+    # -L list scan: use the shared helper, which keeps the real min/max
+    # for a numeric list (matching what actually gets plotted - see
+    # _list_scan_xlimits()'s own docstring for why this matters), not just
+    # for a non-numeric one (e.g. filenames), where a literal min()/max()
+    # of the raw strings would be lexicographic and meaningless, so a
+    # 0-based index range (matching resolve_scan_value()'s own index
+    # substitution) is used instead. Equidistant (-N/-M, non-list) scans
+    # are untouched, keeping their existing min()/max() behaviour.
     if options.list:
-        xmin, xmax = 1, len(first_key_interval)
+        xmin, xmax = _list_scan_xlimits(first_key_interval)
     else:
         xmin, xmax = min(first_key_interval), max(first_key_interval)
 

--- a/tools/Python/mcrun/optimisation.py
+++ b/tools/Python/mcrun/optimisation.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from os.path import join 
 from multiprocessing import Pool
 import copy
+import re
 
 try:
   from scipy.optimize import minimize
@@ -196,6 +197,52 @@ def mcsimdetectors(directory_name: str):
     return [Detector(d['component'], *d['values'].split(), d['filename'], d['statistics']) for d in blocks]
 
 
+# Matches one of a simulation binary's own "Detector: ..." summary lines,
+# e.g.:
+#   Detector: PSDbefore_guides_I=2.34581e+09 PSDbefore_guides_ERR=2.34585e+06 PSDbefore_guides_N=999991 "PSDbefore_guides.dat"
+# The detector name itself can contain underscores (as in the example
+# above), so a plain \w+ before "_I=" isn't reliable - a backreference
+# instead requires the SAME name to reappear before "_ERR=" and "_N=",
+# which correctly anchors the split point regardless of what characters
+# the name itself contains.
+DETECTOR_STDOUT_RE = re.compile(
+    r'Detector:\s*(.+?)_I=(\S+)\s+\1_ERR=(\S+)\s+\1_N=(\S+)\s+"([^"]*)"'
+)
+
+
+def parse_detectors_from_stdout(stdout_text):
+    """ Parses a simulation's own "Detector: NAME_I=... NAME_ERR=...
+        NAME_N=... "file.dat"" summary lines directly out of its stdout,
+        and returns them as the same list of Detector objects
+        mcsimdetectors() builds from a per-step mccode.sim file.
+
+        Needed specifically for --format=NeXus scans: the default McCode
+        output format writes one mccode.sim/mccode.dat pair per scan step,
+        each in its own "dir/0", "dir/1", ... subfolder, which
+        mcsimdetectors() reads back after each step. NeXus format instead
+        (intentionally) accumulates every step into a single shared .h5
+        file (see Scanner.run()'s options.append=True for the NeXus
+        branch) - so there is no per-step mccode.sim to read detector
+        values back from at all; mcsimdetectors() finds only a .h5 file
+        there and returns nothing. The underlying simulation binary still
+        prints its normal per-run "Detector: ..." summary to stdout
+        regardless of output format, though, so that's used as the source
+        of per-step detector values in the NeXus case instead. """
+    from mccode import Detector
+    if not stdout_text:
+        return []
+    detectors = []
+    for match in DETECTOR_STDOUT_RE.finditer(stdout_text):
+        name, intensity, error, count, path = match.groups()
+        # Detector()'s "statistics" argument is normally the ';'-separated
+        # X0=...;dX=...; block that also appears in mccode.sim's per-monitor
+        # header block - stdout's one-line summary doesn't carry that, so
+        # fall back to Detector's own defaults (X0=0, dX=1, Y0=0, dY=1) by
+        # passing an empty string.
+        detectors.append(Detector(name, intensity, error, count, path, ''))
+    return detectors
+
+
 def point_at(N, key, minmax, step):
     """ Helper to compute the point for key at step """
     low, high = map(Decimal, minmax)
@@ -344,8 +391,16 @@ def _simulate_point(args):
         par_values.append(resolve_scan_value(key, point[key], intervals))
 
     current_dir = f'{mcstas_dir}/{i}'
-    mcstas.run(pipe=False, extra_opts={'dir': current_dir})
-    detectors = mcsimdetectors(current_dir)
+    is_nexus = mcstas.options.format.lower() == 'nexus'
+    # See Scanner.run()'s matching NeXus branch: there is no per-step
+    # mccode.sim to read detector values back from in NeXus mode, so
+    # capture stdout (pipe=True) and parse its "Detector: ..." summary
+    # lines directly instead of calling mcsimdetectors().
+    stdout_text = mcstas.run(pipe=is_nexus, extra_opts={'dir': current_dir})
+    if is_nexus:
+        detectors = parse_detectors_from_stdout(stdout_text)
+    else:
+        detectors = mcsimdetectors(current_dir)
 
     result = {
         'index': i,
@@ -394,24 +449,56 @@ class Scanner:
                     current_dir = f'{mcstas_dir}/{i}'
                     LOG.info(f"Output step into scan directory {current_dir}")
                     self.mcstas.run(pipe=False, extra_opts={'dir': current_dir})
+                    LOG.info("Finish running step, get detectors")
+                    detectors = mcsimdetectors(current_dir)
                 else:
                     current_dir = mcstas_dir
                     LOG.info(f"NeXus output step into scan directory {current_dir}")
                     self.mcstas.options.append=True
-                    self.mcstas.run(pipe=False, extra_opts={'dir': current_dir})
+                    # NeXus (intentionally) accumulates every step into one
+                    # shared .h5 file rather than a per-step mccode.sim/
+                    # mccode.dat, so there is no per-step results file to
+                    # read detector values back from at all -
+                    # mcsimdetectors() would just find a .h5 file here and
+                    # return nothing. Capture the simulation's own stdout
+                    # instead (pipe=True) and parse its "Detector: ..."
+                    # summary lines directly (see
+                    # parse_detectors_from_stdout()) - the underlying
+                    # binary always prints that per-run summary regardless
+                    # of output format.
+                    stdout_text = self.mcstas.run(pipe=True, extra_opts={'dir': current_dir})
+                    if stdout_text:
+                        # pipe=True suppresses the simulation's live
+                        # console output in favour of capturing it for
+                        # parsing - echo it back so nothing is silently
+                        # lost, just delayed until the step completes
+                        # rather than streamed in real time.
+                        print(stdout_text, end='' if stdout_text.endswith('\n') else '\n')
+                    LOG.info("Finish running step, get detectors from stdout")
+                    detectors = parse_detectors_from_stdout(stdout_text)
 
-                LOG.info("Finish running step, get detectors")
-                detectors = mcsimdetectors(current_dir)
                 if detectors is not None:
                     LOG.info("Got detectors")
                     if i == 0:
                         LOG.info("Write headers")
                         names = [det.name for det in detectors]
                         outfile.write(build_header(self.mcstas.options, self.intervals.keys(), self.intervals, names))
-                        # Opening a file inside of this loop seems like a bad idea ... oh well
-                        with open(self.simfile, 'w') as simfile:
-                            simfile.write(build_mccodesim_header(self.mcstas.options, self.intervals, names,
-                                                                version=self.mcstas.version))
+                        # NeXus format writes every scan step's data into
+                        # its own combined mccode.h5 rather than per-step
+                        # mccode.sim/detector files - a scan-level
+                        # mccode.sim here would describe mccode.dat
+                        # correctly on its own, but would misleadingly
+                        # look like the usual pairing with per-monitor
+                        # detector files that don't actually exist in
+                        # NeXus mode, so it's skipped. mccode.dat itself is
+                        # still written either way, and stays directly
+                        # plottable via its own embedded header alone (see
+                        # mcplotloader.py's load_sweep_dat_only()).
+                        if self.mcstas.options.format.lower() != 'nexus':
+                            # Opening a file inside of this loop seems like a bad idea ... oh well
+                            with open(self.simfile, 'w') as simfile:
+                                simfile.write(build_mccodesim_header(self.mcstas.options, self.intervals, names,
+                                                                    version=self.mcstas.version))
                         LOG.info("Wrote headers")
                     LOG.info(f"Write step detectors line into {self.outfile}")
                     values = ['%s %s' % (d.intensity, d.error) for d in detectors]
@@ -487,13 +574,18 @@ class Scanner_split:
                 if not wrote_headers:
                     names = [d.name for d in result['detectors']]
                     outfile.write(build_header(self.mcstas.options, self.intervals.keys(), self.intervals, names))
-                    with open(self.simfile, 'w') as simfile:
-                        simfile.write(build_mccodesim_header(
-                            self.mcstas.options,
-                            self.intervals,
-                            names,
-                            version=self.mcstas.version
-                        ))
+                    # See Scanner.run()'s matching NeXus branch: skip the
+                    # scan-level mccode.sim for NeXus format, for the same
+                    # reason - mccode.dat itself is still written and
+                    # stays plottable on its own.
+                    if self.mcstas.options.format.lower() != 'nexus':
+                        with open(self.simfile, 'w') as simfile:
+                            simfile.write(build_mccodesim_header(
+                                self.mcstas.options,
+                                self.intervals,
+                                names,
+                                version=self.mcstas.version
+                            ))
                     wrote_headers = True
 
                 values = ['%s %s' % (d.intensity, d.error) for d in result['detectors']]

--- a/tools/Python/mcrun/optimisation.py
+++ b/tools/Python/mcrun/optimisation.py
@@ -528,8 +528,8 @@ class Scanner:
                             # lost, just delayed until the step completes
                             # rather than streamed in real time.
                             print(stdout_text, end='' if stdout_text.endswith('\n') else '\n')
-                        LOG.info("Finish running step, get detectors from stdout")
-                        detectors = parse_detectors_from_stdout(stdout_text)
+                            LOG.info("Finish running step, get detectors from stdout")
+                            detectors = parse_detectors_from_stdout(stdout_text)
                 except Exception as e:
                     # A single failed scan point (simulation crash,
                     # non-zero exit, unreadable output, a bad parameter
@@ -555,7 +555,7 @@ class Scanner:
                     skipped.append(i)
                     continue
 
-                LOG.info("Got detectors")
+                    LOG.info("Got detectors")
                 if not header_written:
                     # Written on the first SUCCESSFUL point, not
                     # unconditionally at index 0 - point 0 might itself be
@@ -579,29 +579,10 @@ class Scanner:
                         with open(self.simfile, 'w') as simfile:
                             simfile.write(build_mccodesim_header(self.mcstas.options, self.intervals, names,
                                                                 version=self.mcstas.version))
-                    LOG.info("Wrote headers")
-                    header_written = True
-                LOG.info(f"Write step detectors line into {self.outfile}")
-                values = ['%s %s' % (d.intensity, d.error) for d in detectors]
-
-                if not self.mcstas.options.list:
-                    # Normal equidistant scan: LinearInterval/MultiInterval
-                    # .from_range() only ever produce numeric values, so
-                    # this is unchanged.
-                    line = '%s %s\n' % (' '.join(map(str, par_values)), ' '.join(values))
-                else:
-                    # -L list scan: resolve each scanned parameter's
-                    # value independently (see resolve_scan_value()) -
-                    # a genuinely numeric value passes straight
-                    # through, and only a non-numeric one (e.g. a
-                    # filename) becomes its own index within that
-                    # parameter's own list, keeping one proper numeric
-                    # column per scanned parameter either way.
-                    resolved = [resolve_scan_value(key, val, self.intervals)
-                                for key, val in zip(self.intervals.keys(), par_values)]
-                    line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
-                outfile.write(line)
-                outfile.flush()
+                        LOG.info("Wrote headers")
+                        header_written = True
+                        LOG.info(f"Write step detectors line into {self.outfile}")
+                        values = ['%s %s' % (d.intensity, d.error) for d in detectors]
 
                     if not self.mcstas.options.list:
                         # Normal equidistant scan: LinearInterval/MultiInterval
@@ -619,8 +600,27 @@ class Scanner:
                         resolved = [resolve_scan_value(key, val, self.intervals)
                                     for key, val in zip(self.intervals.keys(), par_values)]
                         line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
-                    outfile.write(line)
-                    outfile.flush()
+                        outfile.write(line)
+                        outfile.flush()
+
+                    if not self.mcstas.options.list:
+                        # Normal equidistant scan: LinearInterval/MultiInterval
+                        # .from_range() only ever produce numeric values, so
+                        # this is unchanged.
+                        line = '%s %s\n' % (' '.join(map(str, par_values)), ' '.join(values))
+                    else:
+                        # -L list scan: resolve each scanned parameter's
+                        # value independently (see resolve_scan_value()) -
+                        # a genuinely numeric value passes straight
+                        # through, and only a non-numeric one (e.g. a
+                        # filename) becomes its own index within that
+                        # parameter's own list, keeping one proper numeric
+                        # column per scanned parameter either way.
+                        resolved = [resolve_scan_value(key, val, self.intervals)
+                                    for key, val in zip(self.intervals.keys(), par_values)]
+                        line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
+                        outfile.write(line)
+                        outfile.flush()
 
 
 class Scanner_split:
@@ -683,12 +683,12 @@ class Scanner_split:
                     if self.mcstas.options.format.lower() != 'nexus':
                         with open(self.simfile, 'w') as simfile:
                             simfile.write(build_mccodesim_header(
-                                self.mcstas.options,
-                                self.intervals,
-                                names,
-                                version=self.mcstas.version
+                            self.mcstas.options,
+                            self.intervals,
+                            names,
+                            version=self.mcstas.version
                             ))
-                    wrote_headers = True
+                        wrote_headers = True
 
                 values = ['%s %s' % (d.intensity, d.error) for d in result['detectors']]
                 line = '%s %s\n' % (' '.join(map(str, result['params'])), ' '.join(values))

--- a/tools/Python/mcrun/optimisation.py
+++ b/tools/Python/mcrun/optimisation.py
@@ -162,16 +162,16 @@ end data
     # TODO: figure out correct scan type
     numpoints = 1 if options.optimize else options.numpoints
 
-    # -L list scan: use the position (1..N) within the list, matching
-    # build_header()'s existing convention for -L scans above - meaningful
-    # for a non-numeric list (e.g. filenames), where a literal min()/max()
-    # of the raw strings would be lexicographic and essentially
-    # meaningless, and harmless for a numeric one (the actual per-point
-    # values are written into mccode.dat itself; this is just the
-    # header's overall axis-range hint). Equidistant (-N/-M, non-list)
-    # scans are untouched, keeping their existing min()/max() behaviour.
+    # -L list scan: use the shared helper, which keeps the real min/max
+    # for a numeric list (matching what actually gets plotted - see
+    # _list_scan_xlimits()'s own docstring for why this matters), not just
+    # for a non-numeric one (e.g. filenames), where a literal min()/max()
+    # of the raw strings would be lexicographic and meaningless, so a
+    # 0-based index range (matching resolve_scan_value()'s own index
+    # substitution) is used instead. Equidistant (-N/-M, non-list) scans
+    # are untouched, keeping their existing min()/max() behaviour.
     if options.list:
-        xmin, xmax = 1, len(first_key_interval)
+        xmin, xmax = _list_scan_xlimits(first_key_interval)
     else:
         xmin, xmax = min(first_key_interval), max(first_key_interval)
 
@@ -528,8 +528,8 @@ class Scanner:
                             # lost, just delayed until the step completes
                             # rather than streamed in real time.
                             print(stdout_text, end='' if stdout_text.endswith('\n') else '\n')
-                            LOG.info("Finish running step, get detectors from stdout")
-                            detectors = parse_detectors_from_stdout(stdout_text)
+                        LOG.info("Finish running step, get detectors from stdout")
+                        detectors = parse_detectors_from_stdout(stdout_text)
                 except Exception as e:
                     # A single failed scan point (simulation crash,
                     # non-zero exit, unreadable output, a bad parameter
@@ -555,7 +555,7 @@ class Scanner:
                     skipped.append(i)
                     continue
 
-                    LOG.info("Got detectors")
+                LOG.info("Got detectors")
                 if not header_written:
                     # Written on the first SUCCESSFUL point, not
                     # unconditionally at index 0 - point 0 might itself be
@@ -579,48 +579,37 @@ class Scanner:
                         with open(self.simfile, 'w') as simfile:
                             simfile.write(build_mccodesim_header(self.mcstas.options, self.intervals, names,
                                                                 version=self.mcstas.version))
-                        LOG.info("Wrote headers")
-                        header_written = True
-                        LOG.info(f"Write step detectors line into {self.outfile}")
-                        values = ['%s %s' % (d.intensity, d.error) for d in detectors]
+                    LOG.info("Wrote headers")
+                    header_written = True
+                LOG.info(f"Write step detectors line into {self.outfile}")
+                values = ['%s %s' % (d.intensity, d.error) for d in detectors]
 
-                    if not self.mcstas.options.list:
-                        # Normal equidistant scan: LinearInterval/MultiInterval
-                        # .from_range() only ever produce numeric values, so
-                        # this is unchanged.
-                        line = '%s %s\n' % (' '.join(map(str, par_values)), ' '.join(values))
-                    else:
-                        # -L list scan: resolve each scanned parameter's
-                        # value independently (see resolve_scan_value()) -
-                        # a genuinely numeric value passes straight
-                        # through, and only a non-numeric one (e.g. a
-                        # filename) becomes its own index within that
-                        # parameter's own list, keeping one proper numeric
-                        # column per scanned parameter either way.
-                        resolved = [resolve_scan_value(key, val, self.intervals)
-                                    for key, val in zip(self.intervals.keys(), par_values)]
-                        line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
-                        outfile.write(line)
-                        outfile.flush()
+                if not self.mcstas.options.list:
+                    # Normal equidistant scan: LinearInterval/MultiInterval
+                    # .from_range() only ever produce numeric values, so
+                    # this is unchanged.
+                    line = '%s %s\n' % (' '.join(map(str, par_values)), ' '.join(values))
+                else:
+                    # -L list scan: resolve each scanned parameter's
+                    # value independently (see resolve_scan_value()) -
+                    # a genuinely numeric value passes straight
+                    # through, and only a non-numeric one (e.g. a
+                    # filename) becomes its own index within that
+                    # parameter's own list, keeping one proper numeric
+                    # column per scanned parameter either way.
+                    resolved = [resolve_scan_value(key, val, self.intervals)
+                                for key, val in zip(self.intervals.keys(), par_values)]
+                    line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
+                outfile.write(line)
+                outfile.flush()
 
-                    if not self.mcstas.options.list:
-                        # Normal equidistant scan: LinearInterval/MultiInterval
-                        # .from_range() only ever produce numeric values, so
-                        # this is unchanged.
-                        line = '%s %s\n' % (' '.join(map(str, par_values)), ' '.join(values))
-                    else:
-                        # -L list scan: resolve each scanned parameter's
-                        # value independently (see resolve_scan_value()) -
-                        # a genuinely numeric value passes straight
-                        # through, and only a non-numeric one (e.g. a
-                        # filename) becomes its own index within that
-                        # parameter's own list, keeping one proper numeric
-                        # column per scanned parameter either way.
-                        resolved = [resolve_scan_value(key, val, self.intervals)
-                                    for key, val in zip(self.intervals.keys(), par_values)]
-                        line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
-                        outfile.write(line)
-                        outfile.flush()
+        if skipped:
+            LOG.warning('%d of %d scan point(s) failed or produced no data and were skipped '
+                        '(step indices: %s). %s contains only the %d successful point(s).',
+                        len(skipped), len(points), ', '.join(str(s) for s in skipped),
+                        self.outfile, len(points) - len(skipped))
+        else:
+            LOG.info('Scan complete: all %d point(s) succeeded.', len(points))
 
 
 class Scanner_split:
@@ -688,7 +677,7 @@ class Scanner_split:
                             names,
                             version=self.mcstas.version
                             ))
-                        wrote_headers = True
+                    wrote_headers = True
 
                 values = ['%s %s' % (d.intensity, d.error) for d in result['detectors']]
                 line = '%s %s\n' % (' '.join(map(str, result['params'])), ' '.join(values))

--- a/tools/Python/mcrun/optimisation.py
+++ b/tools/Python/mcrun/optimisation.py
@@ -396,11 +396,30 @@ def _simulate_point(args):
     # mccode.sim to read detector values back from in NeXus mode, so
     # capture stdout (pipe=True) and parse its "Detector: ..." summary
     # lines directly instead of calling mcsimdetectors().
-    stdout_text = mcstas.run(pipe=is_nexus, extra_opts={'dir': current_dir})
-    if is_nexus:
-        detectors = parse_detectors_from_stdout(stdout_text)
-    else:
-        detectors = mcsimdetectors(current_dir)
+    try:
+        stdout_text = mcstas.run(pipe=is_nexus, extra_opts={'dir': current_dir})
+        if is_nexus:
+            detectors = parse_detectors_from_stdout(stdout_text)
+        else:
+            detectors = mcsimdetectors(current_dir)
+        if not detectors:
+            # No exception, but nothing usable either (e.g. a NeXus step
+            # whose stdout didn't contain any "Detector: ..." lines at
+            # all) - treated the same as a runtime failure below: skip
+            # this point rather than writing an empty/malformed row.
+            LOG.warning('Scan step %d produced no detector data - skipping this point. Parameters were: %s',
+                        i, ', '.join(f'{k}={v}' for k, v in point.items()))
+            detectors = None
+    except Exception as e:
+        # A single failed scan point (simulation crash, non-zero exit,
+        # unreadable output, ...) shouldn't take down the whole scan -
+        # log it and report no detectors for this point; Scanner_split.run()
+        # already skips any result with detectors=None rather than writing
+        # a row for it, so the scan carries on to the remaining points and
+        # mccode.dat simply omits this one.
+        LOG.warning('Scan step %d failed (%s: %s) - skipping this point and continuing with the rest of the scan. '
+                    'Parameters were: %s', i, type(e).__name__, e, ', '.join(f'{k}={v}' for k, v in point.items()))
+        detectors = None
 
     result = {
         'index': i,
@@ -435,92 +454,132 @@ class Scanner:
         if mcstas_dir == '':
             mcstas_dir = '.'
 
+        points = list(self.points)
+        header_written = False
+        skipped = []
+
         with open(self.outfile, 'w') as outfile:
-            for i, point in enumerate(self.points):
+            for i, point in enumerate(points):
                 par_values = []
                 for key in self.intervals:
                     self.mcstas.set_parameter(key, point[key])
                     LOG.debug("%s: %s", key, point[key])
                     par_values.append(point[key])
 
-                if not self.mcstas.options.format.lower() == 'nexus':
-                    LOG.info(', '.join(f'{name}: {value}' for name, value in point.items()))
-                    # Change subdirectory as an extra option (dir/1 -> dir/2)
-                    current_dir = f'{mcstas_dir}/{i}'
-                    LOG.info(f"Output step into scan directory {current_dir}")
-                    self.mcstas.run(pipe=False, extra_opts={'dir': current_dir})
-                    LOG.info("Finish running step, get detectors")
-                    detectors = mcsimdetectors(current_dir)
-                else:
-                    current_dir = mcstas_dir
-                    LOG.info(f"NeXus output step into scan directory {current_dir}")
-                    self.mcstas.options.append=True
-                    # NeXus (intentionally) accumulates every step into one
-                    # shared .h5 file rather than a per-step mccode.sim/
-                    # mccode.dat, so there is no per-step results file to
-                    # read detector values back from at all -
-                    # mcsimdetectors() would just find a .h5 file here and
-                    # return nothing. Capture the simulation's own stdout
-                    # instead (pipe=True) and parse its "Detector: ..."
-                    # summary lines directly (see
-                    # parse_detectors_from_stdout()) - the underlying
-                    # binary always prints that per-run summary regardless
-                    # of output format.
-                    stdout_text = self.mcstas.run(pipe=True, extra_opts={'dir': current_dir})
-                    if stdout_text:
-                        # pipe=True suppresses the simulation's live
-                        # console output in favour of capturing it for
-                        # parsing - echo it back so nothing is silently
-                        # lost, just delayed until the step completes
-                        # rather than streamed in real time.
-                        print(stdout_text, end='' if stdout_text.endswith('\n') else '\n')
-                    LOG.info("Finish running step, get detectors from stdout")
-                    detectors = parse_detectors_from_stdout(stdout_text)
-
-                if detectors is not None:
-                    LOG.info("Got detectors")
-                    if i == 0:
-                        LOG.info("Write headers")
-                        names = [det.name for det in detectors]
-                        outfile.write(build_header(self.mcstas.options, self.intervals.keys(), self.intervals, names))
-                        # NeXus format writes every scan step's data into
-                        # its own combined mccode.h5 rather than per-step
-                        # mccode.sim/detector files - a scan-level
-                        # mccode.sim here would describe mccode.dat
-                        # correctly on its own, but would misleadingly
-                        # look like the usual pairing with per-monitor
-                        # detector files that don't actually exist in
-                        # NeXus mode, so it's skipped. mccode.dat itself is
-                        # still written either way, and stays directly
-                        # plottable via its own embedded header alone (see
-                        # mcplotloader.py's load_sweep_dat_only()).
-                        if self.mcstas.options.format.lower() != 'nexus':
-                            # Opening a file inside of this loop seems like a bad idea ... oh well
-                            with open(self.simfile, 'w') as simfile:
-                                simfile.write(build_mccodesim_header(self.mcstas.options, self.intervals, names,
-                                                                    version=self.mcstas.version))
-                        LOG.info("Wrote headers")
-                    LOG.info(f"Write step detectors line into {self.outfile}")
-                    values = ['%s %s' % (d.intensity, d.error) for d in detectors]
-
-                    if not self.mcstas.options.list:
-                        # Normal equidistant scan: LinearInterval/MultiInterval
-                        # .from_range() only ever produce numeric values, so
-                        # this is unchanged.
-                        line = '%s %s\n' % (' '.join(map(str, par_values)), ' '.join(values))
+                try:
+                    if not self.mcstas.options.format.lower() == 'nexus':
+                        LOG.info(', '.join(f'{name}: {value}' for name, value in point.items()))
+                        # Change subdirectory as an extra option (dir/1 -> dir/2)
+                        current_dir = f'{mcstas_dir}/{i}'
+                        LOG.info(f"Output step into scan directory {current_dir}")
+                        self.mcstas.run(pipe=False, extra_opts={'dir': current_dir})
+                        LOG.info("Finish running step, get detectors")
+                        detectors = mcsimdetectors(current_dir)
                     else:
-                        # -L list scan: resolve each scanned parameter's
-                        # value independently (see resolve_scan_value()) -
-                        # a genuinely numeric value passes straight
-                        # through, and only a non-numeric one (e.g. a
-                        # filename) becomes its own index within that
-                        # parameter's own list, keeping one proper numeric
-                        # column per scanned parameter either way.
-                        resolved = [resolve_scan_value(key, val, self.intervals)
-                                    for key, val in zip(self.intervals.keys(), par_values)]
-                        line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
-                    outfile.write(line)
-                    outfile.flush()
+                        current_dir = mcstas_dir
+                        LOG.info(f"NeXus output step into scan directory {current_dir}")
+                        self.mcstas.options.append=True
+                        # NeXus (intentionally) accumulates every step into one
+                        # shared .h5 file rather than a per-step mccode.sim/
+                        # mccode.dat, so there is no per-step results file to
+                        # read detector values back from at all -
+                        # mcsimdetectors() would just find a .h5 file here and
+                        # return nothing. Capture the simulation's own stdout
+                        # instead (pipe=True) and parse its "Detector: ..."
+                        # summary lines directly (see
+                        # parse_detectors_from_stdout()) - the underlying
+                        # binary always prints that per-run summary regardless
+                        # of output format.
+                        stdout_text = self.mcstas.run(pipe=True, extra_opts={'dir': current_dir})
+                        if stdout_text:
+                            # pipe=True suppresses the simulation's live
+                            # console output in favour of capturing it for
+                            # parsing - echo it back so nothing is silently
+                            # lost, just delayed until the step completes
+                            # rather than streamed in real time.
+                            print(stdout_text, end='' if stdout_text.endswith('\n') else '\n')
+                        LOG.info("Finish running step, get detectors from stdout")
+                        detectors = parse_detectors_from_stdout(stdout_text)
+                except Exception as e:
+                    # A single failed scan point (simulation crash,
+                    # non-zero exit, unreadable output, a bad parameter
+                    # combination the instrument itself rejects, ...)
+                    # shouldn't take down the whole scan - log it clearly
+                    # (which parameters were in play) and move on to the
+                    # next point rather than writing anything for this one.
+                    LOG.warning(
+                        'Scan step %d/%d failed (%s: %s) - skipping this point and continuing with the rest of '
+                        'the scan. Parameters were: %s', i + 1, len(points), type(e).__name__, e,
+                        ', '.join(f'{k}={v}' for k, v in point.items()))
+                    skipped.append(i)
+                    continue
+
+                if not detectors:
+                    # No exception, but nothing usable either (e.g. a NeXus
+                    # step whose stdout didn't contain any
+                    # "Detector: ..." lines at all) - skip this point too,
+                    # rather than writing an empty/malformed row that would
+                    # desync the column count from the header.
+                    LOG.warning('Scan step %d/%d produced no detector data - skipping this point. Parameters were: %s',
+                                i + 1, len(points), ', '.join(f'{k}={v}' for k, v in point.items()))
+                    skipped.append(i)
+                    continue
+
+                LOG.info("Got detectors")
+                if not header_written:
+                    # Written on the first SUCCESSFUL point, not
+                    # unconditionally at index 0 - point 0 might itself be
+                    # the one that failed above.
+                    LOG.info("Write headers")
+                    names = [det.name for det in detectors]
+                    outfile.write(build_header(self.mcstas.options, self.intervals.keys(), self.intervals, names))
+                    # NeXus format writes every scan step's data into
+                    # its own combined mccode.h5 rather than per-step
+                    # mccode.sim/detector files - a scan-level
+                    # mccode.sim here would describe mccode.dat
+                    # correctly on its own, but would misleadingly
+                    # look like the usual pairing with per-monitor
+                    # detector files that don't actually exist in
+                    # NeXus mode, so it's skipped. mccode.dat itself is
+                    # still written either way, and stays directly
+                    # plottable via its own embedded header alone (see
+                    # mcplotloader.py's load_sweep_dat_only()).
+                    if self.mcstas.options.format.lower() != 'nexus':
+                        # Opening a file inside of this loop seems like a bad idea ... oh well
+                        with open(self.simfile, 'w') as simfile:
+                            simfile.write(build_mccodesim_header(self.mcstas.options, self.intervals, names,
+                                                                version=self.mcstas.version))
+                    LOG.info("Wrote headers")
+                    header_written = True
+                LOG.info(f"Write step detectors line into {self.outfile}")
+                values = ['%s %s' % (d.intensity, d.error) for d in detectors]
+
+                if not self.mcstas.options.list:
+                    # Normal equidistant scan: LinearInterval/MultiInterval
+                    # .from_range() only ever produce numeric values, so
+                    # this is unchanged.
+                    line = '%s %s\n' % (' '.join(map(str, par_values)), ' '.join(values))
+                else:
+                    # -L list scan: resolve each scanned parameter's
+                    # value independently (see resolve_scan_value()) -
+                    # a genuinely numeric value passes straight
+                    # through, and only a non-numeric one (e.g. a
+                    # filename) becomes its own index within that
+                    # parameter's own list, keeping one proper numeric
+                    # column per scanned parameter either way.
+                    resolved = [resolve_scan_value(key, val, self.intervals)
+                                for key, val in zip(self.intervals.keys(), par_values)]
+                    line = '%s %s\n' % (' '.join(map(str, resolved)), ' '.join(values))
+                outfile.write(line)
+                outfile.flush()
+
+        if skipped:
+            LOG.warning('%d of %d scan point(s) failed or produced no data and were skipped '
+                        '(step indices: %s). %s contains only the %d successful point(s).',
+                        len(skipped), len(points), ', '.join(str(s) for s in skipped),
+                        self.outfile, len(points) - len(skipped))
+        else:
+            LOG.info('Scan complete: all %d point(s) succeeded.', len(points))
 
 
 class Scanner_split:
@@ -565,10 +624,12 @@ class Scanner_split:
         # Sort results to preserve order
         results.sort(key=lambda r: r['index'])
 
+        skipped = [r['index'] for r in results if not r['detectors']]
+
         with open(self.outfile, 'w') as outfile:
             wrote_headers = False
             for result in results:
-                if result['detectors'] is None:
+                if not result['detectors']:
                     continue
 
                 if not wrote_headers:
@@ -592,6 +653,14 @@ class Scanner_split:
                 line = '%s %s\n' % (' '.join(map(str, result['params'])), ' '.join(values))
                 outfile.write(line)
                 outfile.flush()
+
+        if skipped:
+            LOG.warning('%d of %d scan point(s) failed or produced no data and were skipped '
+                        '(step indices: %s). %s contains only the %d successful point(s).',
+                        len(skipped), len(results), ', '.join(str(s) for s in skipped),
+                        self.outfile, len(results) - len(skipped))
+        else:
+            LOG.info('Scan complete: all %d point(s) succeeded.', len(results))
 
 
 class Optimizer:


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

* Generate mccode.dat by fallback parsing of stdout in NeXus mode.
* Allow plotting mccode.dat without access to any mccode.sim.

Result: Overall behaviour of scan is available in mccode.dat also
in case of single-output mccode.h5 / NeXus.

(All in all a follow-up / extension of https://github.com/mccode-dev/McCode/pull/2618)

* Further added mechanism to skip scan-points in case of rumtime failure, functional both in cases where the sim folder is not created (init-time issues) and when a mccode.sim is written but monitor data not.

* Cleaned out references to mcstas.sim (McStas 2.x output)
* Let mcplot (pyqtgraph/matplotlib) spawn both overview plot and NeXus tool if in NeXus + scan mode

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

Claude-assisted:

Prompt1:
When running with the standard 'McCode' output format, the mccode.dat file generated in a scan is populated via reading the underlying 0/ 1/ 2/ ... subfolder datasets.

In NeXus output format however, the underlying data are (intentionally) written to a single HDF5 file instead.

In the NeXus case, please parse the Detector: output from underlying simulations directly from stdout of the simulations instead ( + a copy-pasted stdout output from one step within an mcrun scan)

(Rendered result contained both a mccode.sim and mccode.dat in supplement to mccode.h5 - yet not actually functional with mcplot.)

Prompt 2:
Now look at mcplot - and input file parsing for 'scan' data. It would be nice if there was a fallback-mechanism to plot the content of a mccode.dat without access to mccode.sim and all of the underlying detector files. Could you further finally make an adjustment to NOT create mccode.sim (but still mccode.dat) in the case of a 'NeXus' format scan?

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



