### PR TITLE
Trigger 'RUNALL' if > 4 comps were changed.

### DIFF
--- a/.github/workflows/mcstas-basictest.yml
+++ b/.github/workflows/mcstas-basictest.yml
@@ -429,13 +429,14 @@ jobs:
              export DIFFBASE=$(git merge-base origin/main HEAD)
            fi
            echo "Diffing against: $DIFFBASE"
-
+           export RUNALL="NO"
            export CHANGEDCOMPS=$(git diff --name-only $DIFFBASE HEAD | grep '\.comp$' | grep mcstas-comps | xargs -n1 basename | sed 's/\.comp//g' | sort | uniq | xargs echo)
            export NUMCHANGEDCOMPS=$(git diff --name-only $DIFFBASE HEAD | grep '\.comp$' | grep mcstas-comps | wc -l | xargs echo)
            cd -
            compindex=0
            if [ "$NUMCHANGEDCOMPS" != "0" ];
            then
+             if [ "$NUMCHANGEDCOMPS" -lt "5" ]; then
                for comp in $CHANGEDCOMPS;
                do
                  echo Finding tests including component $comp
@@ -448,10 +449,12 @@ jobs:
                    echo No matching tests found
                  fi
                done
+             else
+               export RUNALL="YES"
+             fi
            fi
 
            cd src
-           export RUNALL="NO"
            export CHANGEDINSTR=$(git diff --name-only $DIFFBASE HEAD | grep '\.instr$' | grep mcstas-comps | xargs -n1 basename | sed 's/\.instr//g' | sort | uniq | xargs echo | sed 's/ /,/g')
            export NUMCHANGEDINSTR=$(git diff --name-only $DIFFBASE HEAD | grep '\.instr$' | grep mcstas-comps | wc -l | xargs echo)
            echo ----

--- a/.github/workflows/mcxtrace-basictest.yml
+++ b/.github/workflows/mcxtrace-basictest.yml
@@ -436,13 +436,14 @@ jobs:
              export DIFFBASE=$(git merge-base origin/main HEAD)
            fi
            echo "Diffing against: $DIFFBASE"
-
-           export CHANGEDCOMPS=$(git diff --name-only $DIFFBASE HEAD | grep '\.comp$' | grep mcxtrace-comps | xargs -n1 basename | sed 's/\.comp//g' | sort | uniq | xargs echo)
-           export NUMCHANGEDCOMPS=$(git diff --name-only $DIFFBASE HEAD | grep '\.comp$' | grep mcxtrace-comps | wc -l | xargs echo)
+           export RUNALL="NO"
+           export CHANGEDCOMPS=$(git diff --name-only $DIFFBASE HEAD | grep '\.comp$' | grep mcstas-comps | xargs -n1 basename | sed 's/\.comp//g' | sort | uniq | xargs echo)
+           export NUMCHANGEDCOMPS=$(git diff --name-only $DIFFBASE HEAD | grep '\.comp$' | grep mcstas-comps | wc -l | xargs echo)
            cd -
            compindex=0
            if [ "$NUMCHANGEDCOMPS" != "0" ];
            then
+             if [ "$NUMCHANGEDCOMPS" -lt "5" ]; then
                for comp in $CHANGEDCOMPS;
                do
                  echo Finding tests including component $comp
@@ -455,10 +456,12 @@ jobs:
                    echo No matching tests found
                  fi
                done
+             else
+               export RUNALL="YES"
+             fi
            fi
 
            cd src
-           export RUNALL="NO"
            export CHANGEDINSTR=$(git diff --name-only $DIFFBASE HEAD | grep '\.instr$' | grep mcxtrace-comps | xargs -n1 basename | sed 's/\.instr//g' | sort | uniq | xargs echo | sed 's/ /,/g')
            export NUMCHANGEDINSTR=$(git diff --name-only $DIFFBASE HEAD | grep '\.instr$' | grep mcxtrace-comps | wc -l | xargs echo)
            echo ----


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

CI-tuning: If more than 5 comps were changed, run full test-suite (runtimes may otherwise for big change-sets exceed the permitted time...)

--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



