### PR TITLE
Fix for collision between stdlib:: syntax and mcrun min:delta:max

### DIFF
--- a/tools/Python/mcrun/mcrun.py
+++ b/tools/Python/mcrun/mcrun.py
@@ -519,8 +519,11 @@ def get_parameters(options):
             # the user needing to work out -N by hand. Checked before the
             # comma-based interval parsing below, since a colon can never
             # appear in a numeric value/list, so a colon anywhere in the
-            # value unambiguously means this syntax was intended.
-            if ':' in value:
+            # value would otherwise unambiguously mean this syntax was
+            # intended - EXCEPT double-colon syntax from NCrystal-backed
+            # reflections="stdlib::ZnO_sg186_ZincOxide.ncmat;temp=300K"
+            # used in context of PowderN. Filter out from the start:
+            if ':' in value and '::' not in value:
                 parts = value.split(':')
                 if len(parts) != 3:
                     raise OptionValueError(


### PR DESCRIPTION

### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Fix collision between e.g. NCrystal stdlib:: syntax and mcrun min:delta:max scan

--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



