### PR TITLE
If non-numeric entries appear in mcgui / nsteps - defer interpretation to mcrun

### DIFF
--- a/tools/Python/mcgui/mcgui.py
+++ b/tools/Python/mcgui/mcgui.py
@@ -391,12 +391,9 @@ class McGuiState(QtCore.QObject):
                 if int(nsteps) > 1: # Numeric, this is scan step mode
                     feedback = 'Scan mode: N=' + str(nsteps) + ' steps. '
                     runstr = runstr + ' -N ' + str(nsteps)
-            except: # Check for list mode
-                if nsteps == '-L' or nsteps == 'list':
-                    runstr = runstr + ' -L '
-                    feedback = 'Scanning, -L list mode. '
-                else:
-                    feedback = 'Ignored scan input (' + str(nsteps) +') '
+            except: # Check for list mode / --multi
+                feedback = 'Attempt scanning with parameters: ' + str(nsteps) + ' '
+                runstr = runstr + ' ' + str(nsteps)
         
         # gravity
         if fixed_params[3]:


### PR DESCRIPTION



### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

If non-numeric entries appear in mcgui / nsteps - forward string for interpretation in mcrun. (`-L`, `-M`, `-Na,b,c,d`)
(may of course return an error for a not-allowed parametrization)


--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



