### PR TITLE
Mcdoc list percent examples in bold

### DIFF
--- a/mcstas-comps/examples/BNL/BNL_H8/README.md
+++ b/mcstas-comps/examples/BNL/BNL_H8/README.md
@@ -20,6 +20,10 @@ cross comparison related in paper "A Model Instrument for Monte Carlo Code
 Comparisons", Neutron News 13 (No. 4), 24-29 (2002).
 ```
 
+## Examples
+
+- **Test: lambda=2.36 Detector: He3H_I=9.84026e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/BNL/BNL_H8_simple/README.md
+++ b/mcstas-comps/examples/BNL/BNL_H8_simple/README.md
@@ -20,6 +20,10 @@ cross comparison related in paper "A Model Instrument for Monte Carlo Code
 Comparisons", Neutron News 13 (No. 4), 24-29 (2002).
 ```
 
+## Examples
+
+- **Test: lambda=2.36 Detector: He3H_I=9.84026e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/BNL/h8_test_legacy/README.md
+++ b/mcstas-comps/examples/BNL/h8_test_legacy/README.md
@@ -26,6 +26,10 @@ purposes only.
 Example: mcrun h8_test_legacy.instr Lambda=2.36
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/DTU/Test_FZP_simple/README.md
+++ b/mcstas-comps/examples/DTU/Test_FZP_simple/README.md
@@ -15,6 +15,10 @@
 Simple test instrument for the FZP_simple component
 ```
 
+## Examples
+
+- **Test: Test_FZP_simple.instr lambda0=10 dlambda=1e-1 l1=40 Detector: psd_monitor_9_I=1.53e-05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/DTU/Vin_test/README.md
+++ b/mcstas-comps/examples/DTU/Vin_test/README.md
@@ -15,6 +15,10 @@
 Simple test instrument for the Virtual_input component
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/DTU/Vout_test/README.md
+++ b/mcstas-comps/examples/DTU/Vout_test/README.md
@@ -15,6 +15,10 @@
 Simple test instrument for the Virtual_output component
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_BEER_MCPL/README.md
+++ b/mcstas-comps/examples/ESS/ESS_BEER_MCPL/README.md
@@ -48,6 +48,11 @@ ESS_BEER_MCPL input=BEER_MCB.mcpl repetition=50 pwdfile=duplex.laz lc=9.35 lam0=
 Detector: psdtof_I=98.3885
 ```
 
+## Examples
+
+- **Test: input=BEER_MR.mcpl repetition=50 lc=6.65 modul=0 mod_twidth=0.0029 Detector: psdtof_I=138.421**
+- Example: input=BEER_MCB.mcpl repetition=50 lc=9.35 modul=1 mod_twidth=0.0029 Detector: psdtof_I=49.1942
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_IN5_reprate/README.md
+++ b/mcstas-comps/examples/ESS/ESS_IN5_reprate/README.md
@@ -16,6 +16,10 @@ McStas instrument for simulating IN5-TYPE (cold chopper) multi-frame spectromete
 The sample is incoherent with an inelastic tunneling line.
 ```
 
+## Examples
+
+- **Test: Lmin=4.9 Detector: PSDfast2_I=1.18335e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_KVASIR/README.md
+++ b/mcstas-comps/examples/ESS/ESS_KVASIR/README.md
@@ -18,6 +18,10 @@ a BIFROST guide guide simulation and adds the secondary spectrometer from
 the proposed KVASIR instrument.
 ```
 
+## Examples
+
+- **Test: t=50 Detector: det_He3_0_ToF_I=0.0302392**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_MCPL_generate_filtered/README.md
+++ b/mcstas-comps/examples/ESS/ESS_MCPL_generate_filtered/README.md
@@ -21,6 +21,10 @@ https://public.esss.dk/users/willend/MCPL/
 The instrument assumes that binary MCPL datasets are available in . named [sector][beamline].mcpl.gz, i.e. W8.mcpl.gz.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_Testbeamline_HZB_V20/README.md
+++ b/mcstas-comps/examples/ESS/ESS_Testbeamline_HZB_V20/README.md
@@ -16,6 +16,10 @@ McStas model of the ESS testbeamline V20 at HZB in Berlin. Please note that not
 all geometrical sizes, distances and parameters have been fully validated.
 ```
 
+## Examples
+
+- **Test: ESS_Testbeamline_HZB_V20 lambda_min=1 frequency=14 Detector: time_lambda_FOC2_I=1.2e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_butterfly_Adjustable_Pulse/README.md
+++ b/mcstas-comps/examples/ESS/ESS_butterfly_Adjustable_Pulse/README.md
@@ -17,6 +17,13 @@ Test instrument for the updated BF1 butterfly moderator design.
 The below example gives a 50-50 (statistics-wise) cold/thermal beam at beamline N10.
 ```
 
+## Examples
+
+- **Test: pulse_duration=2.857e-3 sector=N beamline=10 cold=0.5 Detector: AutoTOFL0_I=2.7e+11**
+- 
+- Was used to generate MCNP benchmarked output for the ESS_butterfly.comp - see
+- <a href="http://ess_butterfly.mcstas.org">http://ess_butterfly.mcstas.org</a>
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_butterfly_Guide_curved_test/README.md
+++ b/mcstas-comps/examples/ESS/ESS_butterfly_Guide_curved_test/README.md
@@ -20,6 +20,10 @@ Example: sector=S beamline=2 cold=0.5 Detector: Monitor2_xy1_I=1.59e+11
 Use the ESS_butterfly_MCPL_test instrument for direct comparison with MCPL-based source descriptions.
 ```
 
+## Examples
+
+- **Test: sector=S beamline=2 cold=0.5 Detector: Monitor2_xy1_I=1.59e+11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_butterfly_MCPL_test/README.md
+++ b/mcstas-comps/examples/ESS/ESS_butterfly_MCPL_test/README.md
@@ -22,6 +22,13 @@ and a 'preconditioned' version of this the file from https://public.esss.dk/user
 Example: sector=S beamline=2 filter=1 Detector: Monitor2_xy1_I=1.59e+11
 ```
 
+## Examples
+
+- **Test: sector=S beamline=2 filter=1 thres=0 Detector: Monitor2_xy1_I=1.59e+11**
+- **Test: sector=S beamline=2 filter=1 thres=4e8 Detector: Monitor2_xy1_I=1.59e+11**
+- 
+- Assumes access to binary MCPL datasets in . named [sector][beamline].mcpl.gz, i.e. W8.mcpl.gz.
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_butterfly_test/README.md
+++ b/mcstas-comps/examples/ESS/ESS_butterfly_test/README.md
@@ -17,6 +17,13 @@ Test instrument for the updated BF1 butterfly moderator design.
 The below example gives a 50-50 (statistics-wise) cold/thermal beam at beamline N10.
 ```
 
+## Examples
+
+- **Test: ESS_butterfly_test.instr sector=N beamline=10 cold=0.5 Detector: AutoTOFL0_I=2.7e+11**
+- 
+- Was used to generate MCNP benchmarked output for the ESS_butterfly.comp - see
+- <a href="http://ess_butterfly.mcstas.org">http://ess_butterfly.mcstas.org</a>
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_butterfly_tfocus_NOFOCUS_test/README.md
+++ b/mcstas-comps/examples/ESS/ESS_butterfly_tfocus_NOFOCUS_test/README.md
@@ -17,6 +17,12 @@ Test instrument for the updated BF1 butterfly moderator design.
 The below example gives a 50-50 (statistics-wise) cold/thermal beam at beamline N10.
 ```
 
+## Examples
+
+- **Test: sector=N beamline=1 cold=0.5 Detector: AutoTOFLend_I=1.5e+08**
+- 
+- This variant is set up for comparison with ESS_butterfly_tfocus_test - but without focusing from the source.
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_butterfly_tfocus_test/README.md
+++ b/mcstas-comps/examples/ESS/ESS_butterfly_tfocus_test/README.md
@@ -17,6 +17,12 @@ Test instrument for the updated BF1 butterfly moderator design.
 The below example gives a 50-50 (statistics-wise) cold/thermal beam at beamline N10.
 ```
 
+## Examples
+
+- **Test: mcrun ESS_butterfly_test.instr sector=N beamline=1 cold=0.5 Detector: AutoTOFLend_I=1.5e+08**
+- 
+- This variant is set up with time-focusing from the source - for comparison with with ESS_butterfly_tfocus_NOFOCUS_test which runs without focusing from the source.
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ESS/ESS_mcpl2hist/README.md
+++ b/mcstas-comps/examples/ESS/ESS_mcpl2hist/README.md
@@ -19,6 +19,10 @@ Generates energy, wavelength, position, veloicty and time histograms via Monitor
 Assumes access to binary MCPL datasets in . named [sector][beamline].mcpl.gz, i.e. W8.mcpl.gz.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/FRMII/FRMII_SPODI/README.md
+++ b/mcstas-comps/examples/FRMII/FRMII_SPODI/README.md
@@ -35,6 +35,10 @@ divergence of 10 minutes and banana detector with 3200 bins to simulate
 the 2D data that are collected on the real detectors.
 ```
 
+## Examples
+
+- **Test: -y -n1e8 Detector: theta_full_I=31556.9**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/FRMII/FRMII_SPODI_MULTI/README.md
+++ b/mcstas-comps/examples/FRMII/FRMII_SPODI_MULTI/README.md
@@ -32,6 +32,10 @@ of 155 degrees, Ge 551 reflection giving rise to the wavelength of ~1.5482 AA,
 and L2 of 5 m.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/FZ_Juelich/FZJ_BenchmarkSfin2/README.md
+++ b/mcstas-comps/examples/FZ_Juelich/FZJ_BenchmarkSfin2/README.md
@@ -17,33 +17,55 @@ The below test uses defaults of the instrument (SANS_benchmark2 modnum=11)*
 
 ```
 
+## Examples
+
+- **Test: -y Detector: PSDnear_I=7400**
+- 
+- Many sample-modes are available, from the SANS_benchmark2 component:
+- The component includes 19 sample-model-settings:
+- case 0 - no coherent scattering
+- case 1 - polymer with Mw = 2.000g/mol
+- case 2 - polymer with Mw = 1.000.000g/mol
+- case 3 - microemulsion
+- case 4 - wormlike micelle
+- case 5 - sphere, R = 25 AA
+- case 6 - sphere, R = 500 AA
+- case 7 - polymer blend
+- case 8 - diblock copolymer
+- case 9 - multilamellar vesicles
+- case 10 - logarithmically spaced series of sharp peaks
+- case 11 - logarithmically spaced series of sharp delta peaks !!!!!!
+- ...
+- case 15 - sphere, R = 150 AA
+- case 18   free
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.
 
 | Name | Unit | Description | Default |
 |------|------|-------------|---------|
-| lbdmin |  |  | 2.00 |
-| lbdmax |  |  | 8.5 |
-| NGbend |  |  | 0.053 |
-| NGblen |  |  | 0.03 |
-| Clen |  |  | 8.0 |
-| SampD |  |  | 0.01 |
-| bendL |  |  | 5.0 |
-| bendR |  |  | 385.0 |
-| bendM |  |  | 7.0 |
-| bendiM |  |  | 7.0 |
-| dfltM |  |  | 1.5 |
-| vorPl |  | for two cavities | 0.5 |
-| PolLen |  | for two cavities | 0.492 |
-| PolTot |  | for two cavities | 2.30 |
-| MDOWN |  |  | 3.6 |
-| Min |  |  | 1.5 |
-| cnum |  | Set to 0.0 for no polarizer as for benchmarking the normal SANS samples, to 2.0 for two cavities, keep default values as much as possible | 0.00 |
-| ROT |  |  | 0.0 |
-| modnum |  |  | 11.0 |
-| sglscatt |  |  | 1.0 |
-| incs |  |  | 0.0005 |
+| lbdmin | AA | Minimum wavelength produced at source | 2.00 |
+| lbdmax | AA | Maximum wavelength produced at source | 8.5 |
+| NGbend | m | Bender dimension, horizontal | 0.053 |
+| NGblen | m | Bender dimension, vertical | 0.03 |
+| Clen | m | Collimation length | 8.0 |
+| SampD | m | Sample 'half-dimension' (geometry is actually 2 x value) | 0.01 |
+| bendL | rad | Bender angle of deflection | 5.0 |
+| bendR | m | Bender radius of curvature | 385.0 |
+| bendM | 1 | Bender 'outer curve mirror m-value' | 7.0 |
+| bendiM | 1 | Bender 'inner curve mirror m-value' | 7.0 |
+| dfltM | 1 | Bender 'top/bottom mirror m-value' | 1.5 |
+| vorPl | m | If >0, post-bender Guide-element | 0.5 |
+| PolLen | m | If >0, length of polariser | 0.492 |
+| PolTot | m | Total primary optic length | 2.30 |
+| MDOWN | 1 | m-value of the Fe/Si-wafer for spin down neutrons | 3.6 |
+| Min | 1 | m-value of material for top. horz. mirror of the outer guide | 1.5 |
+| cnum | 1 | 'Degree of beam-polarisation'. Set to 0.0 for no polarizer as for benchmarking the normal SANS samples, to 2.0 for two cavities, keep default values as much as possible | 0.00 |
+| ROT | deg | Pre-polariser cavity-rotation angle arounz (only if polarised mode) | 0.0 |
+| modnum | 1 | Sample 'mode' (see mcdoc for SANS_benchmark2 component) | 11.0 |
+| sglscatt | 1 | Sample control of single/multiple scattering (see mcdoc for SANS_benchmark2 component) | 1.0 |
+| incs | 1 | Sample fraction of incoherently scattered neutrons (see mcdoc for SANS_benchmark2 component) | 0.0005 |
 
 ## Links
 

--- a/mcstas-comps/examples/FZ_Juelich/FZJ_KWS2_Lens/README.md
+++ b/mcstas-comps/examples/FZ_Juelich/FZJ_KWS2_Lens/README.md
@@ -17,6 +17,10 @@ This instrument is a test instrument for the Lens_simple component.
 Notice effect of gravitation on the final beam.
 ```
 
+## Examples
+
+- **Test: lambda=20.15 Detector: detector_I=3.4633E+01**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/FZ_Juelich/FZJ_SANS_KWS2_AnySample/README.md
+++ b/mcstas-comps/examples/FZ_Juelich/FZJ_SANS_KWS2_AnySample/README.md
@@ -16,6 +16,13 @@ KWS2 SANS instrument at FZ-Juelich. Custom sample (None, Guinier, Debye or Any).
 Sample is at 40 m from source. 2 detectors.
 ```
 
+## Examples
+
+- **Test: lambda=7 sample=0 Detector: detector_I=3450**
+- **Test: lambda=7 sample=1 Detector: detector_I=1182**
+- **Test: lambda=7 sample=2 Detector: detector_I=1751**
+- **Test: lambda=7 sample=3 Detector: detector_I=1249**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/HZB/HZB_FLEX/README.md
+++ b/mcstas-comps/examples/HZB/HZB_FLEX/README.md
@@ -15,6 +15,10 @@
 
 ```
 
+## Examples
+
+- **Test: kI=1.55 Detector: dpsd1_I=4.3e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/HZB/HZB_NEAT/README.md
+++ b/mcstas-comps/examples/HZB/HZB_NEAT/README.md
@@ -32,6 +32,11 @@ pulse (no frame overlap). The sample is a 2mm thick plate rotated by 45 degrees,
 which material can be any powder/liquid/amorphous sample.
 ```
 
+## Examples
+
+- **Test: lambda=6                       Detector: Detector_I=2900**
+- **Test: lambda=6 coh=Y2O3.laz inc=NULL Detector: Detector_I=1080**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/HighNESS/WOFSANS/README.md
+++ b/mcstas-comps/examples/HighNESS/WOFSANS/README.md
@@ -17,6 +17,10 @@ Instrument developed for the HighNESS EU project, describing a Wolter Optics
 Focusing SANS (WOFSANS_v2), applied for the study of moderator parameters.
 ```
 
+## Examples
+
+- **Test: WOFSANS width=0.15 Detector: PSD_10_I=4e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_BRISP/README.md
+++ b/mcstas-comps/examples/ILL/ILL_BRISP/README.md
@@ -69,6 +69,10 @@ In this model, the sample is a plate of thickness e=4 mm, surrounded by an
 Al or Nb container, inside an Al shield (phi=10 cm).
 ```
 
+## Examples
+
+- **Test: coh="V.lau" Detector: Detector_I=31.55**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_D2B/README.md
+++ b/mcstas-comps/examples/ILL/ILL_D2B/README.md
@@ -38,6 +38,10 @@ Ge       511 DM=1.089 AA
 Ge       533 DM=0.863 AA
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: D2B_BananaPSD_I=1.4489E+04**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_D2B_noenv/README.md
+++ b/mcstas-comps/examples/ILL/ILL_D2B_noenv/README.md
@@ -38,6 +38,10 @@ Ge       511 DM=1.089 AA
 Ge       533 DM=0.863 AA
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: D2B_BananaPSD_I=8308.35**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_D4/README.md
+++ b/mcstas-comps/examples/ILL/ILL_D4/README.md
@@ -26,6 +26,10 @@ Cu       002 DM=1.807 AA
 Cu       220 DM=1.278 AA
 ```
 
+## Examples
+
+- **Test: lambda=0.7 Detector: BananaTheta_I=1.44351e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H10_IN8/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H10_IN8/README.md
@@ -38,6 +38,10 @@ In this TAS configuration, Cu200 is used as monochromator and Cu111 as
 analyser, with a single type detector.
 ```
 
+## Examples
+
+- **Test: QM=1 EN=0 Sqw_coh=V.lau Detector: D7_SC3_1D_I=9.36585e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H113/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H113/README.md
@@ -15,6 +15,10 @@
 The H113 supermirror ballistic curved cold guide at the ILL feeding PF1b
 ```
 
+## Examples
+
+- **Test: lambda=10 Detector: GuideOut_Phic_I=2.3402e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H13_IN20/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H13_IN20/README.md
@@ -37,6 +37,10 @@ This model uses two Si111 monochromator and analyzers (unpolarized
 configuration).
 ```
 
+## Examples
+
+- **Test: QM=1 EN=0 Sqw_coh=V.lau Detector: D7_SC3_1D_I=4.83869e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H142/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H142/README.md
@@ -15,6 +15,11 @@
 The H142 S-curved cold guide at the ILL feeding IN12
 ```
 
+## Examples
+
+- **Test: m=1 Detector: GuideOut_Phic_I=9.1e+09**
+- **Test: -g m=1 Detector: GuideOut_Phic_I=9.1e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H142_D33/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H142_D33/README.md
@@ -25,6 +25,10 @@ quantitative analysis of spin incoherent samples. The high flux allows for
 kinetic experiments with time resolution of the order of few milliseconds.
 ```
 
+## Examples
+
+- **Test: ILL_H142_D33.instr lambda=14 dlambda=1.4 Detector: PSD_I=2e-07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H142_IN12/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H142_IN12/README.md
@@ -16,6 +16,10 @@ The H142 beam is the only S-curved guide at the ILL. It is used here to feed
 the IN12 TAS spectrometer (classical configuration).
 ```
 
+## Examples
+
+- **Test: KI=2.662 QM=1 Sqw_coh=V.lau Detector: D7_SC3_1D_I=8.5e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H142_simple/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H142_simple/README.md
@@ -15,6 +15,11 @@
 The H142 S-curved cold guide at the ILL feeding IN12
 ```
 
+## Examples
+
+- **Test: m=1 Detector: GuideOut_xy_I=2.36784e+09**
+- (Target example monitor differs from standard ILL_H142 since we avoid Monitor_nD - and 'capture')
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H143_LADI/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H143_LADI/README.md
@@ -41,6 +41,10 @@ Detector:    image plate 1250 x 450 mm2
 Sample:      at 2.710 mm from the end of the guide H143.
 ```
 
+## Examples
+
+- **Test: -y Detector: ImagePlate_I=959000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H15/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H15/README.md
@@ -15,6 +15,10 @@
 The H15@ILL curved guide sending cold neutrons from the VCS to IN6
 ```
 
+## Examples
+
+- **Test: m=1 Detector: GuideOut_Phic_I=1.16e10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H15_D11/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H15_D11/README.md
@@ -36,6 +36,10 @@ Chamfers [mm] | 0.2            0.2             0.8             0.2
 Wavyness [rad]| 2.5e-5         1e-4            8e-4            2e-4
 ```
 
+## Examples
+
+- **Test: Lambda=4.51 Detector: SampleC_I=2.1e7**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H15_IN6/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H15_IN6/README.md
@@ -44,6 +44,10 @@ improve the statistics.
 Example: lambda=4.14 Detector: M_theta_t_all_I=70
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H15_SAM/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H15_SAM/README.md
@@ -32,11 +32,16 @@ See the <a href="https://www.ill.eu/for-all-users/instruments/instruments-list/s
 
 Example (typical "real-life" measurement sequence):
 
-mcrun ILL_H15_SAM.instr --gravity -n1e7 -dLargeQ lambda=5.2
-mcrun ILL_H15_SAM.instr --gravity -n1e7 -dSmallQ guide1=0 guide2=0 guide3=0 lsd=6.8
+mcrun ILL_H15_SAM.instr --gravity -n1e8 -dLargeQ lambda=5.2
+mcrun ILL_H15_SAM.instr --gravity -n1e8 -dSmallQ guide1=0 guide2=0 guide3=0 lsd=6.8
 
 (Corresponding test-suite entries:)
 ```
+
+## Examples
+
+- **Test: ILL_H15_SAM.instr --gravity lambda=5.2 Detector: psd_I=15486.6**
+- **Test: ILL_H15_SAM.instr --gravity guide1=0 guide2=0 guide3=0 lsd=6.8 Detector: psd_I=25468.3**
 
 ## Input parameters
 

--- a/mcstas-comps/examples/ILL/ILL_H16/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H16/README.md
@@ -15,6 +15,10 @@
 The H16@ILL curved guide sending cold neutrons from the VCS to IN5.
 ```
 
+## Examples
+
+- **Test: m=1 Detector: GuideOut_Phic_I=1.85e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H16_IN5/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H16_IN5/README.md
@@ -18,6 +18,11 @@ with angle restriction (neutrons that scatter in Fe in front of a tube and
 enter a different tube are absorbed).
 ```
 
+## Examples
+
+- **Test: lambda=4.5 Detector: Det_sample_t_I=3.4043e+07**
+- **Test: lambda=4.5 Detector: Det_PSD_I=1.1e6**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H22/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H22/README.md
@@ -15,6 +15,10 @@
 The H22 curved thermal guide at the ILL feeding D1A/D1B, SALSA and VIVALDI
 ```
 
+## Examples
+
+- **Test: m=2 mip=0 Detector: GuideOut_Phic_I=2.75e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H22_D1A/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H22_D1A/README.md
@@ -42,6 +42,10 @@ Al environment (e.g. cryostat/furnace shield).
 This instrument was installed on the H22 guide.
 ```
 
+## Examples
+
+- **Test: lambda=1.911 Detector: BananaPSD_I=3.8578E+05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H22_D1A_noenv/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H22_D1A_noenv/README.md
@@ -42,6 +42,10 @@ Al environment (e.g. cryostat/furnace shield).
 This instrument was installed on the H22 guide.
 ```
 
+## Examples
+
+- **Test: lambda=1.911 Detector: BananaPSD_I=444751**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H22_D1B/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H22_D1B/README.md
@@ -34,6 +34,10 @@ obtained by scanning the temperature. A complete thermal variation of the
 diffraction patterns (1.5 - 300 K) can be achieved in few hours (3-5h).
 ```
 
+## Examples
+
+- **Test: lambda=2.52 Detector: D1B_BananaTheta_I=5065**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H22_D1B_noenv/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H22_D1B_noenv/README.md
@@ -34,6 +34,10 @@ obtained by scanning the temperature. A complete thermal variation of the
 diffraction patterns (1.5 - 300 K) can be achieved in few hours (3-5h).
 ```
 
+## Examples
+
+- **Test: lambda=2.52 Detector: D1B_BananaTheta_I=5415.58**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H22_VIVALDI/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H22_VIVALDI/README.md
@@ -28,6 +28,10 @@ primitive unit cells up to 25 Angs on edge.
 This model include a cryostat and container description, with a crystal sample.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H24/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H24/README.md
@@ -15,6 +15,10 @@
 The H24 curved thermal guide at the ILL feeding IN3, IN13, D10 and S42/Orient Express
 ```
 
+## Examples
+
+- **Test: m=1 Detector: GuideOut_Phic_I=1.22e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H25/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H25/README.md
@@ -15,6 +15,10 @@
 The H25 supermirror curved thermal guide at the ILL feeding S18, D23 and IN22
 ```
 
+## Examples
+
+- **Test: m=2 Detector: GuideOut_Phic_I=1.17e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H25_IN22/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H25_IN22/README.md
@@ -16,6 +16,10 @@ This instrument is a model of IN22@ILL with PG002 monochromator/analyzer,
 installed at the end of the H25 supermirror thermal guide.
 ```
 
+## Examples
+
+- **Test: KI=3.84 QM=1 Sqw_coh=V.lau Detector: Sample_Cradle_I=4.5e+07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H5/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H5/README.md
@@ -16,6 +16,10 @@ This is the geometry before the major H5 guide hall upgrade (up to 2013).*
 
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H512_D22/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H512_D22/README.md
@@ -20,6 +20,14 @@ with monitoring of the scattering in angular (diffraction) and energy modes
 (for spectroscopy).
 ```
 
+## Examples
+
+- **Test: lambda=4.5 Detector: D22_Detector_I=2e+07**
+- 
+- Flux given at sample positions from <www.ill.fr>
+- ILL_H5: D22:  nu=23589.5 [rpm] lambda=4.5 [Angs] sample=H2O_liq.qSq
+- Flux 1.2e8 -- 7.1e7
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H53/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H53/README.md
@@ -15,6 +15,10 @@
 The H53 curved cold guide at the ILL feeding IN14, IN16, D16, ADAM, CRYO-EDM
 ```
 
+## Examples
+
+- **Test: m=1.2 dlambda=8.5 Detector: H53_P5_Out_Phic_I=1.8081e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H53_D16/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H53_D16/README.md
@@ -20,6 +20,10 @@ two beam holes at take-off angles of 90 deg and 115 deg, corresponding to 4.7
 Angs and 5.6 Angs beams and incorporates the slit systems.
 ```
 
+## Examples
+
+- **Test: m=1.2 Detector: D16_BananaTheta_I=9.7E+04**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H53_IN14/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H53_IN14/README.md
@@ -30,6 +30,10 @@ In this TAS configuration, PG002 is used as monochromator analyser,
 with a single type detector.
 ```
 
+## Examples
+
+- **Test: KI=1.55 QM=1 Sqw_coh=V.lau Detector: Sample_Cradle_I=7.5962E+07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H5_new/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H5_new/README.md
@@ -36,6 +36,10 @@ with monitoring of the scattering in angular (diffraction) and energy modes
 (for spectroscopy).
 ```
 
+## Examples
+
+- **Test: lambda=5 Detector: H5_I=1.03234e+14**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_H8_IN1/README.md
+++ b/mcstas-comps/examples/ILL/ILL_H8_IN1/README.md
@@ -41,6 +41,10 @@ In this TAS configuration, Cu220 are used as monochromator and analyser,
 with a single type detector.
 ```
 
+## Examples
+
+- **Test: QM=1 Sqw_coh=V.lau Detector: D7_SC3_1D_I=1.06671e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_IN13/README.md
+++ b/mcstas-comps/examples/ILL/ILL_IN13/README.md
@@ -67,6 +67,10 @@ Q-range:             0.2 < Q/Å-1 < 4.9
 Q-resolution:        ΔQ/Å-1 < 0.1
 ```
 
+## Examples
+
+- **Test: TM=301 Detector: SamposPSD_I=5905.14**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_IN4/README.md
+++ b/mcstas-comps/examples/ILL/ILL_IN4/README.md
@@ -64,6 +64,10 @@ In this model, the sample is a cylindrical liquid/powder/glass scatterer
 surrounded by a container and an Al cryostat.
 ```
 
+## Examples
+
+- **Test: lambda=1.2 DM=1.677 Detector: sample_flux_I=4.43306e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_IN5/README.md
+++ b/mcstas-comps/examples/ILL/ILL_IN5/README.md
@@ -18,6 +18,10 @@ with angle restriction (neutrons that scatter in Fe in front of a tube and
 enter a different tube are absorbed). This model does not include the H16 guide.
 ```
 
+## Examples
+
+- **Test: lambda=4.5 Detector: Det_PSD_I=1.3e6**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_IN5_Spots/README.md
+++ b/mcstas-comps/examples/ILL/ILL_IN5_Spots/README.md
@@ -19,6 +19,10 @@ with angle restriction (neutrons that scatter in Fe in front of a tube and
 enter a different tube are absorbed). This model does not include the H16 guide.
 ```
 
+## Examples
+
+- **Test: lambda=4.5 Detector: Detector_Sqw_I=8.5E5**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_IN6/README.md
+++ b/mcstas-comps/examples/ILL/ILL_IN6/README.md
@@ -40,6 +40,10 @@ with multiple scattering, customized monitors, and the SPLIT mechanism to
 improve the statistics. The H15 guide is not described in this model.
 ```
 
+## Examples
+
+- **Test: lambda=4.14 Detector: M_theta_t_all_I=120000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_Lagrange/README.md
+++ b/mcstas-comps/examples/ILL/ILL_Lagrange/README.md
@@ -30,6 +30,10 @@ PG       002 DM=3.355 AA
 --------------------------
 ```
 
+## Examples
+
+- **Test: lambda=0.897 Detector: Detector_I=3704.83**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ILL/ILL_SALSA/README.md
+++ b/mcstas-comps/examples/ILL/ILL_SALSA/README.md
@@ -32,6 +32,10 @@ Furthermore the sample environment is of course variable depending on the sample
 in question.
 ```
 
+## Examples
+
+- **Test: ILL_SALSA.instr lambda_mean=1.66795 Detector: Beam_entrance_monitor_psd_I=1.80888e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_CRISP/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_CRISP/README.md
@@ -21,6 +21,10 @@ your the instrument with an installed GSL, you should use MCSTAS_CFLAGS like
 MCSTAS_CFLAGS = -g -O2 -lm -lgsl -lgslcblas
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_GEM/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_GEM/README.md
@@ -21,6 +21,10 @@ perform high intensity, high resolution experiments to study the structure of
 disordered materials and crystalline powders.
 ```
 
+## Examples
+
+- **Test: sample="Y2O3.laz" Detector: monzns_I=52.689**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_HET/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_HET/README.md
@@ -19,6 +19,10 @@ Andrew Garret which comes with no guarantees as to its accuracy in modelling the
 Fermi Chopper.
 ```
 
+## Examples
+
+- **Test: Emin=443 Detector: cyl_I=235837**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_IMAT/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_IMAT/README.md
@@ -25,6 +25,11 @@ Journal of Instrumentation, 8 (2013), no 10, http://dx.doi.org/10.1088/1748-0221
 2. Results from calculations published in the previous paper were obtained using McStas ISIS_moderator component (Face="W5")
 ```
 
+## Examples
+
+- **Test: -y Detector: psd4pi_I=0.34**
+- **Test: -y --format=NeXus Detector: psd4pi_I=0.34**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_LET/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_LET/README.md
@@ -17,6 +17,12 @@ Instrument: ISIS_LET*
 This is a simulation of LET on ISIS TS2.
 ```
 
+## Examples
+
+- **Test: Ei=3.7 res=HF Detector: sample_PSDmon_I=31264.8**
+- **Test: Ei=3.7 res=I Detector: sample_PSDmon_I=17839.7**
+- **Test: Ei=3.7 res=HR Detector: sample_PSDmon_I=8835.3**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_MERLIN/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_MERLIN/README.md
@@ -25,6 +25,10 @@ disk chopper, it is able to run in repetition-rate multiplication (RRM) mode, al
 simultaneously measure with several incident energies.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_OSIRIS/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_OSIRIS/README.md
@@ -26,6 +26,10 @@ reflection, and the d-spread is handled in a simple way
 McStas for completeness.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_Prisma2/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_Prisma2/README.md
@@ -22,6 +22,10 @@ line consists of the time-of-flight in microseconds followed by seven
 intensities of neutrons from each individual analyser blade.
 ```
 
+## Examples
+
+- **Test: TT=-30 Detector: mon9_I=7.4973e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_SANS2d/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_SANS2d/README.md
@@ -31,6 +31,10 @@ In reality spectra and backgrounds will vary, fast background is likely much hig
 <p>RKH 2014
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_TOSCA_preupgrade/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_TOSCA_preupgrade/README.md
@@ -27,6 +27,10 @@ output.
 Example: ISIS_TOSCA_preupgrade.instr inc=Benzene_inc_CASTEP_MDANSE2018.sqw -n1e7
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_TS1_Brilliance/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_TS1_Brilliance/README.md
@@ -19,6 +19,10 @@ The Brilliance_monitor is used to determine both the mean and peak brilliances, 
 Example: ISIS_brilliance Detector: Brillmon_I=3.80e+15 (First detector output)
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_TS2_Brilliance/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_TS2_Brilliance/README.md
@@ -19,6 +19,10 @@ The Brilliance_monitor is used to determine both the mean and peak brilliances, 
 Example: ISIS_brilliance Detector: Brillmon_I=3.80e+15 (First detector output)
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ISIS_test/README.md
+++ b/mcstas-comps/examples/ISIS/ISIS_test/README.md
@@ -17,6 +17,10 @@ Refer to the documentation in MCSTAS/contrib/doc/ISISdoc.pdf (.ps)
 for further instructions on using the ISIS_moderator component
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/ISIS/ViewModISIStest/README.md
+++ b/mcstas-comps/examples/ISIS/ViewModISIStest/README.md
@@ -17,6 +17,10 @@ Refer to the documentation in MCSTAS/contrib/doc/ISISdoc.pdf (.ps)
 for further instructions on using the ISIS_moderator component
 ```
 
+## Examples
+
+- **Test: dummy=1 Detector: lam1_I=1.2551e+12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/LLB/LLB_6T2/README.md
+++ b/mcstas-comps/examples/LLB/LLB_6T2/README.md
@@ -22,6 +22,10 @@ PG       002 DM=3.355 AA (Highly Oriented Pyrolythic Graphite)
 Cu       220 DM=1.278 AA
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/ILL_H16_IN5_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/ILL_H16_IN5_Mantid/README.md
@@ -37,6 +37,13 @@ with angle restriction (neutrons that scatter in Fe in front of a tube and
 enter a different tube are absorbed).
 ```
 
+## Examples
+
+- **Test: lambda=4.5 Detector: Det_sample_t_I=3.4043e+07**
+- **Test: lambda=4.5 Detector: Det_PSD_I=1.1e6**
+- **Test: lambda=4.5 --format=NeXus Detector: Det_sample_t_I=3.4043e+07**
+- **Test: lambda=4.5 --format=NeXus Detector: Det_PSD_I=1.1e6**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/ILL_H16_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/ILL_H16_Mantid/README.md
@@ -18,6 +18,10 @@ use with Mantid-friendly NeXus output. (See ILL_H16_IN5_Mantid or ILL_IN5_Mantid
 Example: m=1 Detector: GuideOut_Phic_I=1.85e+10
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/ILL_IN5_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/ILL_IN5_Mantid/README.md
@@ -19,6 +19,11 @@ with angle restriction (neutrons that scatter in Fe in front of a tube and
 enter a different tube are absorbed). This model does not include the H16 guide.
 ```
 
+## Examples
+
+- **Test: lambda=4.5 Detector: Det_PSD_I=1.3e6**
+- **Test: lambda=4.5 --format=NeXus Detector: Det_PSD_I=1.3e6**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/ISIS_SANS2d_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/ISIS_SANS2d_Mantid/README.md
@@ -31,6 +31,11 @@ In reality spectra and backgrounds will vary, fast background is likely much hig
 <p>RKH 2014
 ```
 
+## Examples
+
+- **Test: L1=3.926 Detector: detector_I=6871.7**
+- **Test: L1=3.926 --format=NeXus Detector: detector_I=6871.7**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/ISIS_TOSCA_preupgrade_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/ISIS_TOSCA_preupgrade_Mantid/README.md
@@ -32,6 +32,10 @@ Example: ISIS_TOSCA_preupgrade_Mantid.instr inc=Benzene_inc_CASTEP_MDANSE2018.sq
 Example: ISIS_TOSCA_preupgrade_Mantid.instr inc=Benzene_inc_CASTEP_MDANSE2018.sqw eventmode=1 --format=NeXus Detector: Sphere_I=0.686792
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/SNS_ARCS_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/SNS_ARCS_Mantid/README.md
@@ -21,6 +21,10 @@ B. Fultz,"Design and operation of the wide angular-range chopper spectrometer AR
 Spallation Neutron Source", Review of Scientific Instruments, 83 , 015114 (2012)</ul>
 ```
 
+## Examples
+
+- **Test: Fermi_nu=420 Detector: Full_cyl_I=235445**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/Tools_ONION/README.md
+++ b/mcstas-comps/examples/Mantid/Tools_ONION/README.md
@@ -22,6 +22,10 @@ For an example on how to analyze the data, see the 'Onion_analyzerScript.py' ava
 Acceptable statistics can be achieved by running the simulation with 1E7 neutrons (output file: ~400MB)
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/templateSANS2_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/templateSANS2_Mantid/README.md
@@ -16,6 +16,13 @@ Very simple test instrument for the SANS_spheres2 component, derived / simplifie
 H. Frielinghaus SANS_benchmark2
 ```
 
+## Examples
+
+- **Test: lambda=6 Detector: detectorSANS_I=0.201795**
+- **Test: lambda=6 frac_dir=0.4 Detector: detectorDB_I=66.6933**
+- **Test: lambda=6 --format=NeXus Detector: detectorSANS_I=0.201795**
+- **Test: lambda=6 frac_dir=0.4 --format=NeXus Detector: detectorDB_I=66.6933**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/templateSANS_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/templateSANS_Mantid/README.md
@@ -23,6 +23,11 @@ Needed steps:
 3) mcrun templateSANS_Mantid -n1e6 --format=NeXus
 ```
 
+## Examples
+
+- **Test: lambda=6 Detector: PSDrad_I=105000000**
+- **Test: lambda=6 --format=NeXus Detector: PSDrad_I=105000000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/templateSasView_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/templateSasView_Mantid/README.md
@@ -32,6 +32,10 @@ b) Run Mantid algorithm: 'ConvertUnits' using the 'wavelenth' and 'elastic' opti
 c) Run Mantid algorithm: 'Qxy' using the options 'MaxQxy=0.6', 'DeltaQ=0.003', 'SolidAngleWeighting=False'
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Mantid/templateVanadiumMultipleScat_Mantid/README.md
+++ b/mcstas-comps/examples/Mantid/templateVanadiumMultipleScat_Mantid/README.md
@@ -17,6 +17,10 @@ Instrument demonstrating how to bring multiple scattering information from
 a McStas simulation to Mantid (using NeXus output).
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/NCrystal/NCrystal_example/README.md
+++ b/mcstas-comps/examples/NCrystal/NCrystal_example/README.md
@@ -32,6 +32,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
+## Examples
+
+- **Test: sample_cfg="Y2O3_sg206_Yttrium_Oxide.ncmat;density=0.6x" Detector: powder_pattern_detc_I=4.4e-11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/NCrystal/Union_NCrystal_example/README.md
+++ b/mcstas-comps/examples/NCrystal/Union_NCrystal_example/README.md
@@ -18,6 +18,10 @@ monochromator and samples are described via NCrystal_sample components. Here,
 they are both described via Union components.
 ```
 
+## Examples
+
+- **Test: Detector: powder_pattern_detc_I=1.55e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/NCrystal/Union_NCrystal_mix_example/README.md
+++ b/mcstas-comps/examples/NCrystal/Union_NCrystal_mix_example/README.md
@@ -19,6 +19,10 @@ the monochromator is described via a Union components, but the sample is still
 an NCrystal_sample component.
 ```
 
+## Examples
+
+- **Test: Detector: powder_pattern_detc_I=1.53e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Necsa/SAFARI_MPISI/README.md
+++ b/mcstas-comps/examples/Necsa/SAFARI_MPISI/README.md
@@ -15,6 +15,10 @@
 Necsa Neutron Strain Scanner located at beam port 5 of the SAFARI-1 research reactor, South Africa
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Necsa/SAFARI_PITSI/README.md
+++ b/mcstas-comps/examples/Necsa/SAFARI_PITSI/README.md
@@ -15,6 +15,10 @@
 Necsa Neutron Powder Diffractometer located at beam port 5 of the SAFARI-1 research reactor, South Africa
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/PSI/PSI_DMC/README.md
+++ b/mcstas-comps/examples/PSI/PSI_DMC/README.md
@@ -20,6 +20,10 @@ using this instrumentfile, with SHIFT=0 and 0.1. This will displace the detector
 a bin-width, which is a standard procedure at the DMC diffractometer
 ```
 
+## Examples
+
+- **Test: lambda=2.5666 Detector: Detector_I=7.5965E+02**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/PSI/PSI_DMC_simple/README.md
+++ b/mcstas-comps/examples/PSI/PSI_DMC_simple/README.md
@@ -20,6 +20,10 @@ using this instrumentfile, with SHIFT=0 and 0.1. This will displace the detector
 a bin-width, which is a standard procedure at the DMC diffractometer
 ```
 
+## Examples
+
+- **Test: lambda=2.5666 Detector: Detector_I=7.5965E+02**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/PSI/PSI_Focus/README.md
+++ b/mcstas-comps/examples/PSI/PSI_Focus/README.md
@@ -15,6 +15,11 @@
 This instrument is a model of the FOCUS Spectrometer at PSI, Villigen, CH.
 ```
 
+## Examples
+
+- **Test: lambda=3.4 Detector: PSD_Fermi1_I=1.44416e+07**
+- Example: lambda=3.4 Detector: PSD_SAMPLE_I=1.58754E+05
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/PSI/PSI_ICON/README.md
+++ b/mcstas-comps/examples/PSI/PSI_ICON/README.md
@@ -19,6 +19,10 @@ The sample in the model is a series of metal sheets, each with different scattri
 instrument file was later used in the publication by Estrid B. Naver et. al., see links below.
 ```
 
+## Examples
+
+- **Test: PSI_ICON.instr -y Detector: VarDetectorZoom_I=852147**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.
@@ -28,6 +32,7 @@ Parameters in **boldface** are required; the others are optional.
 | lambda_min | AA | Minimum wavelength on wavelength monitors | 0.3 |
 | lambda_max | AA | Maximum wavelength on wavelength monitors | 10.0 |
 | eventmode | 1 | Flag to store neutron events with calculated sample-detector travel | 0 |
+| all_mons | 1 | Flag to enable all monitors in the instrument | 0 |
 | nx | 1 | Number of x-pixels, camera | 512 |
 | ny | 1 | Number of y-pixels, camera | 512 |
 | Lambda_Min | AA | Minimum wavelength produced from source | 4.1 |

--- a/mcstas-comps/examples/PSI/PSI_source/README.md
+++ b/mcstas-comps/examples/PSI/PSI_source/README.md
@@ -20,6 +20,10 @@ using this instrumentfile, with SHIFT=0 and 0.1. This will displace the detector
 a bin-width, which is a standard procedure at the DMC diffractometer
 ```
 
+## Examples
+
+- **Test: lambda=2.5666 Detector: PSDbefore_guides_I=2.54332e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/PSI/RITA-II/README.md
+++ b/mcstas-comps/examples/PSI/RITA-II/README.md
@@ -49,6 +49,10 @@ mcrun RITA-II.instr -n1e6 L0=3.418 BPL=0.97 BPH=1.03 EI=7 EF=5 SAMPLE=4 REP=10 Q
 Example: BPL=0.97 BPH=1.03 EI=5 EN=0 COLL_MS=40 SAMPLE=1 OUTFILTER=0 REP=10 Detector: psd_detector_I=216.427
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Risoe/TAS1_C1/README.md
+++ b/mcstas-comps/examples/Risoe/TAS1_C1/README.md
@@ -22,6 +22,10 @@ Here it is used as a diffractometer for monochromator rocking curves. The
 detector is at the sample position.
 ```
 
+## Examples
+
+- **Test: PHM=-37.077 Detector: sng_I=0.000429426**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Risoe/TAS1_C1_Tilt/README.md
+++ b/mcstas-comps/examples/Risoe/TAS1_C1_Tilt/README.md
@@ -22,6 +22,10 @@ Here it is used as a diffractometer for a collimator tilt alignment. The
 detector is at the sample position and there is no analyzer.
 ```
 
+## Examples
+
+- **Test: TTM=-74 Detector: sng_I=0.000405056**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Risoe/TAS1_Diff_Powder/README.md
+++ b/mcstas-comps/examples/Risoe/TAS1_Diff_Powder/README.md
@@ -23,6 +23,10 @@ Here it is used as a diffractometer for an alignment study. The
 sample is a powder and there is no analyzer.
 ```
 
+## Examples
+
+- **Test: PHM=-37.077 Detector: sng_I=4.50892e-07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Risoe/TAS1_Diff_Slit/README.md
+++ b/mcstas-comps/examples/Risoe/TAS1_Diff_Slit/README.md
@@ -23,6 +23,10 @@ Here it is used as a diffractometer for a collimation alignment study. The
 sample is a slit and there is no analyzer.
 ```
 
+## Examples
+
+- **Test: C1=30 TT=0 Detector: sng_I=2e-5**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Risoe/TAS1_Diff_Vana/README.md
+++ b/mcstas-comps/examples/Risoe/TAS1_Diff_Vana/README.md
@@ -23,6 +23,10 @@ Here it is used as a diffractometer for an alignment study. The
 sample is a vanadium cylinder and there is no analyzer.
 ```
 
+## Examples
+
+- **Test: PHM=-37.077 Detector: sng_I=1.95173e-09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Risoe/TAS1_Powder/README.md
+++ b/mcstas-comps/examples/Risoe/TAS1_Powder/README.md
@@ -21,6 +21,10 @@ first detailed work performed with the McStas package.
 The sample is a powder and the analyzer is a single plate.
 ```
 
+## Examples
+
+- **Test: PHM=-37.077 Detector: sng_I=2.26723e-07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Risoe/TAS1_Vana/README.md
+++ b/mcstas-comps/examples/Risoe/TAS1_Vana/README.md
@@ -21,6 +21,10 @@ first detailed work performed with the McStas package.
 The sample is a vanadium and the analyzer is a single plate.
 ```
 
+## Examples
+
+- **Test: PHM=-37.077 Detector: sng_I=1.11099e-09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SINE2020/McStas_Isotropic_Sqw/README.md
+++ b/mcstas-comps/examples/SINE2020/McStas_Isotropic_Sqw/README.md
@@ -23,6 +23,10 @@ The default material is liquid Rb as a cylinder of radius 0.01 m x height 0.07 m
 Example: McStas_Isotropic_Sqw Sqw_coh=Rb_liq_coh.sqw  Sqw_inc=Rb_liq_inc.sqw radius=0.01 yheight=0.07
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SINE2020/McStas_PowderN/README.md
+++ b/mcstas-comps/examples/SINE2020/McStas_PowderN/README.md
@@ -23,6 +23,10 @@ The default material is Al as a cylinder of radius 0.01 m x height 0.07 m
 Example: McStas_PowderN reflections=Al.lau radius=0.01 yheight=0.07
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SINE2020/McStas_Single_crystal/README.md
+++ b/mcstas-comps/examples/SINE2020/McStas_Single_crystal/README.md
@@ -23,6 +23,10 @@ The default material is Al as a cylinder of radius 0.01 m x height 0.02 m
 Example: McStas_Single_crystal reflections=Al.lau radius=0.01 yheight=0.02
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SNS/Gallmeier_SNS_decoupled_poisoned/README.md
+++ b/mcstas-comps/examples/SNS/Gallmeier_SNS_decoupled_poisoned/README.md
@@ -15,6 +15,10 @@
 Simple instrumentfile for estimating SNS brilliance, moderator is a the Gallmeier SNS_source_analytic applying Ikeda-Carpenter vs. Pade function fits to MCNPX tables.
 ```
 
+## Examples
+
+- **Test: filename=a1Gw2-2-f5_fit_fit.dat Detector: Brillmon_I=5.51519e+12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SNS/Granroth_SNS_decoupled_poisoned/README.md
+++ b/mcstas-comps/examples/SNS/Granroth_SNS_decoupled_poisoned/README.md
@@ -15,6 +15,10 @@
 Simple instrumentfile for estimating SNS brilliance, moderator is a the Granroth SNS_source applying linear interpolation in MCNPX tables.
 ```
 
+## Examples
+
+- **Test: filename=source_sct091_tu_02_1.dat Detector: Brillmon_I=7.11736e+12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SNS/Mezei_SNS_decoupled_poisoned/README.md
+++ b/mcstas-comps/examples/SNS/Mezei_SNS_decoupled_poisoned/README.md
@@ -17,6 +17,10 @@ ESCRIPTION
 Simple instrumentfile for estimating SNS brilliance, moderator is a rescaled ESS short-pulsed Mezei description.
 ```
 
+## Examples
+
+- **Test: -y Detector: Brillmon_I=1.178e+13**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SNS/SNS_ARCS/README.md
+++ b/mcstas-comps/examples/SNS/SNS_ARCS/README.md
@@ -21,6 +21,10 @@ B. Fultz,"Design and operation of the wide angular-range chopper spectrometer AR
 Spallation Neutron Source", Review of Scientific Instruments, 83 , 015114 (2012)</ul>
 ```
 
+## Examples
+
+- **Test: -y Detector: Full_cyl_I=235445**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SNS/SNS_BASIS/README.md
+++ b/mcstas-comps/examples/SNS/SNS_BASIS/README.md
@@ -40,6 +40,10 @@ hollow cylindrical sample. One Arm Component is used to place the Analyser Compo
 defined as ROT1.
 ```
 
+## Examples
+
+- **Test: mcrun BASIS_guide.instr Lam=6.4 Detector: Guide_end_PSD_I=8.1e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SNS/SNS_analytic_test/README.md
+++ b/mcstas-comps/examples/SNS/SNS_analytic_test/README.md
@@ -16,6 +16,10 @@ Simple test instrument for the SNS_source component.
 Refer to SNS <A href="http://neutrons.ornl.gov/instrument_systems/components/moderators.shtml">Source files.</A>
 ```
 
+## Examples
+
+- **Test: -y Detector: det_I=8.51297e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/SNS/SNS_test/README.md
+++ b/mcstas-comps/examples/SNS/SNS_test/README.md
@@ -16,6 +16,10 @@ Simple test instrument for the SNS_source component.
 Refer to SNS <A href="http://neutrons.ornl.gov/instrument_systems/components/moderators.shtml">Source files.</A>
 ```
 
+## Examples
+
+- **Test: filename="source_sct091_tu_02_1.dat" Detector: det_I=9.89304e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/TRIGA/RTP_DIF/README.md
+++ b/mcstas-comps/examples/TRIGA/RTP_DIF/README.md
@@ -15,6 +15,10 @@
 
 ```
 
+## Examples
+
+- **Test: mcrun RTP_DIF.instr lambda=2.36 Detector: det_big_I=123752**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/TRIGA/RTP_Laue/README.md
+++ b/mcstas-comps/examples/TRIGA/RTP_Laue/README.md
@@ -16,6 +16,10 @@ This is a radiography installed on a radial beam port 3 at the Reactor TRIGA
 PUSPATI (RTP). It uses a thermal beam port.
 ```
 
+## Examples
+
+- **Test: -y Detector: image_plate_scattered_I=179284**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/TRIGA/RTP_NeutronRadiography/README.md
+++ b/mcstas-comps/examples/TRIGA/RTP_NeutronRadiography/README.md
@@ -17,6 +17,10 @@ PUSPATI (RTP). It uses the thermal beam port 3.
 The sample is made of 2 concentric cylinders made of Cu and Fe.
 ```
 
+## Examples
+
+- **Test: theta=20 phi=10 Detector: image_plate_eff_I=9.54919e+07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/TRIGA/RTP_SANS/README.md
+++ b/mcstas-comps/examples/TRIGA/RTP_SANS/README.md
@@ -27,6 +27,10 @@ and SANS set-up. The Be filter is in the monochromator block.
 Example: mcrun RTP_SANS.instr lambda=5
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/TUDelft/SEMSANS_Delft/README.md
+++ b/mcstas-comps/examples/TUDelft/SEMSANS_Delft/README.md
@@ -26,6 +26,14 @@ These parameter and the sphere radius match now with the magnetic fields below t
 A pretty high number of neutrons is needed to get good statistics in the fine position sensitive detector.
 ```
 
+## Examples
+
+- **Test: -y Detector: det_I=7.8145e-08**
+- 
+- Other examples:
+- SESANS_Delft -n 100000000 -N 31 L0=2.165 DL=0.02 By=0,0.0468 AnaSign=1
+- SESANS_Delft -n 100000000 -N 31 L0=2.165 DL=0.02 By=0,0.0468 AnaSign=-1
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/TUDelft/SEMSANS_instrument/README.md
+++ b/mcstas-comps/examples/TUDelft/SEMSANS_instrument/README.md
@@ -15,6 +15,11 @@
 SEMSANS instrument with 2 isosceles triangular field coils
 ```
 
+## Examples
+
+- **Test: -y Detector: TOF_det_I=2.87073e-09**
+- **Test: debug=1 Detector: TOF_det_I=2.87073e-09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.
@@ -59,6 +64,7 @@ Parameters in **boldface** are required; the others are optional.
 | detector_pos | m | Position of detector | 6.957000e+00 |
 | tlow | mu-s | tmin of detector | 2.190523040779461e+03 |
 | thigh | mu-s | tmax of detector | 1.214744595341338e+04 |
+| debug | 1 | Debug flag - when enabled more monitor outputs appear | 0 |
 
 ## Links
 

--- a/mcstas-comps/examples/TUDelft/SESANS_Delft/README.md
+++ b/mcstas-comps/examples/TUDelft/SESANS_Delft/README.md
@@ -26,6 +26,12 @@ The foil-angle, thickness and wavelength yield now matched parameters to have th
 These parameter and the sphere radius match now with the magnetic fields below to get a good measurement range.
 ```
 
+## Examples
+
+- **Test: -y Detector: det_I=2.2537e-07**
+- 
+- Scan Example: SESANS_Delft -n 1000000 -N 31 L0=2.165 DL=0.02 By=0,0.0468
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/BTsimple/README.md
+++ b/mcstas-comps/examples/Templates/BTsimple/README.md
@@ -15,6 +15,10 @@
 Example instrument showing how to calculate brilliance transfer using L_monitor's and WHEN statements
 ```
 
+## Examples
+
+- **Test: -n1e7 BTsimple.instr lambda=10 Detector: BTransfer_I=75.4758**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/Demo_shape_primitives/README.md
+++ b/mcstas-comps/examples/Templates/Demo_shape_primitives/README.md
@@ -16,6 +16,10 @@ This instrument will display a cylinder, a sphere, and a box,
 when run with mcdisplay. Otherwise does nothing.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/Demo_shape_primitives_simple/README.md
+++ b/mcstas-comps/examples/Templates/Demo_shape_primitives_simple/README.md
@@ -16,6 +16,10 @@ This instrument will display a cylinder, a sphere, and a box,
 when run with mcdisplay. Otherwise does nothing.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/TOF_Reflectometer/README.md
+++ b/mcstas-comps/examples/Templates/TOF_Reflectometer/README.md
@@ -21,6 +21,10 @@ Example: mcrun Reflectometer.instr -n1e10 directbeam=1,thetasample=0.4,Qmin=0,Qm
 Example: mcrun Reflectometer.instr -n1e10 directbeam=0,thetasample=0.4,Qmin=0,Qmax=0.15 -d reflectedbeam
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/Test_SasView_bcc_paracrystal_aniso/README.md
+++ b/mcstas-comps/examples/Templates/Test_SasView_bcc_paracrystal_aniso/README.md
@@ -18,6 +18,10 @@ Very simple test instrument for the SasView_bcc_paracrystal component
 Example: model_scale=1 Detector: detector_I=83.8252
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/Test_SasView_guinier/README.md
+++ b/mcstas-comps/examples/Templates/Test_SasView_guinier/README.md
@@ -15,6 +15,10 @@
 Very simple test instrument for the SasView_guinier component
 ```
 
+## Examples
+
+- **Test: model_scale=1 Detector: detector_I=0.445598**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/Tomography/README.md
+++ b/mcstas-comps/examples/Templates/Tomography/README.md
@@ -23,6 +23,10 @@ and a Unix/Mac) in the tools/matlab folder to reconstruct a 3D volume of the obj
 isosurface to do thresholding for extraction of the object surface.
 ```
 
+## Examples
+
+- **Test: omega=0 Detector: monitor_I=2.23492e-09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/mini/README.md
+++ b/mcstas-comps/examples/Templates/mini/README.md
@@ -15,6 +15,10 @@
 Minimalistic instrument for testing GPU implementation
 ```
 
+## Examples
+
+- **Test: mini.instr dummy=0 Detector: detector_I=345.995**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/template/README.md
+++ b/mcstas-comps/examples/Templates/template/README.md
@@ -24,6 +24,10 @@ once your instrument is written and functional:
 sensible parameter set.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateDIFF/README.md
+++ b/mcstas-comps/examples/Templates/templateDIFF/README.md
@@ -35,6 +35,10 @@ Cu       220 DM=1.278 AA
 Cu       111 DM=2.095 AA
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: Diff_BananaPSD_I=153038**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateLaue/README.md
+++ b/mcstas-comps/examples/Templates/templateLaue/README.md
@@ -16,6 +16,11 @@ A single crystal sample is illuminated with a white cold beam.
 Based on a Laue tutorial written by K. Nielsen, Feb 7, 2000.
 ```
 
+## Examples
+
+- **Test: templateLaue reflections=YBaCuO.lau Detector: det_I=1.14351e+07**
+- **Test: templateLaue reflections=leucine.lau Detector: det_I=4.63548e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateNMX/README.md
+++ b/mcstas-comps/examples/Templates/templateNMX/README.md
@@ -17,6 +17,11 @@ A single crystal sample is illuminated with a white cold beam.
 Based on a Laue tutorial written by K. Nielsen, Feb 7, 2000.
 ```
 
+## Examples
+
+- **Test: templateNMX reflections=Rubredoxin.lau Detector: det_I=7.8e4**
+- Example: templateNMX reflections=PPase_D_P1.lau Detector: det_I=29.6512
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateNMX_TOF/README.md
+++ b/mcstas-comps/examples/Templates/templateNMX_TOF/README.md
@@ -22,6 +22,10 @@ A single crystal sample is illuminated with a white cold beam.
 Based on a Laue tutorial written by K. Nielsen, Feb 7, 2000.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateSANS/README.md
+++ b/mcstas-comps/examples/Templates/templateSANS/README.md
@@ -16,6 +16,10 @@ etc. Will be developed further at later time.*
 Very simple test instrument for the Sans_spheres component
 ```
 
+## Examples
+
+- **Test: lambda=6 Detector: detector_I=0.556137**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateSANS2/README.md
+++ b/mcstas-comps/examples/Templates/templateSANS2/README.md
@@ -16,6 +16,11 @@ Very simple test instrument for the SANS_spheres2 component, derived / simplifie
 H. Frielinghaus SANS_benchmark2
 ```
 
+## Examples
+
+- **Test: lambda=6 Detector: detectorSANS_I=0.201795**
+- **Test: lambda=6 frac_dir=1 Detector: detectorDB_I=66.6933**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateSANS_MCPL/README.md
+++ b/mcstas-comps/examples/Templates/templateSANS_MCPL/README.md
@@ -19,6 +19,10 @@ Very simple test instrument for the Sans_spheres component
 Example: lambda=6 Detector: detector_I=6.56942e-17
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateSasView/README.md
+++ b/mcstas-comps/examples/Templates/templateSasView/README.md
@@ -20,6 +20,12 @@ Select sample model with 'model_index':
 47= SasView_parallelepiped
 ```
 
+## Examples
+
+- **Test: model_index=1 Ncount=1e6 par1=4 par2=1 par3=40 par4=20 par5=400 Detector: detector_I=5e6**
+- **Test: model_index=3 Ncount=1e6 par1=220 par2=0.06 par3=40 par4=4 par5=1 Detector: detector_I=3.3e4**
+- **Test: model_index=47 Ncount=1e6 par1=4 par2=2 par3=35 par4=75 par5=400 Detector: detector_I=2.5e6**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateTAS/README.md
+++ b/mcstas-comps/examples/Templates/templateTAS/README.md
@@ -52,6 +52,11 @@ WA=0.16, HA=0.08, RAH=-1, RAV=-1, DA=2.087, NHA=15, NVA=15,
 L1=2.33
 ```
 
+## Examples
+
+- **Test: QM=1 Sqw_coh=V.lau Detector: D7_SC3_1D_I=3.0e+08**
+- **Test: QM=1 Sqw_coh=V.lau Detector: He3H_I=260**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/templateTOF/README.md
+++ b/mcstas-comps/examples/Templates/templateTOF/README.md
@@ -21,6 +21,11 @@ active when using a spherical sample shape (height=0).
 detector is 2.5 m diameter, with 40 cm heigh, 1 inch diameter detector tubes.
 ```
 
+## Examples
+
+- **Test: E0=4.94 Detector:  M_single_coh_I=5e-11**
+- **Test: E0=33 dE=1.07 dt=9.6e-6 Detector: M_single_coh_I=6.6e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Templates/template_simple/README.md
+++ b/mcstas-comps/examples/Templates/template_simple/README.md
@@ -17,6 +17,10 @@ instrument description
 Example: parameters=values
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_KDSource/README.md
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_KDSource/README.md
@@ -19,6 +19,13 @@ Uses an KDSource XML description of bandwidths to apply when resampling the
 base MCPL input from samples.mcpl.gz
 ```
 
+## Examples
+
+- **Test: nloop=1 Detector: PSDMon2_I=4056**
+- **Test: nloop=10 Detector: PSDMon2_I=4056**
+- **Test: nloop=100 Detector: PSDMon2_I=4056**
+- **Test: nloop=1000 Detector: PSDMon2_I=4056**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input/README.md
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input/README.md
@@ -15,6 +15,11 @@
 This is a unit test for the MCPL_input component.
 ```
 
+## Examples
+
+- **Test: -n1e3 repeat=1 MCPLFILE=voutput.mcpl.gz     Detector: m1_I=2.42284e+11**
+- **Test: -n1e3 repeat=1 MCPLFILE=voutput_legacy.mcpl Detector: m1_I=2.42284e+11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input_once/README.md
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_input_once/README.md
@@ -17,6 +17,11 @@ This is a unit test for the MCPL_input_once component, which differs from the or
 2) No implementation of "repetition", if further stats is needed downstream, SPLIT should be applied
 ```
 
+## Examples
+
+- **Test: -n1e3 v_smear=0.1 MCPLFILE=voutput.mcpl.gz Detector: m1_I=2.42284e+11**
+- **Test: -n1e3 v_smear=0.1 MCPLFILE=voutput_legacy  Detector: m1_I=2.42284e+11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_output/README.md
+++ b/mcstas-comps/examples/Tests_MCPL_etc/Test_MCPL_output/README.md
@@ -15,6 +15,10 @@
 This is a unit test for the MCPL_output component.
 ```
 
+## Examples
+
+- **Test: Ncount=1e3 Detector: m1_I=2.42284e+11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_RNG/Test_RNG_rand01/README.md
+++ b/mcstas-comps/examples/Tests_RNG/Test_RNG_rand01/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=1000 Detector: PSD_I=1000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_RNG/Test_RNG_randnorm/README.md
+++ b/mcstas-comps/examples/Tests_RNG/Test_RNG_randnorm/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=0.999999999**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_RNG/Test_RNG_randpm1/README.md
+++ b/mcstas-comps/examples/Tests_RNG/Test_RNG_randpm1/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=1000 Detector: PSD_I=1000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_RNG/Test_RNG_randtriangle/README.md
+++ b/mcstas-comps/examples/Tests_RNG/Test_RNG_randtriangle/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=1.0**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_RNG/Test_RNG_randvec_target_circle/README.md
+++ b/mcstas-comps/examples/Tests_RNG/Test_RNG_randvec_target_circle/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect/README.md
+++ b/mcstas-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect_angular/README.md
+++ b/mcstas-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect_angular/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: Div_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/README.md
+++ b/mcstas-comps/examples/Tests_grammar/README.md
@@ -19,6 +19,12 @@ Test instrument for GROUP of monitors using restore_neutron.
 3rd test: Adding a "catchall" arm recovers the intensity
 ```
 
+## Examples
+
+- **Test: mcrun Test_GROUP_restore catchall=0 Detector: Mon00_12_I=1.00e+06**
+- **Test: mcrun Test_GROUP_restore catchall=0 dim=3 Detector: psd_monitor_4pi_3m_I=4.22e+06**
+- **Test: mcrun Test_GROUP_restore catchall=1 dim=3 Detector: psd_monitor_4pi_3m_I=6.00e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/Test_GROUP/README.md
+++ b/mcstas-comps/examples/Tests_grammar/Test_GROUP/README.md
@@ -15,6 +15,11 @@
 Unit test for the GROUP logic
 ```
 
+## Examples
+
+- **Test: SIGNI=1  Detector: psd00_I=2e-08**
+- **Test: SIGNI=-1 Detector: psd00_I=2e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/Test_Jump_Iterate/README.md
+++ b/mcstas-comps/examples/Tests_grammar/Test_Jump_Iterate/README.md
@@ -16,6 +16,10 @@ A curved guide made of only two guide elements which are iterated with  slight
 rotation in between, to describe a long curved guide.
 ```
 
+## Examples
+
+- **Test: L=60 Detector: Mon_LambdaDX_Out_I=0.790318**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/Unittest_ALLOW_BACKPROP/README.md
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_ALLOW_BACKPROP/README.md
@@ -21,6 +21,12 @@ The second monitor is placed physically "earlier" than the first, but logically 
 2) With Backprop=1 the second monitor should measure a signal since backpropagation is allowed
 ```
 
+## Examples
+
+- **Test: Backprop=0 Detector: PSDcloser_I=0**
+- **Test: Backprop=0.5 Detector: PSDcloser_I=0.049**
+- **Test: Backprop=1 Detector: PSDcloser_I=0.099**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/Unittest_JUMP_ITERATE/README.md
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_JUMP_ITERATE/README.md
@@ -19,6 +19,12 @@ to the monitor. The particles have unit weight and hence the intensity scales
 with the simulated statistics. (Use input parameter Ncount for setting the stats).
 ```
 
+## Examples
+
+- **Test: Ncount=1000 jumps=10 Detector: PSD_I=10000**
+- **Test: Ncount=1000 jumps=20 Detector: PSD_I=20000**
+- **Test: Ncount=100000 jumps=10 Detector: PSD_I=1e6**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/Unittest_JUMP_WHEN/README.md
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_JUMP_WHEN/README.md
@@ -19,6 +19,11 @@ one source quadrant is repteated 'jumps' times. Resulting intensity should be:
 1 + 0.25*jumps;
 ```
 
+## Examples
+
+- **Test: jumps=10 Detector: PSD_I=3.5**
+- **Test: jumps=100 Detector: PSD_I=26**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/Unittest_SPLIT/README.md
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_SPLIT/README.md
@@ -17,6 +17,12 @@ SPLIT unittest.
 One unit of intensity is emitted from a 1x1 m.
 ```
 
+## Examples
+
+- **Test: SPLITS=1 Detector: PSD_I=1**
+- **Test: SPLITS=10 Detector: PSD_I=1**
+- **Test: SPLITS=100 Detector: PSD_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_grammar/Unittest_SPLIT_sample/README.md
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_SPLIT_sample/README.md
@@ -17,6 +17,24 @@ SPLIT unittest.
 One unit of intensity is emitted from a 1x1 m.
 ```
 
+## Examples
+
+- **Test: SAMPLE=1 SPLITS=1 Detector: PSD_I=1**
+- **Test: SAMPLE=1 SPLITS=10 Detector: PSD_I=10**
+- **Test: SAMPLE=1 SPLITS=100 Detector: PSD_I=100**
+- **Test: SAMPLE=2 SPLITS=1 Detector: PSD_I=1**
+- **Test: SAMPLE=2 SPLITS=10 Detector: PSD_I=10**
+- **Test: SAMPLE=2 SPLITS=100 Detector: PSD_I=100**
+- **Test: SAMPLE=3 SPLITS=1 Detector: PSD_I=0.999001**
+- **Test: SAMPLE=3 SPLITS=1 Detector: PSD_transmission_I=0.00071068**
+- **Test: SAMPLE=3 SPLITS=1 Detector: PSD_scattered_I=0.00182805**
+- **Test: SAMPLE=3 SPLITS=10 Detector: PSD_I=9.99001**
+- **Test: SAMPLE=3 SPLITS=10 Detector: PSD_transmission_I=0.007122**
+- **Test: SAMPLE=3 SPLITS=10 Detector: PSD_scattered_I=0.0183156**
+- **Test: SAMPLE=3 SPLITS=100 Detector: PSD_I=99.9001**
+- **Test: SAMPLE=3 SPLITS=100 Detector: PSD_transmission_I=0.070845**
+- **Test: SAMPLE=3 SPLITS=100 Detector: PSD_scattered_I=0.182056**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_monitors/Test_Cyl_monitors/README.md
+++ b/mcstas-comps/examples/Tests_monitors/Test_Cyl_monitors/README.md
@@ -15,6 +15,23 @@
 A test instrument to compare Monitor_nD output against basic 1D and 2D monitors.
 ```
 
+## Examples
+
+- **Test: Test_Cyl_monitors.instr lambda=5 Detector: PSD_I=4825.57**
+- **Test: Test_Cyl_monitors.instr lambda=5 Detector: CylMon_I=4825.57**
+- **Test: Test_Cyl_monitors.instr lambda=5 Detector: CylMonPSD_I=4825.57**
+- **Test: Test_Cyl_monitors.instr lambda=5 Detector: CylMonTOF_I=4825.57**
+- **Test: Test_Cyl_monitors.instr lambda=5 Detector: NDcyl_I=4825.57**
+- **Test: Test_Cyl_monitors.instr lambda=5 Detector: NDcylPSD_I=4825.57**
+- **Test: Test_Cyl_monitors.instr lambda=5 Detector: NDcylTOF_I=4825.57**
+- **Test: Test_Cyl_monitors.instr lambda=5 tz=0.05 Detector: PSD_I=2921.65**
+- **Test: Test_Cyl_monitors.instr lambda=5 tz=0.05 Detector: CylMon_I=2921.65**
+- **Test: Test_Cyl_monitors.instr lambda=5 tz=0.05 Detector: CylMonPSD_I=2921.65**
+- **Test: Test_Cyl_monitors.instr lambda=5 tz=0.05 Detector: CylMonTOF_I=2921.65**
+- **Test: Test_Cyl_monitors.instr lambda=5 tz=0.05 Detector: NDcyl_I=2921.65**
+- **Test: Test_Cyl_monitors.instr lambda=5 tz=0.05 Detector: NDcylPSD_I=2921.65**
+- **Test: Test_Cyl_monitors.instr lambda=5 tz=0.05 Detector: NDcylTOF_I=2921.65**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_monitors/Test_Monitor_nD/README.md
+++ b/mcstas-comps/examples/Tests_monitors/Test_Monitor_nD/README.md
@@ -15,6 +15,10 @@
 A test instrument to compare Monitor_nD output against basic 1D and 2D monitors.
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: PSD_mon_I=8.34136e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_monitors/Test_Monitor_nD_10_uservars/README.md
+++ b/mcstas-comps/examples/Tests_monitors/Test_Monitor_nD_10_uservars/README.md
@@ -15,6 +15,10 @@
 Instrument demonstrating 10 uservars available in Monitor_nD
 ```
 
+## Examples
+
+- **Test: NCount=1e3 Detector: Flex2D_I=1000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_monitors/Test_TOF_PSDmonitor_toQ/README.md
+++ b/mcstas-comps/examples/Tests_monitors/Test_TOF_PSDmonitor_toQ/README.md
@@ -18,6 +18,10 @@ The tested monitor is a 1-dimensional Q-monitor that calculates Q from "measured
 i.e. not from particle velocity parameters.
 ```
 
+## Examples
+
+- **Test: theta=0.91**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Al_windows/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Al_windows/README.md
@@ -26,6 +26,15 @@ Includes 3 models of increasing complexity / sophistication:
 (generated from CIF file COD / 1502689)
 ```
 
+## Examples
+
+- **Test: Window=1 thickness=0.001 Detector: OutputWL_I=0.099**
+- **Test: Window=2 thickness=0.001 Detector: OutputWL_I=0.099**
+- **Test: Window=3 thickness=0.001 Detector: OutputWL_I=0.099**
+- **Test: Window=1 thickness=0.005 Detector: OutputWL_I=0.098**
+- **Test: Window=2 thickness=0.005 Detector: OutputWL_I=0.098**
+- **Test: Window=3 thickness=0.005 Detector: OutputWL_I=0.098**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Collimator_Radial/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Collimator_Radial/README.md
@@ -18,6 +18,12 @@ The Exact_radial_coll contributed component also takes into account the absorbin
 blade thickness between slits, which decreases slightly intensity.
 ```
 
+## Examples
+
+- **Test: Collimator=1 Detector: BananaTheta_I=1.52649e-08**
+- **Test: Collimator=2 Detector: BananaTheta_I=1.41509e-08**
+- **Test: Collimator=3 Detector: BananaTheta_I=1.581e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Conics_pairs/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Conics_pairs/README.md
@@ -15,6 +15,11 @@
 Example instrument that shows some ways of using Conics_Ph and Conics_EH
 ```
 
+## Examples
+
+- **Test: Test_Conics_pairs OPTIC=1 Detector: psd_i_I=1.41346e-12**
+- **Test: Test_Conics_pairs OPTIC=2 fs=100000 Detector: psd_i_I=4.92971e-21**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_DiskChoppers/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_DiskChoppers/README.md
@@ -15,6 +15,11 @@
 Simple test instrument that compares the use of 2 DiskChoppers with one MultiDiskChopper
 ```
 
+## Examples
+
+- **Test: Test_DiskChoppers.instr chopper=0 Detector: Tofl_I=0.00277**
+- **Test: Test_DiskChoppers.instr chopper=1 Detector: Tofl_I=0.00277**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_DiskChoppers2/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_DiskChoppers2/README.md
@@ -16,6 +16,13 @@ Simple test instrument that compares DiskChoppers with a simple, rotating Slit.
 When ABSORBER is set, a slab of B4C is acts as absorbing medium.
 ```
 
+## Examples
+
+- **Test: Test_DiskChoppers.instr chopper=0 Detector: Tofl_I=0.0005**
+- **Test: Test_DiskChoppers.instr chopper=1 Detector: Tofl_I=0.0005**
+- **Test: Test_DiskChoppers.instr chopper=0 ABSORBER=1 Detector: Tofl_I=0.0007**
+- **Test: Test_DiskChoppers.instr chopper=1 ABSORBER=1 Detector: Tofl_I=0.0007**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Fermi/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Fermi/README.md
@@ -18,6 +18,13 @@ shows that all implementations are equivalent. However, approximating rotating
 guide are 30% faster than McStas Fermi chopper.
 ```
 
+## Examples
+
+- **Test: Fermi=1 Detector: Monitor2_xt_I=0.00051256**
+- **Test: Fermi=3 Detector: Monitor2_xt_I=0.00051377**
+- **Test: Fermi=4 Detector: Monitor2_xt_I=0.000572427**
+- **Test: Fermi=5 Detector: Monitor2_xt_I=0.00058003**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_FocalisationMirrors/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_FocalisationMirrors/README.md
@@ -19,6 +19,10 @@ images the focal point onto the detector.*
 Test instrument for the MirrorElli and MirrorPara components
 ```
 
+## Examples
+
+- **Test: G=1 Detector: monPSD_I=2.50457e-16**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Guides/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Guides/README.md
@@ -17,6 +17,18 @@ contributed components. It shows that all implementations are equivalent,
 except the Guide_honeycomb which has a different geometry.
 ```
 
+## Examples
+
+- **Test: Guide=1 Detector: Monitor2_xy_I=0.00726875**
+- **Test: Guide=2 Detector: Monitor2_xy_I=0.00725213**
+- **Test: Guide=3 Detector: Monitor2_xy_I=0.00727304**
+- **Test: Guide=4 Detector: Monitor2_xy_I=0.00721742**
+- **Test: Guide=5 Detector: Monitor2_xy_I=0.00721742**
+- **Test: Guide=6 Detector: Monitor2_xy_I=0.00721742**
+- **Test: Guide=7 Detector: Monitor2_xy_I=0.00724912**
+- **Test: Guide=8 Detector: Monitor2_xy_I=0.00683072**
+- **Test: Guide=9 Detector: Monitor2_xy_I=0.00724912**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Guides_Curved/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Guides_Curved/README.md
@@ -16,6 +16,13 @@ Cross comparison of curved Guide components, using McStas and
 contributed components. It shows that all implementations are to good approximation equivalent.
 ```
 
+## Examples
+
+- **Test: Guide=1 Detector: Monitor2_xy1_I=0.00224746**
+- **Test: Guide=2 Detector: Monitor2_xy2_I=0.00177338**
+- **Test: Guide=3 Detector: Monitor2_xy3_I=0.00186028**
+- **Test: Guide=4 Detector: Monitor2_xy4_I=0.00168562**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Lens/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Lens/README.md
@@ -17,6 +17,14 @@
 
 ```
 
+## Examples
+
+- %Description
+- 
+- Very simple setup with 30 stacked lenses which focus a cold neutron,
+- non diverging beam (ideal case). A set of PSD monitors is positioned
+- around the focusing point to show the beam spot.
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent/README.md
@@ -15,6 +15,10 @@
 Basic test instrument for the Monochromator_bent component
 ```
 
+## Examples
+
+- **Test: Test_Monochromator_bent.instr mono_mos=0 Detector: PSD_exit_monitor_I=0.543355**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent_complex/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Monochromator_bent_complex/README.md
@@ -18,6 +18,11 @@ Daniel Gabriel Mazzone (daniel.mazzone@psi.ch) and Jakob Lass
 component in an instrument draft.
 ```
 
+## Examples
+
+- **Test: Test_Monochromator_bent_complex.instr mos=60 Detector: E_PSD_mon_end_I=0.000215194**
+- **Test: Test_Monochromator_bent_complex.instr mos=60 use_single_plane=1 Detector: E_PSD_mon_end_I=0.000215194**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Monochromators/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Monochromators/README.md
@@ -18,6 +18,25 @@ It shows that implementations are equivalent.
 PG 002 oriented examples:
 ```
 
+## Examples
+
+- **Test: Mono=1 Detector: psd1_I=8.9e-05**
+- **Test: Mono=2 Detector: psd1_I=8.9e-05**
+- **Test: Mono=3 Detector: psd1_I=8.9e-05**
+- **Test: Mono=4 Detector: psd1_I=8.9e-05**
+- **Test: Mono=5 Detector: psd1_I=8.9e-05**
+- **Test: Mono=6 Detector: psd1_I=1.0e-04**
+- **Test: Mono=6 PG=1 Detector: psd1_I=1.3e-04**
+- **Test: Mono=6 powder=1 Moz=60 Detector: psd1_I=4.5e-07**
+- **Test: Mono=6 ay=2.13389 az=-1.232 bz=2.464 cx=6.711 Detector: psd1_I=1.0e-04**
+- **Test: Mono=6 ay=2.94447 by=1.47224 bz=2.54999 cx=0.936252 recip=1 Detector: psd1_I=1.0e-04**
+- **Test: Mono=7 ay=2.94447 by=1.47224 bz=2.54999 cx=0.936252 recip=1 Detector: psd1_I=9.6e-05**
+- SiO2 lattice orientation examples:
+- Example: Mono=1 DM=4.25504 lmin=0.1 lmax=7.0 lambda=6.0
+- Example: Mono=6 DM=4.25504 lmin=0.1 lmax=7.0 lambda=6.0 reflections=SiO2_quartza.lau  ax=4.3271 az=-2.49825 bz=4.9965 cy=-5.4543
+- Example: Mono=6 DM=4.25504 lmin=0.1 lmax=7.0 lambda=6.0 reflections=SiO2_quartza.lau recip=1 ax=1.45205 bx=0.726027 bz=1.25752 cy=-1.15197
+- Example: Mono=7 DM=4.25504 lmin=0.1 lmax=7.0 lambda=6.0 NXrefs=SiO2-alpha_sg154_AlphaQuartz.ncmat recip=1 ax=1.45205 bx=0.726027 bz=1.25752 cy=-1.15197
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_NMO/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_NMO/README.md
@@ -16,6 +16,10 @@ Implements a test instrument for the component FlatEllipse_finite_mirror,
 implementing Nested Mirror Optic (NMO) as suggested by B&ouml;ni et al.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_PSD_Detector/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_PSD_Detector/README.md
@@ -16,6 +16,10 @@ Test for PSD_Detector component showing charge drift
 and parallax effect when rotating detector with e.g. 'rot=10'
 ```
 
+## Examples
+
+- **Test: rot=0 Detector: mydet_I=3.57344e-18**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Pol_Bender_Vs_Guide_Curved/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Pol_Bender_Vs_Guide_Curved/README.md
@@ -18,6 +18,10 @@ The intensity on the monitor should be roughly 0.000228
 with mean 8.65+-0.62 AA.
 ```
 
+## Examples
+
+- **Test: guideLength=10 Detector: psdGuide_I=0.0022**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Rotator/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Rotator/README.md
@@ -17,6 +17,10 @@ Unittest for Rotator/Derotator
 Example: mcrun test.instr <parameters=values>
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Selectors/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Selectors/README.md
@@ -16,6 +16,11 @@ Cross comparison of Selector components, using McStas and
 contributed components. It shows that all implementations are equivalent.
 ```
 
+## Examples
+
+- **Test: selector=1 Detector: VS_Mon_I=0.009**
+- **Test: selector=2 Detector: VS_Mon_I=0.0093**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_StatisticalChopper/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_StatisticalChopper/README.md
@@ -16,6 +16,10 @@ This instrument is a simple model of a kind of TOF instrument, with powder sampl
 and statistical chopper. The de-correlation is also performed in a dedicated monitor.
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: time_mon2_I=3.44e-12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_Vertical_Bender/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_Vertical_Bender/README.md
@@ -15,6 +15,10 @@
 Quick and dirty test instrument write-up for Vertical_Bender.
 ```
 
+## Examples
+
+- **Test: Test_Vertical_Bender.instr -g curvature=10000 Detector: Pout_I=0.00134901**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_filters/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_filters/README.md
@@ -17,6 +17,13 @@ Where applicable, the temperature is set to 80K (corresponding to the header
 of the Be.trm file used in Filter_gen
 ```
 
+## Examples
+
+- **Test: Filter=0 Detector: L_out_I=2183.87**
+- **Test: Filter=1 T=80 Detector: L_out_I=1875.02**
+- **Test: Filter=2 Detector: L_out_I=1868.5**
+- **Test: Filter=3 Detector: L_out_I=2011.26**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_optics/Test_focus/README.md
+++ b/mcstas-comps/examples/Tests_optics/Test_focus/README.md
@@ -21,6 +21,10 @@ For mono_curvh=0, mono_curvv=0 the monochromator is flat.
 For mono_curvh=-1, mono_curvv=-1 optimal horizontal and vertical focusing is chosen.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_other/test_File/README.md
+++ b/mcstas-comps/examples/Tests_other/test_File/README.md
@@ -16,6 +16,10 @@ input-files as METADATA blocks*
 
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/He3_spin_filter/README.md
+++ b/mcstas-comps/examples/Tests_polarization/He3_spin_filter/README.md
@@ -17,6 +17,13 @@ For the values POLHE=.8 and .5 results comply with "Batz, M et al. “(3) He Spi
 Journal of research of the National Institute of Standards and Technology vol. 110,3 293-8. 1 Jun. 2005, doi:10.6028/jres.110.042"
 ```
 
+## Examples
+
+- **Test: POLHE=0.5 Detector: postpol_monitor_flux_I=1.8e-23**
+- **Test: POLHE=0.8 Detector: postpol_monitor_flux_I=2.3e-23**
+- **Test: POLHE=0.5 box=1 Detector: postpol_monitor_flux_I=1.8e-23**
+- **Test: POLHE=0.8 box=1 Detector: postpol_monitor_flux_I=2.3e-23**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/SE_example/README.md
+++ b/mcstas-comps/examples/Tests_polarization/SE_example/README.md
@@ -21,6 +21,10 @@ MeanPolLambda_montior is used to monitor beam polarisation.
 Example: mcrun SE_example.instr dBz=-0.0001,0.0001 -N41 -n1e5
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/SE_example2/README.md
+++ b/mcstas-comps/examples/Tests_polarization/SE_example2/README.md
@@ -21,6 +21,10 @@ MeanPolLambda_montior is used to monitor beam polarisation.
 Example: mcrun SE_example2.instr dBz=-0.0001,0.0001 -N41 -n1e5
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Supermirror_thin_substrate/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Supermirror_thin_substrate/README.md
@@ -15,6 +15,10 @@
 Test instrument for a thin-substrate supermirrror (component SupermirrorFlat)
 ```
 
+## Examples
+
+- **Test: Supermirror_thin_substrate.instr src_x=0.01 Detector: spectrum_I=4.11233e-05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Magnetic_Constant/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Magnetic_Constant/README.md
@@ -20,6 +20,13 @@ This instrument matches the example: Test_Pol_MSF (under tests)
 made with the old component: Pol_constBfield
 ```
 
+## Examples
+
+- **Test: ROT_ANGLE=180 Detector: pollambdaMonitor2z_I=0.0768972**
+- **Test: ROT_ANGLE=180 ONOFF=1 Detector: pollambdaMonitor2z_I=0.0768972**
+- **Test: ROT_ANGLE=180 ONOFF=2 Detector: pollambdaMonitor2z_I=0.0768972**
+- **Test: ROT_ANGLE=180 ONOFF=3 Detector: pollambdaMonitor2z_I=0.0768972**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Magnetic_Majorana/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Magnetic_Majorana/README.md
@@ -22,6 +22,10 @@ Seeger et al. NIM A: Volume 457, Issues 1-2 , 11 January 2001, Pages 338-346
 Note that there are some sytematic fluctuation with the current solution.
 ```
 
+## Examples
+
+- **Test: Blarge=1.0 -n 10000 Detector: pollambdaMonitor2z_I=8.79645e-07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Magnetic_Rotation/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Magnetic_Rotation/README.md
@@ -20,6 +20,10 @@ See:
 Seeger et al. NIM A: Volume 457, Issues 1-2 , 11 January 2001, Pages 338-346
 ```
 
+## Examples
+
+- **Test: -n1e5 RESTORENEUT=1 Detector: MPLMonNum2Y_I=3.54525**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_Bender/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_Bender/README.md
@@ -16,6 +16,10 @@ Test that Pol_bender polarizes an unpolarized beam, and allows one
 to test the different options.
 ```
 
+## Examples
+
+- **Test: GUIDELENGTH=1 Detector: psdBender_I=0.703658**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_FieldBox/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_FieldBox/README.md
@@ -17,6 +17,10 @@ A neutron beam polarized aling the x-axis is emitted with central wavelength suc
 that the  polarization is rotated pihalfturns radians in the field.
 ```
 
+## Examples
+
+- **Test: Test_Pol_FieldBox pihalfturns=3 Detector: pl1z_I=2.30783**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_Guide_Vmirror/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_Guide_Vmirror/README.md
@@ -16,6 +16,11 @@ A simple description of the V4 instrument in Berlin as explained in:
 NIM A 451 (2000) 474-479
 ```
 
+## Examples
+
+- **Test: polariserIn=1 Detector: psdPolGuide_I=3.95407e+12**
+- **Test: polariserIn=2 Detector: psdPolGuide_I=4.29664e+12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_Guide_mirror/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_Guide_mirror/README.md
@@ -17,6 +17,10 @@ in a non-polarizing setting, with absorbing walls. This is how it would be set t
 as a frame-overlap mirror.
 ```
 
+## Examples
+
+- **Test: mirrorIn=1 Detector: psdGuide_I=1.40915e+12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_MSF/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_MSF/README.md
@@ -17,6 +17,10 @@ This instrument demonstrates how to use the component
 Pol_constBfield to make a Mezei Spin flipper.
 ```
 
+## Examples
+
+- **Test: Test_Pol_MSF.instr Detector: pollambdaMonitor2z_I=0.136736**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_Mirror/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_Mirror/README.md
@@ -20,6 +20,10 @@ The intensity on the first monitor should be the same as the sum
 of the two polarization monitors.
 ```
 
+## Examples
+
+- **Test: mirrorOption=0.99 Detector: lamReflec_I=3.27108e-05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_SF_ideal/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_SF_ideal/README.md
@@ -17,6 +17,10 @@ Simply test the ideal spin flippers function
 Example: mcrun test.instr <parameters=values>
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_Set/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_Set/README.md
@@ -18,6 +18,10 @@ Second check is that when the polarisation is hardcoded to (0, 1, 0)
 after Incoherent it is (0, -1/3, 0).
 ```
 
+## Examples
+
+- **Test: Test_Pol_Set.instr Detector: polMonitor3_I=-0.333333**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_Tabled/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_Tabled/README.md
@@ -17,6 +17,11 @@ is working. The field referred to by the default input parameter MF is 10 \mu T 
 at entry and flips to l0 \mu T along the negative z-axis halfway through
 ```
 
+## Examples
+
+- **Test: -n1e4 interpol_method=default MF=flipfield.dat Detector: pol_6_I=1.0**
+- **Test: -n1e4 interpol_method=default MF=constfield.dat Detector: polx_6_I=0.05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_Pol_TripleAxis/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_Pol_TripleAxis/README.md
@@ -24,6 +24,10 @@ Three cases can be done:
 The Vanadium sample should give I(0)=2*(I(-1)+I(1)) and I(-1)=2*I(1).
 ```
 
+## Examples
+
+- **Test: OPTION=-1 Detector: pollambdaMonitorDet_I=5.63101e-12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_V_cavity_SNAG_double_side/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_V_cavity_SNAG_double_side/README.md
@@ -15,6 +15,10 @@
 Test instrument for Transmission_V_polarisator, double layer reflectivity.
 ```
 
+## Examples
+
+- **Test: Test_V_cavity_SNAG_double_side.instr Lam=7 Detector: div_lambda_hor_I=1.0e+13**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_V_cavity_SNAG_single_side/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_V_cavity_SNAG_single_side/README.md
@@ -15,6 +15,10 @@
 Test instrument for Transmission_V_polarisator, single layer reflectivity.
 ```
 
+## Examples
+
+- **Test: Test_V_cavity_SNAG_single_side.instr Lam=7 Detector: div_lambda_hor_I=1.1e+13**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_polarization/Test_pol_ideal/README.md
+++ b/mcstas-comps/examples/Tests_polarization/Test_pol_ideal/README.md
@@ -15,6 +15,12 @@
 Simply runs a short test to check that Set_pol, Pol_analyser_ideal, and Pol_monitor really do work
 ```
 
+## Examples
+
+- **Test: xory=1 Detector: monitor_I=25.9341**
+- **Test: xory=0 Detector: monitor_I=4.4496**
+- **Test: xory=1 Detector: pmonitory_I=-0.70717**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/GISANS_tests/README.md
+++ b/mcstas-comps/examples/Tests_samples/GISANS_tests/README.md
@@ -18,6 +18,10 @@ developed to model the GISANS features described in M. S. Hellsing et. al [1]
 Test case 1, grazing incidence from front
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Samples_Incoherent/README.md
+++ b/mcstas-comps/examples/Tests_samples/Samples_Incoherent/README.md
@@ -50,6 +50,19 @@ cube.off: 6=PowderN,
 9=Incoherent
 ```
 
+## Examples
+
+- **Test: SAMPLE=1 STOP=1 Detector: PSD_Sphere_4pi_I=1.2321e+06**
+- **Test: SAMPLE=2 STOP=1 Detector: PSD_Sphere_4pi_I=1.2324e+06**
+- **Test: SAMPLE=3 STOP=1 Detector: PSD_Sphere_4pi_I=1.3196e+06**
+- **Test: SAMPLE=4 STOP=1 Detector: PSD_Sphere_4pi_I=1.3246e+06**
+- **Test: SAMPLE=5 STOP=1 Detector: PSD_Sphere_4pi_I=1.3252e+06**
+- **Test: SAMPLE=6 STOP=1 -n 1e5 Detector: PSD_Sphere_4pi_I=1.2324e+06**
+- **Test: SAMPLE=7 STOP=1 -n 1e5 Detector: PSD_Sphere_4pi_I=1.3225e+06**
+- **Test: SAMPLE=8 STOP=1 -n 1e5 Detector: PSD_Sphere_4pi_I=1.3233e+06**
+- **Test: SAMPLE=9 STOP=1 -n 1e5 Detector: PSD_Sphere_4pi_I=1.3239e+06**
+- **Test: SAMPLE=10 STOP=1 -n 1e5 Detector: PSD_Sphere_4pi_I=1.28905e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Samples_Incoherent_off/README.md
+++ b/mcstas-comps/examples/Tests_samples/Samples_Incoherent_off/README.md
@@ -17,6 +17,10 @@ The Incoherent component is here used with a description file. The shape may be 
 forcing the size of the bounding box.
 ```
 
+## Examples
+
+- **Test: geometry="socket.off" Detector: monitor_I=0.0150169**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Samples_Isotropic_Sqw/README.md
+++ b/mcstas-comps/examples/Tests_samples/Samples_Isotropic_Sqw/README.md
@@ -17,6 +17,10 @@ It produces a tof-angle and angle-energy detectors and also exports the
 S(q,w) and S(q) data.
 ```
 
+## Examples
+
+- **Test: lambda=3.4 Detector: M_theta_t_I=1.60949e-07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Samples_Phonon/README.md
+++ b/mcstas-comps/examples/Tests_samples/Samples_Phonon/README.md
@@ -16,6 +16,11 @@ Simple test instrument for the Phonon_simple component.
 Refer to the component documentation for further instructions.
 ```
 
+## Examples
+
+- **Test: E=10 -n 1e5 focus_r=0.001 Detector: mon1_I=2.86265e-25**
+- **Test: E=10 -n 1e5 focus_a=0.1 Detector: mon1_I=2.86265e-25**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Samples_SpinWave_BCO/README.md
+++ b/mcstas-comps/examples/Tests_samples/Samples_SpinWave_BCO/README.md
@@ -16,6 +16,12 @@ Simple test instrument for the SpinWave_BCO component.
 Refer to the component documentation for further instructions.
 ```
 
+## Examples
+
+- **Test: h=1 l=0 Detector: Emon_I=0.0517575**
+- **Test: h=0 l=0.5 E=6.73 Detector: Emon_I=0.0108855**
+- **Test: h=1 l=1 Detector: Emon_I=0.000655744**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Samples_vanadium/README.md
+++ b/mcstas-comps/examples/Tests_samples/Samples_vanadium/README.md
@@ -16,6 +16,10 @@ This instrument shows the vanadium sample scattering anisotropy.
 This is an effect of attenuation of the beam in the cylindrical sample.
 ```
 
+## Examples
+
+- **Test: ROT=0 Detector: PSD_4pi_I=7.97023e-05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Incoherent/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Incoherent/README.md
@@ -15,6 +15,10 @@
 A test instrument for Incoherent output on spherical monitor.
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: Sph_mon_I=1.12762e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Incoherent_MS/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Incoherent_MS/README.md
@@ -44,6 +44,13 @@ By scanning across thickness values, one then finds a curve, that should fit the
 analytical calculations.
 ```
 
+## Examples
+
+- **Test: mcrun Test_Incoherent_MS sample=none Detector: total_scat_I=9.99909e+06**
+- **Test: mcrun Test_Incoherent_MS sample=thin Detector: psd_det_I=27.12**
+- **Test: mcrun Test_Incoherent_MS sample=thick Detector: psd_det_I=26.59**
+- **Test: mcrun Test_Incoherent_MS sample=thick Detector: psd_det_I=26.59**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Magnon_bcc_2D/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Magnon_bcc_2D/README.md
@@ -15,6 +15,10 @@
 
 ```
 
+## Examples
+
+- **Test: inelastic=1 Detector: det_I=4.98e11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Magnon_bcc_TAS/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Magnon_bcc_TAS/README.md
@@ -15,6 +15,11 @@
 Generic TAS instrument for test of samples with dispersions. Modeled over the RITA-2 instrument at PSI (one analyzer only). The instrument is able to position in q-space at q=(h 0 0) and fixed Ei and Ef. This can be used to longitudinal constant-E scans or constant-q scans. In addition, transverse constant-E scans can be made by scanning the sample orientation A3.
 ```
 
+## Examples
+
+- **Test: Test_Magnon_bcc_TAS.instr hw=0.5 Detector: e_monitor1_I=460000**
+- Example: Test_Magnon_bcc_TAS.instr hw=0,1 -N21
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_PowderN/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_PowderN/README.md
@@ -15,6 +15,16 @@
 A test instrument for PowderN output on a spherical monitor.
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: Sph_mon_I=1.09119e+09**
+- **Test: lambda=1 d_phi=10 Detector: Sph_mon_I=8.94853e+07**
+- **Test: lambda=1 directbeam=1 SPLITS=2 Detector: Sph_mon_I=4.77847e+09**
+- **Test: lambda=1 directbeam=1 SPLITS=5 Detector: Sph_mon_I=4.77847e+09**
+- **Test: lambda=1 directbeam=1 SPLITS=10 Detector: Sph_mon_I=4.77847e+09**
+- **Test: lambda=1 directbeam=1 SPLITS=20 Detector: Sph_mon_I=4.77847e+09**
+- **Test: lambda=5 reflections="stdlib::ZnO_sg186_ZincOxide.ncmat;temp=300K" directbeam=1 SPLITS=20 Detector: Sph_mon_I=2.03816e+8**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_PowderN_Res/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_PowderN_Res/README.md
@@ -21,6 +21,10 @@ By default, absorption in the sample is effectively suppressed.
 Example: Lambda0=2.5667 dLambda=0.01 radius=0.001,0.021 TT=71.8 D_PHI=6 SPLITS=117 Distance=30 sig_abs=1e-09 -N21
 ```
 
+## Examples
+
+- **Test: Lambda0=2.5667 dLambda=0.01 radius=0.01 TT=71.8 D_PHI=6 SPLITS=117 Distance=30 sig_abs=1e-09 Detector: DetectorSmall_I=288.57**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_PowderN_concentric/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_PowderN_concentric/README.md
@@ -15,6 +15,13 @@
 A test instrument for PowderN output on a spherical monitor.
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: Sph_sum_I=4.93378e+09**
+- **Test: lambda=1 Detector: Sph_front_I=3.35878e+08**
+- **Test: lambda=1 Detector: Sph_sample_I=7.28574e+08**
+- **Test: lambda=1 Detector: Sph_back_I=2.73695e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Powders/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Powders/README.md
@@ -15,6 +15,41 @@
 A test instrument for Powder output from different sample components.
 ```
 
+## Examples
+
+- **Test: lambda=2.5 directbeam=0 comp=0 material=Ge SPLITS=1 Detector: Sph_mon_I=3.67e+08**
+- **Test: lambda=2.5 directbeam=0 comp=0 material=Ge SPLITS=1 Detector: psd_mon_I=7.35e+05**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=Ge SPLITS=1 Detector: Sph_mon_I=4.2e+08**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=Ge SPLITS=1 Detector: psd_mon_I=8.3e+05**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=Ge SPLITS=1 Detector: Sph_mon_I=4.2e+08**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=Ge SPLITS=1 Detector: psd_mon_I=8.3e+05**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=Ge SPLITS=1 Detector: Sph_mon_I=4.2e+08**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=Ge SPLITS=1 Detector: psd_mon_I=8.3e+05**
+- **Test: lambda=2.5 directbeam=0 comp=0 material=Al twotheta=76.5 SPLITS=1 Detector: Sph_mon_I=9.1e+07**
+- **Test: lambda=2.5 directbeam=0 comp=0 material=Al twotheta=76.5 SPLITS=1 Detector: psd_mon_I=1.94e+05**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=Al twotheta=76.5 SPLITS=1 Detector: Sph_mon_I=1.1e+08**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=Al twotheta=76.5 SPLITS=1 Detector: psd_mon_I=2e+05**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=Al twotheta=76.5 SPLITS=1 Detector: Sph_mon_I=1.1e+08**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=Al twotheta=76.5 SPLITS=1 Detector: psd_mon_I=2e+05**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=Al twotheta=76.5 SPLITS=1 Detector: Sph_mon_I=1.1e+08**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=Al twotheta=76.5 SPLITS=1 Detector: psd_mon_I=2.19e+05**
+- **Test: lambda=2.5 directbeam=0 comp=0 material=LaMnO3 twotheta=80 SPLITS=1 Detector: Sph_mon_I=2.48e+08**
+- **Test: lambda=2.5 directbeam=0 comp=0 material=LaMnO3 twotheta=80 SPLITS=1 Detector: psd_mon_I=1.78e+05**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=LaMnO3 twotheta=80 SPLITS=1 Detector: Sph_mon_I=3.1e+08**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=LaMnO3 twotheta=80 SPLITS=1 Detector: psd_mon_I=2.1e+05**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=LaMnO3 twotheta=80 SPLITS=1 Detector: Sph_mon_I=3.1e+08**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=LaMnO3 twotheta=80 SPLITS=1 Detector: psd_mon_I=1.9e+05**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=LaMnO3 twotheta=80 SPLITS=1 Detector: Sph_mon_I=3.1e+08**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=LaMnO3 twotheta=80 SPLITS=1 Detector: psd_mon_I=1.9e+05**
+- **Test: lambda=2.5 directbeam=0 comp=0 material=NaCl twotheta=78 SPLITS=1 Detector: Sph_mon_I=2.13e+08**
+- **Test: lambda=2.5 directbeam=0 comp=0 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.2e+05**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=NaCl twotheta=78 SPLITS=1 Detector: Sph_mon_I=2.5e+08**
+- **Test: lambda=2.5 directbeam=0 comp=1 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.4e+05**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=NaCl twotheta=78 SPLITS=1 Detector: Sph_mon_I=2.5e+08**
+- **Test: lambda=2.5 directbeam=0 comp=2 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.4e+05**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=NaCl twotheta=78 SPLITS=1 Detector: Sph_mon_I=2.5e+08**
+- **Test: lambda=2.5 directbeam=0 comp=3 material=NaCl twotheta=78 SPLITS=1 Detector: psd_mon_I=3.4e+05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_SANS/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_SANS/README.md
@@ -29,6 +29,20 @@ SANSNanodiscsWithTagsFast SAMPLE=10
 SANSPDBFast               SAMPLE=11
 ```
 
+## Examples
+
+- **Test: SAMPLE=0 Detector: PSDMonitor_I=2.529e-09**
+- **Test: SAMPLE=1 Detector: PSDMonitor_I=2.486e-10**
+- **Test: SAMPLE=2 Detector: PSDMonitor_I=2.297e-10**
+- **Test: SAMPLE=3 Detector: PSDMonitor_I=8.720e-11**
+- **Test: SAMPLE=4 Detector: PSDMonitor_I=1.326e-05**
+- **Test: SAMPLE=5 Ncount=1e6 Detector: PSDMonitor_I=2.714e-09**
+- **Test: SAMPLE=6 Ncount=1e6 Detector: PSDMonitor_I=2.051e-09**
+- **Test: SAMPLE=7 Ncount=1e5 Detector: PSDMonitor_I=1.687e-09**
+- **Test: SAMPLE=9 Detector: PSDMonitor_I=2.071e-09**
+- **Test: SAMPLE=10 Detector: PSDMonitor_I=2.079e-09**
+- **Test: SAMPLE=11 Detector: PSDMonitor_I=1.642e-09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_SX/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_SX/README.md
@@ -15,6 +15,15 @@
 A test instrument to compare Monitor_nD output against basic 1D and 2D monitors.
 ```
 
+## Examples
+
+- **Test: lambda=5 directbeam=0 Detector: Sph_mon_I=7.2e+7**
+- **Test: lambda=5 directbeam=0 SPLITS=5 Detector: Sph_mon_I=7.2e+7**
+- **Test: lambda=5 directbeam=0 SPLITS=10 Detector: Sph_mon_I=7.2e+7**
+- **Test: lambda=5 order=1 directbeam=0 Detector: Sph_mon_I=7.2e+7**
+- **Test: lambda=5 order=1 directbeam=0 SPLITS=5 Detector: Sph_mon_I=7.2e+7**
+- **Test: lambda=5 order=1 directbeam=0 SPLITS=10 Detector: Sph_mon_I=7.2e+7**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Sans_spheres/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Sans_spheres/README.md
@@ -17,6 +17,11 @@ component, and the SANS_spheres2 component, in order to ensure that they
 give the same value in this specific case.
 ```
 
+## Examples
+
+- **Test: use_SANS_spheres2=0 Detector: psd_det_I=9.73795e+06**
+- **Test: use_SANS_spheres2=1 Detector: psd_det_I=9.73795e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Single_crystal_inelastic/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Single_crystal_inelastic/README.md
@@ -24,6 +24,10 @@ once your instrument is written and functional:
 sensible parameter set.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Sqw/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Sqw/README.md
@@ -15,6 +15,10 @@
 A test instrument for testing Isotropic_Sqw output on a spherical monitor.
 ```
 
+## Examples
+
+- **Test: lambda=1 Detector: Sph_mon_I=1.21087e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_Sqw_monitor/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_Sqw_monitor/README.md
@@ -82,6 +82,11 @@ beam_wavelength_Angs=4.0, beam_resolution_meV=0.1,
 sample_detector_distance_m=3.5, detector_height_m=4.0
 ```
 
+## Examples
+
+- **Test: beam_wavelength_Angs=4.1 Detector: M_single_coh_I=8.7974e-11**
+- **Test: beam_wavelength_Angs=1.6 beam_resolution_meV=1.07 Detector: M_single_coh_I=3.50732e-09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_TOFRes_sample/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_TOFRes_sample/README.md
@@ -17,6 +17,10 @@ Testing resolution of a TOF spectrometer, use "reso.dat" output with mcresplot.p
 TOF resolution test instrument.
 ```
 
+## Examples
+
+- **Test: TWOTHETA=60 Detector: TOFL3_I=1.49356e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_TasReso/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_TasReso/README.md
@@ -31,6 +31,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see http://www.gnu.org/licenses/.
 ```
 
+## Examples
+
+- **Test: src_lam=4.5 Detector: emon_I=887.137**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Test_single_magnetic_crystal/README.md
+++ b/mcstas-comps/examples/Tests_samples/Test_single_magnetic_crystal/README.md
@@ -17,6 +17,10 @@ component. It is a very simple implementation of a Laue camera using 4PI spheric
 monitors.
 ```
 
+## Examples
+
+- **Test: Test_single_magnetic_crystal.instr L0=4 Detector: PSD4PImon_I=3.89987e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_samples/Unittest_SANS_benchmark2/README.md
+++ b/mcstas-comps/examples/Tests_samples/Unittest_SANS_benchmark2/README.md
@@ -15,6 +15,24 @@
 Very simple test instrument for the SANS_benchmark2 component from H. Frielinghaus.
 ```
 
+## Examples
+
+- **Test: modnum=1  Detector: detectorSANS_I=0.0123201**
+- **Test: modnum=2  Detector: detectorSANS_I=0.00635726**
+- **Test: modnum=3  Detector: detectorSANS_I=18.8412**
+- **Test: modnum=4  Detector: detectorSANS_I=0.00600315**
+- **Test: modnum=5  Detector: detectorSANS_I=0.0310337**
+- **Test: modnum=6  Detector: detectorSANS_I=0.660282**
+- **Test: modnum=7  Detector: detectorSANS_I=0.776435**
+- **Test: modnum=8  Detector: detectorSANS_I=3.89201**
+- **Test: modnum=9  Detector: detectorSANS_I=0.0427871**
+- **Test: modnum=10 Detector: detectorSANS_I=0.0234776**
+- **Test: modnum=11 Detector: detectorSANS_I=0.229431**
+- **Test: modnum=12 Detector: detectorSANS_I=0.0026947**
+- **Test: modnum=13 Detector: detectorSANS_I=0.00269978**
+- **Test: modnum=14 Detector: detectorSANS_I=0.002694**
+- **Test: modnum=15 Detector: detectorSANS_I=0.200408**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_sources/Test_Source_custom/README.md
+++ b/mcstas-comps/examples/Tests_sources/Test_Source_custom/README.md
@@ -16,6 +16,10 @@ This is a test file for the Source_custom component
 Using the parameters for the HBS bi-spectral source
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_sources/Test_Source_pulsed/README.md
+++ b/mcstas-comps/examples/Tests_sources/Test_Source_pulsed/README.md
@@ -15,6 +15,12 @@
 A test instrument to check if the component 'Source_pulsed' provides valid spectra and intensities.
 ```
 
+## Examples
+
+- **Test: source=1 Detector: m1_I=4.680e+09**
+- **Test: source=2 Detector: m1_I=2.305e+09**
+- **Test: source=3 Detector: m1_I=5.292e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_sources/Test_Source_quasi/README.md
+++ b/mcstas-comps/examples/Tests_sources/Test_Source_quasi/README.md
@@ -15,6 +15,11 @@
 This instrument is a unit test for the quasi-stochastic source component.
 ```
 
+## Examples
+
+- **Test: Test_Source_quasi.instr SRC=0 Detector: psd_I=1.21847E-18**
+- **Test: Test_Source_quasi.instr SRC=1 Detector: psd_I=1.21847E-18**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_sources/Test_Sources/README.md
+++ b/mcstas-comps/examples/Tests_sources/Test_Sources/README.md
@@ -22,6 +22,16 @@ that source component does not support MPI.
 Example: source=1 Detector: m1_I=9.97273e+11
 ```
 
+## Examples
+
+- **Test: source=2 Detector: m1_I=9.48467e+11**
+- **Test: source=3 Detector: m1_I=9.96553e+11**
+- **Test: source=4 Detector: m1_I=9.966e+11**
+- **Test: source=5 Detector: m1_I=2.4279e+11**
+- **Test: source=6 Detector: m1_I=2.42284e+11**
+- **Test: source=7 Detector: m1_I=2.28139e+13**
+- **Test: source=8 Detector: m1_I=5.0787e+13**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Conditional_test/README.md
+++ b/mcstas-comps/examples/Tests_union/Conditional_test/README.md
@@ -15,6 +15,12 @@
 Use of all conditional components in one instrument file
 ```
 
+## Examples
+
+- **Test: dummy=1 Detector: detector_scat_I=40.2053**
+- **Test: dummy=1 Detector: test_logger_2D_space_zx_con_time_I=76662.3**
+- **Test: dummy=1 Detector: test_logger_2D_space_zx_con_PSD_I=387.97**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/External_component_test/README.md
+++ b/mcstas-comps/examples/Tests_union/External_component_test/README.md
@@ -16,6 +16,10 @@ Demonstration of the use of "number_of_activations" and exit volumes to
 include a regular McStas component in an ensemble of Union components.
 ```
 
+## Examples
+
+- **Test: Detector: detector_I=213.109**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Geometry_test/README.md
+++ b/mcstas-comps/examples/Tests_union/Geometry_test/README.md
@@ -15,6 +15,11 @@
 Use of all basic geometries, mesh(as a torus), sphere, cylinder, cone and box
 ```
 
+## Examples
+
+- **Test: meshfile="torus.off" Detector: detector_scat_I=47.5**
+- **Test: meshfile="torus.STL" Detector: detector_scat_I=47.5**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Hidden_Cylinder/README.md
+++ b/mcstas-comps/examples/Tests_union/Hidden_Cylinder/README.md
@@ -20,6 +20,10 @@ To test this simply do
 a "mcdisplay Hidden_Cylinder.instr -c -y"
 ```
 
+## Examples
+
+- **Test: pin_rad=0.0025 Detector: det_I=3.42884e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/IncoherentPhonon_test/README.md
+++ b/mcstas-comps/examples/Tests_union/IncoherentPhonon_test/README.md
@@ -18,6 +18,10 @@ V. Laliena, Uni Zaragoza.
 Example: comp_select=1 Detector: energy_mon_2_I=1156.84
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Logger_test/README.md
+++ b/mcstas-comps/examples/Tests_union/Logger_test/README.md
@@ -17,6 +17,10 @@ All arms are 30 cm below the actual center point in order to avoid arms
 in the mcdisplay picture. Uses all Union loggers.
 ```
 
+## Examples
+
+- **Test: Detector: test_logger_1D_I=31.7195**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Many_meshes/README.md
+++ b/mcstas-comps/examples/Tests_union/Many_meshes/README.md
@@ -18,6 +18,10 @@ Test with:
 mcdisplay -y -c
 ```
 
+## Examples
+
+- **Test: pin_rad=0.0025 Detector:det_I=4.63384e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space/README.md
@@ -20,6 +20,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated abs_logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space_event/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space_event/README.md
@@ -15,6 +15,10 @@
 
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space_t/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space_t/README.md
@@ -19,6 +19,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated abs_logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space_t_lam/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_space_t_lam/README.md
@@ -26,6 +26,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated abs_logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_t/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_1D_t/README.md
@@ -19,6 +19,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated abs_logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_2D_space/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_2D_space/README.md
@@ -18,6 +18,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated abs_logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_event/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_event/README.md
@@ -15,6 +15,10 @@
 
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_abs_logger_nD/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_abs_logger_nD/README.md
@@ -20,6 +20,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated abs_logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_absorption/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_absorption/README.md
@@ -17,6 +17,10 @@ without processes and just the make_material component, and requires
 a few special cases.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_absorption_image/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_absorption_image/README.md
@@ -16,6 +16,10 @@ Simple test instrument showing absorption image of a cryostat with vanadium
 sample using the Union components.
 ```
 
+## Examples
+
+- **Test: stick_displacement=0 Detector: screen_I=0.00925**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_box/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_box/README.md
@@ -18,6 +18,10 @@ be set, and when two or more geometries overlap, the one with highest
 priority determines what material is simulated in that region.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_conditional_PSD/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_conditional_PSD/README.md
@@ -17,6 +17,10 @@ its output to neutrons that reached the conditional_PSD area in specified
 time interval. This is used to investigate origin of interesting signals.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_conditional_standard/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_conditional_standard/README.md
@@ -17,6 +17,10 @@ their trace in Union_master within certain set limits. Here two loggers
 are modified by a single conditional component that requires a final time.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_inhomogenous_process/README.md
@@ -46,6 +46,19 @@ The 10th example plays with some more complex tiny expressions using the
 gaussian function and the heavyside function.
 ```
 
+## Examples
+
+- **Test: sample=thin Detector: lin_det_I=0.007387**
+- **Test: sample=union_inc Detector: lin_det_I=0.007387**
+- **Test: sample=union_inho Detector: lin_det_I=0.007387**
+- **Test: sample=inc_linear Detector: lin_det_I=0.017457**
+- **Test: sample=inho_linear Detector: lin_det_I=0.017457**
+- **Test: sample=inc_and_inho Detector: lin_det_I=0.017457**
+- **Test: sample=phonon thick=0.001 Detector: lin_det_I=0.00505839**
+- **Test: sample=inc_trans Detector: lin_det_I=0.081029**
+- **Test: sample=inho_trans Detector: lin_det_I=0.081040**
+- **Test: sample=gauss_heavy Detector: lin_det_I=0.0985658**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_logger_1D/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_logger_1D/README.md
@@ -19,6 +19,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_logger_2DQ/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_logger_2DQ/README.md
@@ -20,6 +20,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_logger_2D_kf/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_logger_2D_kf/README.md
@@ -20,6 +20,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_logger_2D_kf_t/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_logger_2D_kf_t/README.md
@@ -20,6 +20,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_logger_2D_space/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_logger_2D_space/README.md
@@ -20,6 +20,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_logger_2D_space_t/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_logger_2D_space_t/README.md
@@ -21,6 +21,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_logger_3D_space/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_logger_3D_space/README.md
@@ -19,6 +19,10 @@ Includes conditional component to test record_to_temp functionality
 of investigated logger.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_loggers_base/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_loggers_base/README.md
@@ -15,6 +15,10 @@
 
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_mask/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_mask/README.md
@@ -16,6 +16,10 @@ Masks allow restricing some geometry to the internal part of a mask
 geometry. All Union geometry components can be used as masks.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_mesh_boxes/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_mesh_boxes/README.md
@@ -16,6 +16,10 @@ Instrument provided by Sam Lambrick from ISIS, that uses three meshes to
 make their boxes.
 ```
 
+## Examples
+
+- **Test: Detector: psd_detector_I=10.7752**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_powder/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_powder/README.md
@@ -15,6 +15,10 @@
 Simple test instrument for powder sample simulated using Union components.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tests_union/Test_texture/README.md
+++ b/mcstas-comps/examples/Tests_union/Test_texture/README.md
@@ -17,6 +17,10 @@ Simple test instrument for texture sample component.
 Example: lmax=0 Detector: monitor_I=8.08899e-05
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tools/Histogrammer/README.md
+++ b/mcstas-comps/examples/Tools/Histogrammer/README.md
@@ -30,6 +30,10 @@ Example: mcrun Histogrammer.instr filename="events.dat" MODE=1 options="sphere t
 - Reads a Virtual_output generated event file and applies a spherical PSD
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tools/MCPL2Mantid_flat/README.md
+++ b/mcstas-comps/examples/Tools/MCPL2Mantid_flat/README.md
@@ -23,6 +23,10 @@ An example mcpl input file corresponding to the default geometry can be generate
 templateSANS_MCPL
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tools/MCPL2hist/README.md
+++ b/mcstas-comps/examples/Tools/MCPL2hist/README.md
@@ -24,6 +24,10 @@ Example3: 2D TOF-lambda plot of beam:
 NDoptions=3 defines options="previous, auto, tof, lambda"
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tools/MCPL_filter_energy/README.md
+++ b/mcstas-comps/examples/Tools/MCPL_filter_energy/README.md
@@ -16,6 +16,10 @@ Example: Split an MCPL file at an energy of 0.5 meV
 mcrun MCPL_filter_energy MCPLfile=my.mcpl.gz energy=0.5
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tools/MCPL_filter_radius/README.md
+++ b/mcstas-comps/examples/Tools/MCPL_filter_radius/README.md
@@ -16,6 +16,10 @@ Example: Split an MCPL file at a radius of 2.5 m from the origin
 mcrun MCPL_filter_radius MCPLfile=my.mcpl.gz radius=2.5
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tools/MCPL_filter_wavelength/README.md
+++ b/mcstas-comps/examples/Tools/MCPL_filter_wavelength/README.md
@@ -16,6 +16,10 @@ Example: Split an MCPL file at a wavelength of 0.5 AA
 mcrun MCPL_filter_wavelength MCPLfile=my.mcpl.gz wavelength=0.5
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Tools/vinput2mcpl/README.md
+++ b/mcstas-comps/examples/Tools/vinput2mcpl/README.md
@@ -17,6 +17,10 @@ Instrument for conversion of Virtual input files to MCPL.
 Example: vinput2mcpl inputfile=C8_L214.dat outputfile=C8_L214.mcpl,gz
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/Bispectral/README.md
+++ b/mcstas-comps/examples/Union_demos/Bispectral/README.md
@@ -18,6 +18,10 @@ with different coatings. Materials are simulated using NCrystal.
 Example: mcrun Bispectral.instr l_min=0.5 l_max=6.0
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/Demonstration/README.md
+++ b/mcstas-comps/examples/Union_demos/Demonstration/README.md
@@ -21,6 +21,11 @@ multiple scattering occur and events are thus taking place in the last
 two samples.
 ```
 
+## Examples
+
+- **Test: stick_displacement=0 Detector: m4pi_I=21849.9**
+- **Test: stick_displacement=0 Detector: Banana_monitor_I=101.8**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/External_component/README.md
+++ b/mcstas-comps/examples/Union_demos/External_component/README.md
@@ -18,6 +18,10 @@ an external component into an ensamle of Union components
 Example: stick_displacement=0 Detector: detector_I=189.144
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/Laue_camera/README.md
+++ b/mcstas-comps/examples/Union_demos/Laue_camera/README.md
@@ -15,6 +15,12 @@
 Laue camera using Union components for the sample
 ```
 
+## Examples
+
+- **Test: mosaic=5 Detector: det_I=2.08262e+07**
+- **Test: mosaic=5 Detector: PSDlin_transmission_scattered_I=1.0346e+06**
+- **Test: mosaic=5 Detector: PSDlin_transmission_transmitted_I=2.30318e+08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/Manual_example/README.md
+++ b/mcstas-comps/examples/Union_demos/Manual_example/README.md
@@ -17,6 +17,10 @@ Example on using Union components from the Union project manual
 Example: Detector: Banana_monitor_I=3.823e-05
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/Sample_picture_replica/README.md
+++ b/mcstas-comps/examples/Union_demos/Sample_picture_replica/README.md
@@ -17,6 +17,10 @@ All arms are 30 cm below the actual center point in order to avoid arms
 in the mcdisplay picture.
 ```
 
+## Examples
+
+- **Test: Detector: detector_I=1977.65**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/Tagging_demo/README.md
+++ b/mcstas-comps/examples/Union_demos/Tagging_demo/README.md
@@ -17,6 +17,10 @@ Powder in Al can
 Example: Detector: Banana_monitor_I=9.84391e-09
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_demos/Time_of_flight/README.md
+++ b/mcstas-comps/examples/Union_demos/Time_of_flight/README.md
@@ -17,6 +17,10 @@ simple test instrument for sample component.
 Example: stick_displacement=0 Detector: banana_detector_tof_I=566.295
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_sample_environments/SE_usage_example/README.md
+++ b/mcstas-comps/examples/Union_sample_environments/SE_usage_example/README.md
@@ -18,6 +18,10 @@ See the cryostat_example.instr file for details on the used sample
 environment.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_sample_environments/cryostat_example/README.md
+++ b/mcstas-comps/examples/Union_sample_environments/cryostat_example/README.md
@@ -23,6 +23,10 @@ to avoid conflicting with existing models of Al in the instrument file that incl
 sample environment.
 ```
 
+## Examples
+
+- **Test: stick_displacement=0 Detector: m4pi_I=7.3e2**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_validation/Incoherent_validation/README.md
+++ b/mcstas-comps/examples/Union_validation/Incoherent_validation/README.md
@@ -15,6 +15,12 @@
 Validation of Union components against incoherent scattering component
 ```
 
+## Examples
+
+- **Test: comp_select=1 sample_radius=0.01 sample_height=0.01 pack=1 sigma_inc_vanadium=5.08 sigma_abs_vanadium=5.08 Vc_vanadium=13.827 geometry_interact=0.5 Detector: Detector: PSD_transmission_I=19084.8**
+- **Test: comp_select=1 sample_radius=0.01 sample_height=0.01 pack=1 sigma_inc_vanadium=5.08 sigma_abs_vanadium=5.08 Vc_vanadium=13.827 geometry_interact=0.5 Detector: Detector: PSDlin_scattering_I=1.10444**
+- **Test: comp_select=1 sample_radius=0.01 sample_height=0.01 pack=1 sigma_inc_vanadium=5.08 sigma_abs_vanadium=5.08 Vc_vanadium=13.827 geometry_interact=0.5 Detector: Detector: PSDlin_scattering_2_I=1.54102**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_validation/Mirror_validation/README.md
+++ b/mcstas-comps/examples/Union_validation/Mirror_validation/README.md
@@ -25,6 +25,10 @@ discrepancy at small angles especially if R0 of the mirror coating is lowered.
 Example: mcrun Mirror_validation.instr angle=0.7
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_validation/Powder_validation/README.md
+++ b/mcstas-comps/examples/Union_validation/Powder_validation/README.md
@@ -15,6 +15,21 @@
 Validation of Union powder against standard PowderN component.
 ```
 
+## Examples
+
+- **Test: comp_select=1 Detector: detectors_m4pi_I=67635.2**
+- **Test: comp_select=2 Detector: detectors_m4pi_I=67635.2**
+- **Test: comp_select=1 Detector: PSDlin_scattering_I=5.79875**
+- **Test: comp_select=2 Detector: PSDlin_scattering_I=5.79875**
+- **Test: comp_select=1 d_phi=0 Detector: PSD2lin_scattering_I=5**
+- **Test: comp_select=2 d_phi=0 Detector: PSD2lin_scattering_I=5**
+- **Test: comp_select=1 div=0.5 dE=1 d_phi=0 sigma_inc=3.4176 sigma_abs=2.9464 Vc=1079.1 material_data_file=Na2Ca3Al2F14.laz Detector: detectors_m4pi_I=3750**
+- **Test: comp_select=2 div=0.5 dE=1 d_phi=0 sigma_inc=3.4176 sigma_abs=2.9464 Vc=1079.1 material_data_file=Na2Ca3Al2F14.laz Detector: detectors_m4pi_I=3750**
+- **Test: comp_select=1 div=0.5 dE=1 d_phi=0 sigma_inc=3.4176 sigma_abs=2.9464 Vc=1079.1 material_data_file=Na2Ca3Al2F14.laz Detector: PSDlin_scattering=2.88**
+- **Test: comp_select=2 div=0.5 dE=1 d_phi=0 sigma_inc=3.4176 sigma_abs=2.9464 Vc=1079.1 material_data_file=Na2Ca3Al2F14.laz Detector: PSDlin_scattering=2.88**
+- **Test: comp_select=1 div=0.5 dE=1 d_phi=0 sigma_inc=3.4176 sigma_abs=2.9464 Vc=1079.1 material_data_file=Na2Ca3Al2F14.laz Detector: Banana_monitor_I=12.5**
+- **Test: comp_select=2 div=0.5 dE=1 d_phi=0 sigma_inc=3.4176 sigma_abs=2.9464 Vc=1079.1 material_data_file=Na2Ca3Al2F14.laz Detector: Banana_monitor_I=12.5**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/Union_validation/Single_crystal_validation/README.md
+++ b/mcstas-comps/examples/Union_validation/Single_crystal_validation/README.md
@@ -15,6 +15,12 @@
 Validation of Union single crystal against standard single_crystal.
 ```
 
+## Examples
+
+- **Test: comp_select=1 Detector: Banana_monitor_I=9.5e5**
+- **Test: comp_select=1 Detector: PSDlin_transmission_scattered_I=793256**
+- **Test: comp_select=2 Detector: PSDlin_transmission_scattered_I=795548**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/elearning/Radiography_Lithium_Battery/README.md
+++ b/mcstas-comps/examples/elearning/Radiography_Lithium_Battery/README.md
@@ -19,6 +19,10 @@ Nota Bene: For simpification, this version of the instrument does <strong>NOT</s
 Radiography_Lithium_Battery was derived from Radiography_absorbing_edge. by Linda Udby and Peter Willendrup.
 ```
 
+## Examples
+
+- **Test: Radiography_Lithium_Battery -y Detector: PSD_1cm_detector_50mum_I=9.97993e-16**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/elearning/Radiography_absorbing_edge/README.md
+++ b/mcstas-comps/examples/elearning/Radiography_absorbing_edge/README.md
@@ -19,6 +19,10 @@ http://vnt.nmi3.org/moodle/mod/quiz/view.php?id=56
 Example: mcrun  Radiography_absorbing_edge.instr -n5e8 l=0.2 -d EdgeImaging
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/elearning/Reflectometer/README.md
+++ b/mcstas-comps/examples/elearning/Reflectometer/README.md
@@ -23,6 +23,10 @@ beam. The scattering is in the horizontal plane.
 Example: mcrun reflectometer.instr <parameters=values>
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/elearning/SANSsimple/README.md
+++ b/mcstas-comps/examples/elearning/SANSsimple/README.md
@@ -17,6 +17,10 @@ Instrument longer description (type, elements, usage...)
 Example: mcrun SANSsimple.instr <parameters=values>
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/elearning/SANSsimpleSpheres/README.md
+++ b/mcstas-comps/examples/elearning/SANSsimpleSpheres/README.md
@@ -18,6 +18,10 @@ This simple SANS instrument is used for the SANS simulation quiz on th e-learnin
 Example: mcrun SANSsimple.instr  Lambda=10 DLambda=0
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcstas-comps/examples/elearning/SimplePowderDiffractometer/README.md
+++ b/mcstas-comps/examples/elearning/SimplePowderDiffractometer/README.md
@@ -19,6 +19,10 @@ A banana detector records scattering agles [20,100]
 Example: mcrun SimplePowderDIffractometer.instr coll=40, container=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1mm/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1mm/README.md
@@ -42,6 +42,10 @@ width: pore width ?
 Example: ATHENA_1mm.instr porenumber=3
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1pore/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1pore/README.md
@@ -43,6 +43,10 @@ width: pore width ?
 Example: ATHENA_1pore.instr porenumber=3
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1ring/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1ring/README.md
@@ -30,6 +30,10 @@ width: pore width ?
 Example: ATHENA_1ring.instr shellnumber=3
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1sh_W1_OA/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1sh_W1_OA/README.md
@@ -29,6 +29,10 @@ rad_p: The radius at the "parabolic" and of the optic. At the source end.
 Example: ATHENA_1sh_W1_OA.instr shellnumber=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1sh_both/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1sh_both/README.md
@@ -29,6 +29,10 @@ rad_p: The radius at the "parabolic" and of the optic. At the source end.
 Example: ATHENA_1sh_both.instr shellnumber=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1sh_conical/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1sh_conical/README.md
@@ -29,6 +29,10 @@ rad_p: The radius at the "parabolic" and of the optic. At the source end.
 Example: ATHENA_1sh_conical.instr shellnumber=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1shell/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_1shell/README.md
@@ -30,6 +30,10 @@ width: pore width ?
 Example: ATHENA_1shell.instr shellnumber=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_cfgA_1mm/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_cfgA_1mm/README.md
@@ -31,6 +31,10 @@ in q, to avoid overly lagre data-files.
 Example: ATHENA_cfgA_1mm.instr porenumber=3
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/ATHENA_cfgA_1mm_FEMd/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/ATHENA_cfgA_1mm_FEMd/README.md
@@ -32,6 +32,10 @@ in q, to avoid overly lagre data-files.
 Example: ATHENA_cfgA_1mm_FEMd.instr porenumber=3
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/NuSTAR_1shell_con/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/NuSTAR_1shell_con/README.md
@@ -30,6 +30,10 @@ width: pore width ?
 Example: NuSTAR_1shell_con.instr shellnumber=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/Simple_1shell/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/Simple_1shell/README.md
@@ -18,6 +18,10 @@ optical plates covering the full circle. Reflectivity is 1 for all energies.
 Example: Simple_1shell.instr FL=12
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_ESA/Test_shells/README.md
+++ b/mcxtrace-comps/examples/AstroX_ESA/Test_shells/README.md
@@ -18,6 +18,10 @@ optical plates covering the full circle. Reflectivity is 1 for all energies.
 Example: Test_shells.instr shell_type=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_NASA/CXO/README.md
+++ b/mcxtrace-comps/examples/AstroX_NASA/CXO/README.md
@@ -17,6 +17,10 @@ in the Chandra Observers' Guide. Fully collimated X-ray light impinges on the
 optic consisting of 4 mirrors in the true Wolter I configuration.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/AstroX_NASA/NuSTAR_1shell/README.md
+++ b/mcxtrace-comps/examples/AstroX_NASA/NuSTAR_1shell/README.md
@@ -29,6 +29,10 @@ rad_p: The radius at the "parabolic" and of the optic. At the source end.
 Example: NuSTAR_1shell.instr shellnumber=1
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/BARC/Czerny_Turner/README.md
+++ b/mcxtrace-comps/examples/BARC/Czerny_Turner/README.md
@@ -20,6 +20,10 @@ It can be found here: https://inis.iaea.org/collection/NCLCollectionStore/_Publi
 Example: Do a scan (scan parameter =1) from x_screw=20 to 103 mm. The calculated monitor "Wavelength(Ang) as a function of x_screw(mm)" will be a linear function. The monochromator functions properly.
 ```
 
+## Examples
+
+- **Test: x_screw=60 Detector: w_monitor_I=1.10881e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/DTU/Airport_scannerII/README.md
+++ b/mcxtrace-comps/examples/DTU/Airport_scannerII/README.md
@@ -18,6 +18,10 @@ off/ply-files a scene is put together which may be used for tomography style
 simulations. The default input file contains a single object: a mechanical socket.
 ```
 
+## Examples
+
+- **Test: Airport_scannerII.instr -n1e5 Ncount=1e4 posX=-0.25 posY=-0.3 Detector: psd2_I=0.000629398**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/DTU/Pump_probe/README.md
+++ b/mcxtrace-comps/examples/DTU/Pump_probe/README.md
@@ -17,6 +17,10 @@ Instrument short description*
 Instrument longer description (type, elements, usage...)
 ```
 
+## Examples
+
+- **Test: Pump_probe.instr Dt=2e-9 Detector: dpsd1_I=1.7077e-28**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/DTU/Pump_probe_solvent/README.md
+++ b/mcxtrace-comps/examples/DTU/Pump_probe_solvent/README.md
@@ -33,6 +33,10 @@ parameters. Please be aware the by restricting the azimuthal range it is not unc
 the acceptance area of subsequent components. This is particularly the case for small psi.
 ```
 
+## Examples
+
+- **Test: Pump_probe_solvent.instr Dt=0 Detector: det_ccd_I=0.00664655**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/ESRF/ESRF_BM29/README.md
+++ b/mcxtrace-comps/examples/ESRF/ESRF_BM29/README.md
@@ -20,6 +20,10 @@ Note that this model does not include much of the beamline optics, instead it em
 by settgin relevant beam parameters from a model source.
 ```
 
+## Examples
+
+- **Test: ESRF_BM29.instr Lambda=1 Detector: QMonitor_I=5.2e-12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/ESRF/ESRF_ID01/README.md
+++ b/mcxtrace-comps/examples/ESRF/ESRF_ID01/README.md
@@ -23,6 +23,12 @@ e.g. total detector intensity as a function of position, one can map out impurit
 their scattering properties.
 ```
 
+## Examples
+
+- **Test: ESRF_ID01.instr Pix=0 Piy=0 Detector: PSDMonitor_I=3.26027e-05**
+- **Test: ESRF_ID01.instr Delta=65.88 Eta=32.945 Pix=50 Piy=-50 Detector: MAXIPix_I=1.77323e-06**
+- **Test: ESRF_ID01.instr Delta=67.44 Eta=33.22 Pix=50 Piy=-50 Detector: MAXIPix_I=2.26516e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/ESRF/ESRF_ID11/README.md
+++ b/mcxtrace-comps/examples/ESRF/ESRF_ID11/README.md
@@ -15,6 +15,10 @@
 Model of the ESRF ID11 Transfocator based beamline.
 ```
 
+## Examples
+
+- **Test: ESRF_ID11.instr ANGLE=0 Detector: psd_eh3_sample_I=0.284963**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/MAXII/MAXII_711/README.md
+++ b/mcxtrace-comps/examples/MAXII/MAXII_711/README.md
@@ -16,6 +16,10 @@ A simple beamline setup consisting of a single focusing mirror,
 a monochromator, and a four-circle goniometer at the sample stage.
 ```
 
+## Examples
+
+- **Test: MAXII_711.instr R=-100 tth=28 dphi=30 -n1e7 Detector: mono_exit_psd_I=5.1609e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/MAXII/MAXII_811/README.md
+++ b/mcxtrace-comps/examples/MAXII/MAXII_811/README.md
@@ -22,6 +22,11 @@ If mirrors are in the monochromators are automatically reposistioned to
 accomadate the deflected beam.
 ```
 
+## Examples
+
+- **Test: MAXII_811.instr M1=1 M2=1 M1_pitch=1 M2_pitch=1 theta=14.226   Detector: sphere_psd_I=2.0e+08**
+- **Test: MAXII_811.instr M1=0 M2=0 theta=14.226    Detector: hutch_E2_I=2.25761e+11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/MAXIV/MAXIV_Bloch/README.md
+++ b/mcxtrace-comps/examples/MAXIV/MAXIV_Bloch/README.md
@@ -19,6 +19,11 @@ P Parameters are the ones used in the general simulation, i.e when the FOI is in
 P2 parameters are used when the strain of the beamline is the FOI, i.e what happens when the distances change.
 ```
 
+## Examples
+
+- **Test: E0=0.03 dE=0 undK=0 Nper=187 zm_mirror1=14 theta_mirror1=3 R0_M1=1 zm_mirror2=2 R0_M2=1  grating_mode=0 zm_mirror3=1 theta_mirror3=3 R0_M3=1 zm_ExitSlit=9 xwidth_ExSlit=0.005 yheight_ExSlit=0.005 zm_mirror4=19 theta_mirror4=3 R0_M4=1 SourceChoice=0 cff=2.25 m=3 Exitslit_yshift=2 Detector: M4Before_e_monitor_I=5.64942e-20**
+- **Test: E0=0.6 Detector: M4Before_e_monitor_I=1.80435e-21**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/MAXIV/MAXIV_DanMAX_pxrd1d/README.md
+++ b/mcxtrace-comps/examples/MAXIV/MAXIV_DanMAX_pxrd1d/README.md
@@ -17,6 +17,10 @@ This early version uses a Gaussian approximation source, and a simple bandpass f
 as the multilayer.
 ```
 
+## Examples
+
+- **Test: MAXIV_DanMAX_pxrd1d.instr -c -n1e6 E0=15 PXRD_SIMPLE=1 Detector: dm_strip_banana_I=0.00081782**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/MAXIV/MAXIV_DanMAX_pxrd2d/README.md
+++ b/mcxtrace-comps/examples/MAXIV/MAXIV_DanMAX_pxrd2d/README.md
@@ -17,6 +17,10 @@ This early version uses a Gaussian approximation source, and a simple bandpass f
 as the multilayer.
 ```
 
+## Examples
+
+- **Test: MAXIV_DanMAX_pxrd2d.instr -c -n1e6 E0=15 Detector: Pilatus_2M_I=8.10837e-05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/MAXIV/MAXIV_FemtoMAX/README.md
+++ b/mcxtrace-comps/examples/MAXIV/MAXIV_FemtoMAX/README.md
@@ -16,6 +16,10 @@ This a a skeleton version of the FemtoMAX short-pulse facility at MAXIV
 N.b. This model is out of date with the present day instrumentation of FemtoMAX.
 ```
 
+## Examples
+
+- **Test: DXUS=1e-2 Detector: EXAFS_I=2.74995e-13**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/NBI/NBI_Lab_TOMO/README.md
+++ b/mcxtrace-comps/examples/NBI/NBI_Lab_TOMO/README.md
@@ -16,6 +16,11 @@ Consists simply of a Mo-source, a sample, an Al-filter and a detector, all in li
 The sample is a chess-king off-shape.
 ```
 
+## Examples
+
+- **Test: NBI_Lab_TOMO.instr -n 1e5 fname="spectrumU50_th5.dat" Omega=0 detw=0.2 deth=0.2 Detector: Detector_Si_I=3.9e+13**
+- **Test: NBI_Lab_TOMO.instr fname="spectrumU50_th5.dat" Detector: Detector_Si_I=9.77305e+11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/NECSA/NECSA_Brucker_D8_Advance/README.md
+++ b/mcxtrace-comps/examples/NECSA/NECSA_Brucker_D8_Advance/README.md
@@ -23,6 +23,10 @@ This is a lab-scale diffractometer, Brucker D8 Advance type.
 Example: <parameters=values>
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/NECSA/NECSA_MIXRAD_Nikon_Tomo/README.md
+++ b/mcxtrace-comps/examples/NECSA/NECSA_MIXRAD_Nikon_Tomo/README.md
@@ -25,6 +25,10 @@ This is a simple description of the MIXRAD Nikon X-ray tomograph installed at NE
 Example: <parameters=values>
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/NIST/DBD_IBM_Si_analyzer_BC/README.md
+++ b/mcxtrace-comps/examples/NIST/DBD_IBM_Si_analyzer_BC/README.md
@@ -15,6 +15,10 @@
 This is a preliminary setup of the DBD with the Ge111 Johansson IBM
 ```
 
+## Examples
+
+- **Test: use_flat_source=0 -n1e7 Detector: focus_monitor_I=2.38803e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/NIST/PBD_BT/README.md
+++ b/mcxtrace-comps/examples/NIST/PBD_BT/README.md
@@ -15,6 +15,10 @@
 This is a preliminary setup of the PBD, using single-bounce crystals instead of 3-bounce crystals
 ```
 
+## Examples
+
+- **Test: beam_vert=0.005 beam_hor=0.001 slit_1_vert=0.001 slit_1_hor=0.002 omega=53.35 theta=160.05 Detector: mirror_psd_I=1.11886e+16**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/NSLS2/NSLS2_CHX/README.md
+++ b/mcxtrace-comps/examples/NSLS2/NSLS2_CHX/README.md
@@ -20,6 +20,10 @@ The choice of the source sizes along with angular divergence corresponds to the 
 high emittance (e=0.99nm).
 ```
 
+## Examples
+
+- **Test: NSLS2_CHX -n1e6 L=33.5 L2=35.3 L3=44 Energy=10 Detector: Det_ff_I=2.82787e+16**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SAXSLAB/JJ_SAXS/README.md
+++ b/mcxtrace-comps/examples/SAXSLAB/JJ_SAXS/README.md
@@ -19,6 +19,10 @@ Limitations include:
 - iNo reflectivity coating is implemented.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SAXSLAB/SAXS_saxlab/README.md
+++ b/mcxtrace-comps/examples/SAXSLAB/SAXS_saxlab/README.md
@@ -29,6 +29,10 @@ which points slightly down.
 In real life the beam axis is parallel to the ground and the source is shining slightly upwards.
 ```
 
+## Examples
+
+- **Test: Energy=8.05 Detector: detector_I=1.28656e+07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_ANATOMIX/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_ANATOMIX/README.md
@@ -58,6 +58,10 @@ EH3             | 165.7-174.1 | Guard slits; TXM sample stage and zone-plate tab
 EH4             | 197.2-208.5 | Guard slits; microtomography sample stage; detector table; X-ray grating interferometer | EH4
 ```
 
+## Examples
+
+- **Test: -n 1e5 E0=17 Detector: psd_monitor_after_cc_I=1e18**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_CASSIOPEE/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_CASSIOPEE/README.md
@@ -31,6 +31,10 @@ Position | Element
 30.83    | Slit
 ```
 
+## Examples
+
+- **Test: E0=0 Detector: PSD_M1out_I=2.74309e+15**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_DIFFABS/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_DIFFABS/README.md
@@ -40,6 +40,10 @@ Position | Element
 32.09    | a set of detectors (transmission, XRD and XRF), radius 654 mm
 ```
 
+## Examples
+
+- **Test: E0=13 Detector: sample_stage_I=2.20096e+10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_DISCO/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_DISCO/README.md
@@ -17,6 +17,10 @@ You may scan the grating monochromator with e.g.:
 mxrun -n 1e5 SOLEIL_DISCO.instr -N84 x_screw=20,103 scan=1
 ```
 
+## Examples
+
+- **Test: grazing_angle_one=22.5 -n 1e5 Detector: second_HFP_I=2.08292e+11**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_LUCIA/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_LUCIA/README.md
@@ -24,6 +24,10 @@ Position | Element
 29.1     | Fluorescence Detector at 90 deg
 ```
 
+## Examples
+
+- **Test: -n 1e7 E0=3.09 Detector: mon_spl_SDD_I=9.69081e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_MARS/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_MARS/README.md
@@ -26,6 +26,10 @@ HERFD-XANES) and microbeam techniques (microXRF, XAS, XRD).
 This model implements the XRD station for powders.
 ```
 
+## Examples
+
+- **Test: E0=16.99 Detector: detector_diffraction_I=2.56e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_PSICHE/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_PSICHE/README.md
@@ -24,6 +24,10 @@ and the monochromatic beam tomography.
 The sample handles absorption, with edge contrast, as well as fluorescence.
 ```
 
+## Examples
+
+- **Test: -n 1e6 E0=25 sample_material="Ag0.6In0.2Sn0.2" Detector: mon_spl_xy_I=7.61e+13**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_PX2a/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_PX2a/README.md
@@ -31,6 +31,11 @@ This is a simplified model with an Undulator, mirrors, a double crystal
 monochromator, a sample stage and a detector.
 ```
 
+## Examples
+
+- **Test: E0=12.65 sample="Mo.lau" SPLITs=1500 Detector: psd4pi_I=1.75e+12**
+- **Test: E0=12.65 sample="adrenaline.lau" SPLITs=4200 Detector: psd4pi_I=4.5e+15**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.
@@ -45,6 +50,7 @@ Parameters in **boldface** are required; the others are optional.
 | rotX | deg | Sample rotation around X | 0 |
 | rotY | deg | Sample rotation around Y | 0 |
 | rotZ | deg | Sample rotation around Z | 0 |
+| SPLITs |  |  | 10 |
 
 ## Links
 

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_ROCK/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_ROCK/README.md
@@ -46,6 +46,10 @@ Manganese and chrome scan: mxrun SOLEIL_ROCK.instr E0=5.700,6.800 scan=1 sample_
 Pretty energy repartition monitor result: mxrun SOLEIL_ROCK.instr E0=17.000 cc=2 -n1e8
 ```
 
+## Examples
+
+- **Test: E0=15.918 Detector: fluo_monitor_I=2e+09**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_SIXS/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_SIXS/README.md
@@ -47,6 +47,10 @@ Position | Element
 Example: E0=10 Detector: mon_spl_fluo_I=3.66859e+14
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SOLEIL/SOLEIL_SWING/README.md
+++ b/mcxtrace-comps/examples/SOLEIL/SOLEIL_SWING/README.md
@@ -35,6 +35,10 @@ Position | Element
 Example: E0=13 Detector: Eiger4M_I=7.5752e+06
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SSRL/SSRL_bl_11_2_not_white_src/README.md
+++ b/mcxtrace-comps/examples/SSRL/SSRL_bl_11_2_not_white_src/README.md
@@ -24,6 +24,10 @@ mxrun -n 1e7 SSRL_bl_11_2_not_white_src.instr -N601 Etohit=6900,7500
 Example: Etohit=6900 Detector: EnergyMonitor_first_I=1.3e+10
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/SSRL/SSRL_bl_11_2_white_src/README.md
+++ b/mcxtrace-comps/examples/SSRL/SSRL_bl_11_2_white_src/README.md
@@ -21,6 +21,10 @@ You may scan like so for example:
 mxrun -n 1e7 SSRL_bl_11_2_white_src.instr -N601 Etohit=6900,7500 detuning_percentage=40
 ```
 
+## Examples
+
+- **Test: Etohit=6900 Detector: EnergyMonitor_first_I=4.24366e+07**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Templates/Focal_pt_monitor/README.md
+++ b/mcxtrace-comps/examples/Templates/Focal_pt_monitor/README.md
@@ -26,6 +26,10 @@ is placed elsewhere an implicit offset will be the result.
 The
 ```
 
+## Examples
+
+- **Test: Focal_pt_monitor Rcurve=100e-6 Detector: fpt_I=1.9805e-16**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Templates/Template_1Slit_Diff/README.md
+++ b/mcxtrace-comps/examples/Templates/Template_1Slit_Diff/README.md
@@ -17,6 +17,10 @@ The slit is positioned 1m downstream from a point source. The slit
 width may be varied. The slit height is set to .8e-6 m.
 ```
 
+## Examples
+
+- **Test: SLITW=5e-6 Detector: psd0_I=9.89638e-14**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Templates/Template_2Slit_Diff/README.md
+++ b/mcxtrace-comps/examples/Templates/Template_2Slit_Diff/README.md
@@ -17,6 +17,10 @@ Two identical slits are positioned 1m downstream from a point source, The slit
 width and their separation may be varied. The slit height is set to .8e-6 m.
 ```
 
+## Examples
+
+- **Test: SLITW=1e-6 SLITSEP=4e-6 Detector: psd0_I=7.1e-14**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Templates/Template_Johann_spec/README.md
+++ b/mcxtrace-comps/examples/Templates/Template_Johann_spec/README.md
@@ -23,6 +23,10 @@ To include a Johann spectrometer in an instrument the sample should be put where
 source is in this template. and otherwis copy-paste.
 ```
 
+## Examples
+
+- **Test: L=2 dtheta_s=0 Detector: det4_I=9.5640e-05**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Templates/template/README.md
+++ b/mcxtrace-comps/examples/Templates/template/README.md
@@ -24,6 +24,10 @@ once your instrument is written and functional:
 sensible parameter set.
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Templates/template_simple/README.md
+++ b/mcxtrace-comps/examples/Templates/template_simple/README.md
@@ -17,6 +17,10 @@
 Example: <parameters=values>
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests/Be_BM_beamline/README.md
+++ b/mcxtrace-comps/examples/Tests/Be_BM_beamline/README.md
@@ -19,6 +19,10 @@ other wavelengths present in the beam will not be focussed prefectly and may be
 by the slit.
 ```
 
+## Examples
+
+- **Test: L1=10 Detector: psd2_I=21256.7**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests/Test_Detector_pn/README.md
+++ b/mcxtrace-comps/examples/Tests/Test_Detector_pn/README.md
@@ -21,6 +21,10 @@ A restore_flag parameter may be passed to Detector_pn which negates the absorpti
 effect for subsequent components.
 ```
 
+## Examples
+
+- **Test: Test_Detector_pn restore_flag=1 Detector: detap2_I=1.02182e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests/Test_Monitor_nD_10_uservars/README.md
+++ b/mcxtrace-comps/examples/Tests/Test_Monitor_nD_10_uservars/README.md
@@ -15,6 +15,10 @@
 Instrument demonstrating 10 uservars available in Monitor_nD
 ```
 
+## Examples
+
+- **Test: NCount=1e3 Detector: Flex2D_I=1000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests/Test_monitors/README.md
+++ b/mcxtrace-comps/examples/Tests/Test_monitors/README.md
@@ -15,6 +15,13 @@
 This is a unit test instrument to test some of the McXtrace monitors.
 ```
 
+## Examples
+
+- **Test: Test_monitors.instr monitor_no=1 Detector: epsd0_I=1.81362**
+- **Test: Test_monitors.instr monitor_no=2 Detector: epsd1_I=1.81367**
+- **Test: Test_monitors.instr monitor_no=3 Detector: div_I=1.83645**
+- **Test: Test_monitors.instr monitor_no=4 Detector: mnd_psd_I=1.83632**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_input/README.md
+++ b/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_input/README.md
@@ -15,6 +15,11 @@
 This is a unit test for the MCPL_input component.
 ```
 
+## Examples
+
+- **Test: -n1e3 repeat=1 MCPLFILE=voutput.mcpl.gz     Detector: m1_I=7.9657e-08**
+- **Test: -n1e3 repeat=1 MCPLFILE=voutput_legacy.mcpl Detector: m1_I=7.9657e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_output/README.md
+++ b/mcxtrace-comps/examples/Tests_MCPL_etc/Test_MCPL_output/README.md
@@ -15,6 +15,10 @@
 This is a unit test for the MCPL_output component.
 ```
 
+## Examples
+
+- **Test: Ncount=1e3 -n1e3 Detector: m1_I=7.9657e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_RNG/Test_RNG_rand01/README.md
+++ b/mcxtrace-comps/examples/Tests_RNG/Test_RNG_rand01/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=1000 Detector: PSD_I=1000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randnorm/README.md
+++ b/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randnorm/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=0.999999999**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randpm1/README.md
+++ b/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randpm1/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=1000 Detector: PSD_I=1000**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randtriangle/README.md
+++ b/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randtriangle/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=1.0**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randvec_target_circle/README.md
+++ b/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randvec_target_circle/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect/README.md
+++ b/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: PSD_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect_angular/README.md
+++ b/mcxtrace-comps/examples/Tests_RNG/Test_RNG_randvec_target_rect_angular/README.md
@@ -21,6 +21,10 @@ For a low statistics, one may e.g. check that setting the seed gives
 varied output or fixing the seed gives fixed output·
 ```
 
+## Examples
+
+- **Test: Ncount=20000000 Detector: Div_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_grammar/Test_GROUP/README.md
+++ b/mcxtrace-comps/examples/Tests_grammar/Test_GROUP/README.md
@@ -15,6 +15,11 @@
 Unit test for the GROUP logic
 ```
 
+## Examples
+
+- **Test: SIGNI=1  Detector: psd00_I=7.9e-8**
+- **Test: SIGNI=-1 Detector: psd00_I=7.9e-8**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Template_DCM/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Template_DCM/README.md
@@ -19,6 +19,10 @@ simply add Arms before and after the crystal assembly that rotate by
 The crystal is illuminated by a model point source.
 ```
 
+## Examples
+
+- **Test: theta=9.17 Detector: emon_dcm1_I=6.14859e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_CRL/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_CRL/README.md
@@ -19,6 +19,13 @@ This is a test with the
 - LENS=3: Lens_CRL_RTM
 ```
 
+## Examples
+
+- **Test: Test_CRL.instr LENS=0 L1=35.047 L2=17.523 Detector: line_I=1.20107e-12**
+- **Test: Test_CRL.instr LENS=1 L1=35.047 L2=17.523 Detector: pt_I=3.01094e-13**
+- **Test: Test_CRL.instr LENS=2 L1=35.047 L2=17.523 Detector: line_I=1.2957e-12**
+- **Test: Test_CRL.instr LENS=3 L1=35.047 L2=17.523 Detector: line_I=1.20107e-12**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_CRL_Be/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_CRL_Be/README.md
@@ -15,6 +15,10 @@
 Test of a compound refractive lenses using the Lens_parab component.
 ```
 
+## Examples
+
+- **Test: Test_CRL_Be L=14 Detector: e_monitor_I=0.341818**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_Filter/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_Filter/README.md
@@ -15,17 +15,22 @@
 Test instrument for checking the Filter.comp component
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.
 
 | Name | Unit | Description | Default |
 |------|------|-------------|---------|
-| filter_mat |  | Chemical symbol of the filter material | "Rh.txt" |
+| filter_mat |  | Chemical symbol / datafile of the filter material | "Rh.txt" |
 | thickness | m | thickness of the filter block | 100e-6 |
 | L0 | AA | centre wavlength of the source | 1 |
 | DL | AA | half width of the (uniform) wavelength distribution | 0.1 |
 | F2 | 1 | add a 2nd filter component further away | 0 |
+| mu_col | idx | Index of mu-column (from 0) in datafile (required for some inputs). | -1 |
 
 ## Links
 

--- a/mcxtrace-comps/examples/Tests_optics/Test_KB/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_KB/README.md
@@ -19,6 +19,10 @@ The KB should satisfy f_m=R.sin(theta/2) and f_s=R/2.sin(theta)
 Example: Test_KB L=12
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_ML_elliptic/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_ML_elliptic/README.md
@@ -16,6 +16,12 @@ Tests the correct working of the mulitlyer_elliptic component both using a
 reflectivity file and the kinematical approximation.
 ```
 
+## Examples
+
+- **Test: Test_ML_elliptic.instr S1=1 S2=2 gamma=1.2 fromfile=0 Detector: emon1_I=6.91956e-21**
+- **Test: Test_ML_elliptic.instr S1=1 S2=2 gamma=1.2 fromfile=1 Detector: emon1_I=4.61321e-21**
+- **Test: Test_ML_elliptic.instr S1=1 S2=2 gamma=1.2 fromfile=1 fxw=2e-2 fyh=1e-3 Detector: emon1_I=9.22372e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_Mask/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_Mask/README.md
@@ -16,6 +16,11 @@ A non-divergent beam impinges on a masking image, with 2d-detectors up- and down
 of the mask.
 ```
 
+## Examples
+
+- **Test: Test_Mask.instr invert=0 Detector: psd1_I=0.223645**
+- **Test: Test_Mask.instr invert=1 Detector: psd1_I=0.670667**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_Mirror_toroid/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_Mirror_toroid/README.md
@@ -15,6 +15,10 @@
 A mere unit test instrument. Also includes a perfectly flat Mirror as reference.
 ```
 
+## Examples
+
+- **Test: Test_Mirror_toroid.instr gamma=5 Detector: psd3_I=7.21499e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_Mirrors/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_Mirrors/README.md
@@ -19,9 +19,31 @@ index=1: Mirror_elliptic
 index=2: Mirror_parabolic
 index=3: Mirror_curved
 index=4: Mirror_toroid
-index=5: Mirror_toroid_pothole
-index=6: Multilayer_elliptic
+index=5: Multilayer_elliptic
+index=6: Mirror_toroid_pothole (contrib)
 ```
+
+## Examples
+
+- **Test: Test_Mirrors.instr index=0 gamma=5 Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=1 gamma=5 Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=2 gamma=5 Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=3 gamma=5 Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=4 gamma=5 Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=5 gamma=5 Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=6 gamma=5 Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=0 gamma=0.1 coating=Ref_W_Si.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=1 gamma=0.1 coating=Ref_W_Si.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=2 gamma=0.1 coating=Ref_W_Si.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=3 gamma=0.1 coating=Ref_W_Si.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=4 gamma=0.1 coating=Ref_W_Si.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=5 gamma=0.1 coating=Ref_W_Si.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=0 gamma=0.1 coating=Ref_W_B4C.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=1 gamma=0.1 coating=Ref_W_B4C.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=2 gamma=0.1 coating=Ref_W_B4C.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=3 gamma=0.1 coating=Ref_W_B4C.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=4 gamma=0.1 coating=Ref_W_B4C.txt Detector: psd4_I=2e-08**
+- **Test: Test_Mirrors.instr index=5 gamma=0.1 coating=Ref_W_B4C.txt Detector: psd4_I=2e-08**
 
 ## Input parameters
 
@@ -29,11 +51,12 @@ Parameters in **boldface** are required; the others are optional.
 
 | Name | Unit | Description | Default |
 |------|------|-------------|---------|
-| gamma | deg | Nominal glancing angle of mirror | 0.5 |
+| gamma | deg | Nominal glancing angle of mirror | 5 |
 | index | 1 | Index of the Mirror component to test | 1 |
 | L | m | Distance source-mirror and mirror-detector | 2 |
 | radius | m | Radius of curvature | 1000 |
 | E0 | keV | Mean photon energy | 12.5 |
+| coating | string | "None" or reflectivity file, such as "Ref_W_B4C.txt" | "NULL" |
 
 ## Links
 

--- a/mcxtrace-comps/examples/Tests_optics/Test_Mono/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_Mono/README.md
@@ -24,6 +24,14 @@ The input parameter 'Mono' chooses which model to use:
 5: Bragg_crystal_simple - a simple mono with a static (flat) Darwin width.
 ```
 
+## Examples
+
+- **Test: Test_Mono.instr Mono=1 Detector: emon_I=5.39036e-17**
+- **Test: Test_Mono.instr Mono=2 Detector: emon_I=5.41029e-17**
+- **Test: Test_Mono.instr Mono=3 Detector: emon_I=5.33687e-17**
+- **Test: Test_Mono.instr Mono=4 Detector: emon_I=5.33687e-17**
+- **Test: Test_Mono.instr Mono=5 Detector: emon_I=5.33687e-17**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_capillary/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_capillary/README.md
@@ -16,6 +16,10 @@ Very simple setup to compare intensities diffracted by Monochromators.
 It shows that implementations are equivalent.
 ```
 
+## Examples
+
+- **Test: Test_capillary -n 1e6 TL=3 TR=0.001 L1=0.4 Detector: psd14_I=7.34669e-08**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_grating_reflect/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_grating_reflect/README.md
@@ -15,6 +15,10 @@
 Simply a bending magnet illuminating a reflection grating.
 ```
 
+## Examples
+
+- **Test: E0=1 Detector: psd_monitor_I=3.79378e+06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_grating_trans/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_grating_trans/README.md
@@ -16,6 +16,11 @@ A simple test insrument for the transmission grating component. Two examples
 of gratings are included matching those in the Chandra X-ray Observatory
 ```
 
+## Examples
+
+- **Test: Test_grating_trans.instr E0=1.2 dE=0.01 GD=3 MEG=0 Detector: psd_giant_I=0.0269197**
+- **Test: Test_grating_trans.instr E0=1.2 dE=0.01 GD=3 MEG=1 Detector: psd_giant_I=0.0573462**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_mirror_elliptic/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_mirror_elliptic/README.md
@@ -18,6 +18,10 @@ Try distance_from_source = 1 (rays reflected back towards the center)
 distance_from_source = 0.5 (rays reflected back in a parallel-like fashion)
 ```
 
+## Examples
+
+- **Test: distance_from_source=1 Detector: psd_monitor_I=3.3e-9**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_optics/Test_mirror_parabolic/README.md
+++ b/mcxtrace-comps/examples/Tests_optics/Test_mirror_parabolic/README.md
@@ -17,6 +17,11 @@ with normal incidence on a parabolic mirror, is reflected to the focal point, an
 back to flat detector some distance, D, away.
 ```
 
+## Examples
+
+- **Test: D=0.0025 MM=1 Detector: detBB_I=1**
+- **Test: D=1 MM=1 Detector: detBB_I=0.104959**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_other/test_File/README.md
+++ b/mcxtrace-comps/examples/Tests_other/test_File/README.md
@@ -16,6 +16,10 @@ input-files as METADATA blocks*
 
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Template_SasView/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Template_SasView/README.md
@@ -20,6 +20,12 @@ Select sample model with 'model_index':
 47= SasView_parallelepiped
 ```
 
+## Examples
+
+- **Test: model_index=1 Ncount=1e5 par1=4 par2=1 par3=40 par4=20 par5=400 Detector: detector_I=605**
+- **Test: model_index=3 Ncount=1e5 par1=220 par2=0.06 par3=40 par4=4 par5=1 Detector: detector_I=4.2**
+- **Test: model_index=47 Ncount=1e5 par1=4 par2=2 par3=35 par4=75 par5=400 Detector: detector_I=297**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_Absorption/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Absorption/README.md
@@ -22,6 +22,13 @@ This test compares the folowwing components:
 - index=4: Fluorescence
 ```
 
+## Examples
+
+- **Test: Test_Absorption.instr -n1e5 index=1 Detector: emon_I=8.25376e-12**
+- **Test: Test_Absorption.instr -n1e5 index=2 Detector: emon_I=8.24127e-12**
+- **Test: Test_Absorption.instr -n1e5 index=3 Detector: emon_I=8.28866e-12**
+- **Test: Test_Absorption.instr -n1e5 index=4 Detector: emon_I=9.36962e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_Air/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Air/README.md
@@ -16,6 +16,10 @@ This instrument checks whether the Air component works as intended.
 A point source illuminates  the central part of a rectangular volume of air ( 0.02 x 0.02 x Lair  m^3 ).
 ```
 
+## Examples
+
+- **Test: Test_Air.instr AIR=1 E0=7 Lair=0.01 Detector: fpi_scat_I=7.94701e-15**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_FluoPowder/README.md
@@ -22,6 +22,16 @@ The idea is to compare the fluorescence and diffraction patterns:
 - index=5: use Fluorescence+PowderN (under estimates contributions)
 ```
 
+## Examples
+
+- **Test: Test_FluoPowder.instr E0=15 index=1 Detector: Sph_mon_pow_I=2.23591e-18**
+- **Test: Test_FluoPowder.instr -n 1e5 E0=15 index=2 Detector: Sph_mon_pow_I=1.89664e-18**
+- **Test: Test_FluoPowder.instr E0=15 index=3 Detector: Sph_mon_I=2.8904e-18**
+- **Test: Test_FluoPowder.instr E0=15 index=4 Detector: Sph_mon_flu_I=6.18074e-19**
+- Example: Test_FluoPowder.instr E0=15 index=5 Detector: Sph_mon_I=1.76094e-18
+- 
+- (Fluorescence+PowderN GROUP is unstable on GPU, disable index=5 test for now)
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Fluorescence/README.md
@@ -16,6 +16,10 @@ This instrument simply has a lab source, a few monitors and a sample
 to model material fluorescence, Compton and Rayleigh scattering.
 ```
 
+## Examples
+
+- **Test: Test_Fluorescence.instr material=LaB6 -n1e5 Detector: emon_I=1.31537e-14**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_PowderN/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_PowderN/README.md
@@ -17,6 +17,14 @@ The default sample itself is an LaB6-powder.
 Alternatively, the Single_crystal (powder mode) and FluoPowder components can also be tested.
 ```
 
+## Examples
+
+- **Test: index=1 Detector: Sph_mon_I=1.26755e-11**
+- Example: index=2 Detector: Sph_mon_I=4.44793e-13
+- **Test: index=3 Detector: Sph_mon_I=1.98093e-11**
+- 
+- (Unittest disabled for Single_crystal powder-mode, numerically unstable on GPU)
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_SAXS/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_SAXS/README.md
@@ -29,6 +29,20 @@ SAXSNanodiscsWithTagsFast SAMPLE=10
 SAXSPDBFast               SAMPLE=11
 ```
 
+## Examples
+
+- **Test: SAMPLE=0 Detector: PSDMonitor_I=2.93715e-14**
+- **Test: SAMPLE=1 Detector: PSDMonitor_I=2.7118e-14**
+- **Test: SAMPLE=2 Detector: PSDMonitor_I=2.64954e-14**
+- **Test: SAMPLE=3 Detector: PSDMonitor_I=9.77905e-15**
+- **Test: SAMPLE=4 Detector: PSDMonitor_I=1.16433e-10**
+- **Test: SAMPLE=5 Ncount=1e4 Detector: PSDMonitor_I=1.2001e-14**
+- **Test: SAMPLE=6 Ncount=1e4 Detector: PSDMonitor_I=1.2400e-14**
+- **Test: SAMPLE=7 Ncount=1e4 Detector: PSDMonitor_I=7.07865e-14**
+- **Test: SAMPLE=9 Detector: PSDMonitor_I=1.11073e-14**
+- **Test: SAMPLE=10 Detector: PSDMonitor_I=1.02884e-14**
+- **Test: SAMPLE=11 Detector: PSDMonitor_I=5.47707e-15**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_SX/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_SX/README.md
@@ -22,6 +22,14 @@ The idea is to compare the fluorescence and diffraction patterns:
 
 ```
 
+## Examples
+
+- **Test: index=1 Detector: psd_Diff_I=2.29638e-13**
+- **Test: index=2 Detector: psd_Diff_I=6.1e-14**
+- Example: index=3 Detector: psd_Diff_I=1.19386e-13
+- 
+- (Fluorescence+Single_crystal GROUP is unstable on GPU, disable index=3 test for now)
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_SX_standalone/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_SX_standalone/README.md
@@ -18,6 +18,10 @@ The default sample itself is a Mo bulk crystal.*
 
 ```
 
+## Examples
+
+- **Test: -y Detector: psd_Diff_I=2.29638e-13**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_Saxs_spheres/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Saxs_spheres/README.md
@@ -18,6 +18,10 @@ The spheres are nominally made from Be in non-absorbing solution.*
 
 ```
 
+## Examples
+
+- **Test: Test_Saxs_spheres.instr -n1e6 RR=20 Detector: detector2_I=5.0956e-16**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_samples/Test_Sqw/README.md
+++ b/mcxtrace-comps/examples/Tests_samples/Test_Sqw/README.md
@@ -15,6 +15,10 @@
 A test instrument for testing Isotropic_Sqw output on a spherical monitor.
 ```
 
+## Examples
+
+- **Test: E0=12 Detector: Sph_mon_I=3.63728e-21**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_sources/Test_BM/README.md
+++ b/mcxtrace-comps/examples/Tests_sources/Test_BM/README.md
@@ -15,6 +15,11 @@
 This is a simple test-instrument for the bending magnet component.
 ```
 
+## Examples
+
+- **Test: Test_BM.instr SOURCE=0 e0=12.5 de=0.5 Detector: emon_I=2.93138e+13**
+- **Test: Test_BM.instr SOURCE=1 e0=12.5 de=0.5 Detector: emon_I=1.28549e+15**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_sources/Test_Source_quasi/README.md
+++ b/mcxtrace-comps/examples/Tests_sources/Test_Source_quasi/README.md
@@ -15,6 +15,11 @@
 This instrument is a unit test for the quasi-stochastic source component.
 ```
 
+## Examples
+
+- **Test: Test_Source_quasi.instr SRC=0 Detector: psd_I=1**
+- **Test: Test_Source_quasi.instr SRC=1 Detector: psd_I=1**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_sources/Test_Sources/README.md
+++ b/mcxtrace-comps/examples/Tests_sources/Test_Sources/README.md
@@ -25,6 +25,17 @@ Source_div      SRC=6
 Source_div      SRC=7
 ```
 
+## Examples
+
+- **Test: Test_Sources.instr SRC=0 Detector: emon_I=1.99918**
+- **Test: Test_Sources.instr SRC=1 Detector: psd_I=1.59652**
+- **Test: Test_Sources.instr SRC=2 Detector: lmon_I=7.95755e-06**
+- **Test: Test_Sources.instr SRC=3 Detector: emon_I=7.95649e-06**
+- **Test: Test_Sources.instr SRC=4 Detector: lmon_I=7.95748e-06**
+- **Test: Test_Sources.instr SRC=5 Detector: psd_I=7.95748e-06**
+- **Test: Test_Sources.instr SRC=6 Detector: emon_I=1**
+- **Test: Test_Sources.instr SRC=7 Detector: lmon_I=0.993603**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_sources/Test_source_lab/README.md
+++ b/mcxtrace-comps/examples/Tests_sources/Test_source_lab/README.md
@@ -16,6 +16,11 @@ This instrument serves as a unit test for the Source_lab component.
 The emon1-monitor catches the Kalpha-peaks, and emon2 the Kbeta peaks.
 ```
 
+## Examples
+
+- **Test: Test_source_lab.instr Emax=40 Detector: emon1_I=7.16e+15**
+- **Test: Test_source_lab.instr Emax=40 Detector: emon2_I=1.17e+15**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_sources/Test_source_spectra/README.md
+++ b/mcxtrace-comps/examples/Tests_sources/Test_source_spectra/README.md
@@ -16,6 +16,11 @@ A unit test instrument for the Source component that can take input from a SPECT
 of an undulator/wiggler etc. and input it into McXtrace.
 ```
 
+## Examples
+
+- **Test: Test_source_spectra.instr flag4d=0 E0=12.4 dE=0.001 stemx=sp8LU_x stemy=sp8LU_y Detector: psd2_I=1.42775e+11**
+- **Test: Test_source_spectra.instr flag4d=1 E0=12.4 dE=0.001 stem4d=sp8LU_xy Detector: psd2_I=3.53418e-06**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_sources/Test_undulator/README.md
+++ b/mcxtrace-comps/examples/Tests_sources/Test_undulator/README.md
@@ -15,6 +15,10 @@
 A simple undulator with parameters as in Kim, 1989 (sec. 4).
 ```
 
+## Examples
+
+- **Test: Test_undulator.instr minh=1 maxh=2 FAST=1 Detector: e_monitor1_I=2e+14**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_union/Geometry_test/README.md
+++ b/mcxtrace-comps/examples/Tests_union/Geometry_test/README.md
@@ -20,6 +20,10 @@ Example: meshfile="torus.off" Detector: detector_scat_I=47.5
 Example: meshfile="torus.STL" Detector: detector_scat_I=47.5
 ```
 
+## Examples
+
+
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/Tests_union/PowderCompton_union/README.md
+++ b/mcxtrace-comps/examples/Tests_union/PowderCompton_union/README.md
@@ -16,6 +16,11 @@ An example instrument showing the union system with a sample geometry consisting
 of a sphere and a box
 ```
 
+## Examples
+
+- **Test: E0=12 refs=Al2O3_Corundum_COD_9007634.cif.hkl Detector: fpi_I=6.55324e-10**
+- **Test: E0=12 refs=Pb_Lead_COD_9008477.cif.hkl Detector: fpi_I=3.4529e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.
@@ -23,9 +28,8 @@ Parameters in **boldface** are required; the others are optional.
 | Name | Unit | Description | Default |
 |------|------|-------------|---------|
 | E0 | keV | incident energy | 12 |
-| refs1 |  |  | "data/Corundum.cif.laz" |
-| refs2 |  |  | "data/Pb.cif.hkl" |
-| YY |  |  | 0 |
+| refs | string | Reflection-list for powder-process | "Al2O3_Corundum_COD_9007634.cif.hkl" |
+| YY | m | Vertical slit-position | 0 |
 
 ## Links
 

--- a/mcxtrace-comps/examples/Tests_union/Test_KN_Comp_Rayl_union/README.md
+++ b/mcxtrace-comps/examples/Tests_union/Test_KN_Comp_Rayl_union/README.md
@@ -16,6 +16,10 @@ An example instrument that uses either Klein-Nishina, Rayleigh, or Compton on a 
 filled with whatever material is indicated by the atom number
 ```
 
+## Examples
+
+- **Test: E0=12 Detector: emon_sphere_I=1.7661e-10**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/mcxtrace-comps/examples/XFEL/XFEL_SPB/README.md
+++ b/mcxtrace-comps/examples/XFEL/XFEL_SPB/README.md
@@ -17,6 +17,10 @@ This model includes the long beam transport from the source all the way into
 experimental hutch.
 ```
 
+## Examples
+
+- **Test: XFEL_SPB.instr preCRL=0 -n1e7 L0=1.3051 DL=0.01 Detector: detector_I=0.00194989**
+
 ## Input parameters
 
 Parameters in **boldface** are required; the others are optional.

--- a/tools/Python/mccodelib/utils.py
+++ b/tools/Python/mccodelib/utils.py
@@ -480,6 +480,28 @@ def parse_header(text):
     
     return info
 
+def format_examples(test_text):
+    '''
+    Splits the raw %Example header text (as stored in
+    InstrCompHeaderInfo.test) into an ordered list of (line, is_example)
+    tuples. Lines starting with the '%Example:' tag have the leading
+    '%Example:' tag replaced with 'Test:' (so they render as
+    'Test: ...') and are flagged True so that doc writers can highlight
+    them (e.g. in bold); all other lines are passed through unchanged and
+    flagged False. Order is preserved even when %Example: lines are
+    interspersed with other text.
+    '''
+    lines = []
+    if not test_text:
+        return lines
+    for l in test_text.splitlines():
+        m = re.match(r'%Example:\s*(.*)', l)
+        if m:
+            lines.append(('Test: ' + m.group(1), True))
+        else:
+            lines.append((l, False))
+    return lines
+
 def read_define_instr(file):
     '''
     Reads lines from file obj until DEFINE INSTRUMENT, then reads lines until ")".

--- a/tools/Python/mcdoc/mcdoc.py
+++ b/tools/Python/mcdoc/mcdoc.py
@@ -103,6 +103,52 @@ def _tex(s):
     return s
 
 
+def _examples_html_body(test_text):
+    ''' Render the %Example: header lines as an HTML <LI> list, in
+    original order. Lines tagged as '%Example:' are shown in bold as
+    'Test: ...'; any other lines in the section are shown unmodified.
+    Returns '' when there are no lines to show. '''
+    items = utils.format_examples(test_text)
+    if not items:
+        return ''
+    rendered = []
+    for line, is_example in items:
+        content = '<strong>%s</strong>' % line if is_example else line
+        rendered.append('  <LI> %s' % content)
+    return '\n'.join(rendered)
+
+
+def _examples_md_body(test_text):
+    ''' Render the %Example: header lines as a Markdown bullet list, in
+    original order. Lines tagged as '%Example:' are shown in bold as
+    'Test: ...'; any other lines in the section are shown unmodified.
+    Returns '' when there are no lines to show. '''
+    items = utils.format_examples(test_text)
+    if not items:
+        return ''
+    rendered = []
+    for line, is_example in items:
+        text = _md_text(line)
+        rendered.append('- **%s**' % text if is_example else '- %s' % text)
+    return '\n'.join(rendered)
+
+
+def _examples_tex_body(test_text):
+    ''' Render the %Example: header lines as a LaTeX itemize list, in
+    original order. Lines tagged as '%Example:' are shown in bold as
+    'Test: ...'; any other lines in the section are shown unmodified.
+    Returns '' when there are no lines to show. '''
+    items = utils.format_examples(test_text)
+    if not items:
+        return ''
+    rendered = [r'\begin{itemize}']
+    for line, is_example in items:
+        esc = _tex(line)
+        rendered.append(r'  \item \textbf{%s}' % esc if is_example else r'  \item %s' % esc)
+    rendered.append(r'\end{itemize}')
+    return '\n'.join(rendered)
+
+
 def _mccode_label():
     ''' Returns ('McStas' or 'McXtrace') depending on the active flavour. '''
     return 'McXtrace' if mccode_config.get_mccode_prefix() == 'mx' else 'McStas'
@@ -701,6 +747,7 @@ class InstrDocWriter:
         h = h.replace(t[5], i.origin)
         h = h.replace(t[6], i.date)
         h = h.replace(t[7], i.description)
+        h = h.replace(t[14], _examples_html_body(i.test))
 
         h = h.replace(t[8], self.par_header)
         doc_rows = ''
@@ -745,7 +792,8 @@ class InstrDocWriter:
             '%INSTRFILE%',
             '%INSTRFILE_BASE%',
             '%LINKS%',
-            '%VERSION%']
+            '%VERSION%',
+            '%EXAMPLES%']
     par_str = "<TR> <TD>%s</TD><TD>%s</TD><TD>%s</TD><TD ALIGN=RIGHT>%s</TD></TR>"
     par_str_boldface = "<TR> <TD><strong>%s</strong></TD><TD>%s</TD><TD>%s</TD><TD ALIGN=RIGHT>%s</TD></TR>"
     par_header = par_str % ('<strong>Name</strong>', '<strong>Unit</strong>', '<strong>Description</strong>', '<strong>Default</strong>')
@@ -771,6 +819,7 @@ $(function () {
 <P ALIGN=CENTER>
  [ <A href="#id">Identification</A>
  | <A href="#desc">Description</A>
+ | <A href="#ex">Examples</A>
  | <A href="#ipar">Input parameters</A>
  | <A href="#links">Links</A> ]
 </P>
@@ -793,6 +842,13 @@ $(function () {
 %DESCRIPTION%
 </PRE>
 
+<H2><A NAME=ex></A>Examples</H2>
+(Test cases in bold)
+
+<UL>
+%EXAMPLES%
+</UL>
+
 <H2><A NAME=ipar></A>Input parameters</H2>
 Parameters in <B>boldface</B> are required;
 the others are optional.
@@ -812,6 +868,7 @@ the others are optional.
 <P ALIGN=CENTER>
  [ <A href="#id">Identification</A>
  | <A href="#desc">Description</A>
+ | <A href="#ex">Examples</A>
  | <A href="#ipar">Input parameters</A>
  | <A href="#links">Links</A> ]
 </P>
@@ -877,6 +934,7 @@ class CompDocWriter:
         h = h.replace(t[5], i.origin)
         h = h.replace(t[6], i.date)
         h = h.replace(t[7], i.description)
+        h = h.replace(t[15], _examples_html_body(i.test))
 
         h = h.replace(t[8], self.par_header)
 
@@ -931,7 +989,8 @@ class CompDocWriter:
             '%COMPFILE_BASE%',
             '%LINKS%',
             '%VERSION%',
-            '%PARLIST%']
+            '%PARLIST%',
+            '%EXAMPLES%']
     par_str = "<TR> <TD>%s</TD><TD>%s</TD><TD>%s</TD><TD ALIGN=RIGHT>%s</TD><TD ALIGN=RIGHT>%s</TD></TR>"
     par_str_boldface = "<TR> <TD><strong>%s</strong></TD><TD>%s</TD><TD>%s</TD><TD ALIGN=RIGHT>%s</TD><TD ALIGN=RIGHT>%s</TD></TR>"
     par_header = par_str % ('<strong>Name</strong>', '<strong>Unit</strong>', '<strong>Description</strong>', '<strong>Default</strong>', '<input type="text" value="' + "CompInstanceName" + '" id="instance">')
@@ -1055,6 +1114,7 @@ $(function () {
 <P ALIGN=CENTER>
  [ <A href="#id">Identification</A>
  | <A href="#desc">Description</A>
+ | <A href="#ex">Examples</A>
  | <A href="#ipar">Input parameters</A>
  | <A href="#links">Links</A> ]
 </P>
@@ -1076,6 +1136,13 @@ $(function () {
 <PRE>
 %DESCRIPTION%
 </PRE>
+
+<H2><A NAME=ex></A>Examples</H2>
+(Test cases in bold)
+
+<UL>
+%EXAMPLES%
+</UL>
 
 <H2><A NAME=ipar></A>Input parameters</H2>
 Parameters in <B>boldface</B> are required;
@@ -1117,6 +1184,7 @@ the others are optional.
 <P ALIGN=CENTER>
  [ <A href="#id">Identification</A>
  | <A href="#desc">Description</A>
+ | <A href="#ex">Examples</A>
  | <A href="#ipar">Input parameters</A>
  | <A href="#links">Links</A> ]
 </P>
@@ -1176,6 +1244,10 @@ class InstrMdDocWriter:
         lines.append(_md_text(i.description))
         lines.append('```')
         lines.append('')
+        lines.append('## Examples')
+        lines.append('')
+        lines.append(_examples_md_body(i.test))
+        lines.append('')
         lines.append('## Input parameters')
         lines.append('')
         lines.append('Parameters in **boldface** are required; the others are optional.')
@@ -1234,6 +1306,10 @@ class CompMdDocWriter:
         lines.append('```text')
         lines.append(_md_text(i.description))
         lines.append('```')
+        lines.append('')
+        lines.append('## Examples')
+        lines.append('')
+        lines.append(_examples_md_body(i.test))
         lines.append('')
         lines.append('## Input parameters')
         lines.append('')
@@ -1314,6 +1390,9 @@ class InstrLatexDocWriter:
         out.append(i.description if i.description is not None else '')
         out.append(r'\end{lstlisting}')
         out.append('')
+        out.append(r'\section*{Examples}')
+        out.append(_examples_tex_body(i.test))
+        out.append('')
         out.append(r'\section*{Input parameters}')
         out.append(r'Parameters in \textbf{boldface} are required; the others are optional.')
         out.append('')
@@ -1378,6 +1457,9 @@ class CompLatexDocWriter:
         out.append(r'\begin{lstlisting}')
         out.append(i.description if i.description is not None else '')
         out.append(r'\end{lstlisting}')
+        out.append('')
+        out.append(r'\subsection*{Examples}')
+        out.append(_examples_tex_body(i.test))
         out.append('')
         out.append(r'\subsection*{Input parameters}')
         out.append(r'Parameters in \textbf{boldface} are required; the others are optional.')


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Minor AI-driven mcdoc change:
* Present any `%Example:` line as **Test:** (in bold) in all mcdoc-generated snippets (`html`/`TeX`/`md`)

Plus simple reruns of `mcdoc`/`mxdoc` in-repo for re-generation of `.instr` `README.md`'s
* `mcdoc  -i --dir mcstas-comps/examples/ --md --in-repo`
* `mxdoc  -i --dir mcxtrace-comps/examples/ --md --in-repo`
--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:
Claude, prompt:

```
My McStas/McXtrace repo is available via an MCP plugin in the folder (....)

The mcdoc tool (found in tools/Python/mcdoc) parses documentation headers in .comp and .instr files. Outputs are html/md/TeX snippets.

Some of the parsing-code is inside tools/Python/mccodelib

Header lines starting with 
%Example: 
define test-scenarios for instrument files. These lines are currently not shown on the generated doc pages - I would like them to be, in bold. Please add in the order of the file - i.e. even if these lines are mixed with other lines, the %Example: lines should be bold and other lines not. 

And please present %Example: asTest: in bold.  in generated outputs. And add the lines

### Examples
(Test cases in bold) 

in the html template
```

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



