### PR TITLE
Patch issue #2637 - Vertical_Bender gravity always disabled

### DIFF
--- a/mcstas-comps/contrib/Vertical_Bender.comp
+++ b/mcstas-comps/contrib/Vertical_Bender.comp
@@ -214,9 +214,10 @@ INITIALIZE%{
 //	      "This component likely does not work with Gx component,\n",
 //	      NAME_CURRENT_COMP);
 
-  } else
+  } else {
     fprintf(stdout,"Vertical_Bender %s: Gravity is off!\n",NAME_CURRENT_COMP);
     localG = coords_set(0, 0, 0);
+  }
 
     // To be able to handle the situation properly where a component of
     // the gravity is along the z-axis we also define entrance (in) and


### PR DESCRIPTION
### Free-form text area

Fixes #2637. Vertical_Bender.comp's `INITIALIZE` had a dangling `if`/`else` with no braces: 
`localG = coords_set(0, 0, 0); `
ran unconditionally after the `else`, silently zeroing a correctly-computed gravity vector even when mcgravitation was true. This meant the component behaved as if gravity were always off, regardless of `-g`. Fix adds the missing braces so both statements are properly scoped to the else branch. One-line, behavior-only-changes-when-gravity-is-actually-enabled fix — verified to have zero effect on gravity-off simulations (bit-identical output before/after) and a real, expected effect once gravity is genuinely active inside the bender.
--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution

Used Claude (Anthropic) throughout: to trace the bug's root cause (identifying the dangling-else pattern and confirming its scope via the component's other mcgravitation checks), to trace its git history back to its introduction in 2017, and to benchmark its effect before/after the fix on a real instrument model. The fix itself is a two-character change (adding {/}).

--------------
### Development OS / boundary conditions
macOS (Darwin). No special dependencies.

The identical fix was extensively tested via a separate instrument model (LOKI) using this component under McStas 3.5.42 / 3.7.24 

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [x] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My PR is meant to fix a specific, existing issue
  * [x] I have indicated the issue number here: #2637
  * [ ] I have added documentation for the fix and possible side effects

--------------