### PR TITLE
FetchContent solution for mcstas-chopper-lib from Greg Tucker

### DIFF
--- a/cmake/Modules/ChopperLib.cmake
+++ b/cmake/Modules/ChopperLib.cmake
@@ -1,0 +1,45 @@
+# Fetches the contributed mcstas-chopper-lib repo (Greg Tucker,
+# https://github.com/mcdotstar/mcstas-chopper-lib) at configure time and
+# installs its pieces into the three McStas resource locations they belong
+# in. This is deliberately *not* built as a CMake subproject: chopper-lib's
+# own CMakeLists.txt builds a compiled chopper_lib library plus its CTest
+# suite (and requires CMake >= 3.25 to do so), but McStas has no use for a
+# compiled library here -- chopper-lib.c/.h are %include-d as raw source
+# directly into generated instrument C, exactly like the existing
+# mcstas-comps/share/*-lib.c snippets. We therefore only Populate the
+# source tree (content_fetch, see fetcher.cmake) and copy/install specific
+# files out of it; the 3.25 floor in chopper-lib's own CMakeLists.txt is
+# never evaluated.
+include(fetcher)
+
+set( CHOPPERLIB_REPO "https://github.com/mcdotstar/mcstas-chopper-lib.git" CACHE STRING
+     "Location (URL or local path) of mcstas-chopper-lib sources." )
+set( CHOPPERLIB_VERSION "v4.0.0" CACHE STRING
+     "Git tag/ref of mcstas-chopper-lib to fetch. Pinned rather than tracking a branch: \
+chopper-lib is young, under active development, and its own README documents breaking \
+field renames between major versions." )
+
+content_fetch(chopperlib "${CHOPPERLIB_VERSION}" "${CHOPPERLIB_REPO}")
+
+# 1) C library snippets, %include-d by components/instruments -> resources/share
+#    (alongside e.g. monitor_nd-lib.c)
+install( FILES "${chopperlib_SOURCE_DIR}/chopper-lib.c"
+               "${chopperlib_SOURCE_DIR}/chopper-lib.h"
+         DESTINATION "${DEST_DATADIR_CODEFILES}" )
+
+# 2) Components -> resources/contrib
+file( GLOB CHOPPERLIB_COMPS "${chopperlib_SOURCE_DIR}/*.comp" )
+install( FILES ${CHOPPERLIB_COMPS} DESTINATION "${DEST_DATADIR_COMPS}/contrib" )
+
+# 3) Instruments -> one folder per instrument under resources/examples/Tests_optics,
+#    matching the Test_Xxx/Test_Xxx.instr convention already used there.
+file( GLOB CHOPPERLIB_INSTRUMENTS "${chopperlib_SOURCE_DIR}/*.instr" )
+foreach( chopperlib_instr ${CHOPPERLIB_INSTRUMENTS} )
+  get_filename_component( chopperlib_instr_name "${chopperlib_instr}" NAME_WE )
+  install( FILES "${chopperlib_instr}"
+           DESTINATION "${DEST_DATADIR_EXAMPLES}/Tests_optics/${chopperlib_instr_name}" )
+endforeach()
+unset( chopperlib_instr )
+unset( chopperlib_instr_name )
+
+message( STATUS "mcstas-chopper-lib ${CHOPPERLIB_VERSION}: staged from ${chopperlib_SOURCE_DIR}" )

--- a/cmake/Modules/fetcher.cmake
+++ b/cmake/Modules/fetcher.cmake
@@ -32,3 +32,22 @@ function(git_fetch package min_version fetch_version_or_branch source required s
         set("${package}_BINARY_DIR" "${${package}_BINARY_DIR}" PARENT_SCOPE)
     endif()
 endfunction()
+
+# Lighter-weight sibling to git_fetch(): fetches a repo's source tree via
+# FetchContent, but never add_subdirectory()'s it and never runs a
+# find_package() pre-check. Use this for "contributed" repos whose CMakeLists
+# we do not want to build (e.g. because it has its own, possibly higher,
+# cmake_minimum_required, or because we only want to lift specific files out
+# of it -- comps/instruments/library snippets -- rather than build it as a
+# CMake subproject. Honors the standard FetchContent overrides, e.g.
+# -D<package>_SOURCE_DIR=/local/checkout or FETCHCONTENT_SOURCE_DIR_<PACKAGE>=...
+function(content_fetch package version_or_tag source)
+    message(STATUS "Fetch ${package} ${version_or_tag} from ${source}")
+    FetchContent_Declare(${package} GIT_REPOSITORY ${source} GIT_TAG ${version_or_tag} GIT_SHALLOW TRUE)
+    FetchContent_GetProperties(${package})
+    if (NOT ${package}_POPULATED)
+        FetchContent_Populate(${package})
+    endif()
+    set("${package}_SOURCE_DIR" "${${package}_SOURCE_DIR}" PARENT_SCOPE)
+    set("${package}_BINARY_DIR" "${${package}_BINARY_DIR}" PARENT_SCOPE)
+endfunction()

--- a/mcstas-comps/CMakeLists.txt
+++ b/mcstas-comps/CMakeLists.txt
@@ -93,6 +93,13 @@ endif()
 
 install( DIRECTORY "examples/"  DESTINATION "${DEST_DATADIR_EXAMPLES}")
 
+# Contributed mcstas-chopper-lib (Greg Tucker): fetched at configure time and
+# installed into share/contrib/examples -- see cmake/Modules/ChopperLib.cmake
+option( ENABLE_CHOPPERLIB "Fetch & install contributed mcstas-chopper-lib (lib snippets, contrib comps, example instruments)" ON )
+if ( ENABLE_CHOPPERLIB AND NOT EXCLUDE_CONTRIB )
+  include( ChopperLib )
+endif()
+
 
 # Include mcstas-comp revision tag file
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/revision.in" "${WORK}/revision" @ONLY)


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

@g5t has developed a nice solution for ESS source <-> new chopper-lib interplay. This PR adds chopper-lib to mcstas via CMake FetcContent

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

Claude, my prompt:
```
My McCode (McStas/McXtrace) checkout in (...) is available to you via an MCP plugin.

The codes are built using CMake - and we are gradually moving to mainly focusing on conda-forge as distribution channel, the McStas recipe is found here:
https://github.com/conda-forge/mcstas-suite-feedstock

I would like to integrate this new library from Greg Tucker which is placed in an independent repo https://github.com/mcdotstar/mcstas-chopper-lib. I would like an automated solution that works at release / config / build time rather than a static import. 

The chopper-lib comes with both 'lib' code (.c/.h snippets) that should end up in the users McStas resource dir 'share', components that should end up in the users McStas resource 'contrib' dir and instruments  should end up in independent folders under the users McStas resource 'examples/Tests_optics' dir.

Please initially take a look at the CMake code in the McStas checkout and investigate 1) if we require a new enough CMake for using FetchContent and 2) how you would propose implementing the wanted mechanism to automatically fetch the mcstas-chopper-lib for distribution / installation

```
--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



