### PR TITLE
PROP_NO_G_ functions

### DIFF
--- a/docs/manuals/mcstas/kernelcalls.tex
+++ b/docs/manuals/mcstas/kernelcalls.tex
@@ -79,6 +79,14 @@ the neutron rays which have negative propagation times are removed automatically
 \item \textbfMCRH{PROP\_GRAV\_DT}$(dt,Ax,Ay,Az)$. Like \textbf{PROP\_DT}, but it also
   includes gravity using the acceleration $(Ax,Ay,Az)$. In addition
   to adjusting $(x,y,z)$ and $t$, also $(vx,vy,vz)$ is modified.
+\item \textbfMCRH{PROP\_NO\_G\_DT}$(dt)$. Propagates the neutron through the
+  time interval $dt$ using straight-line motion, regardless of the global
+  gravitation setting. The negative-time and back-propagation rules are the
+  same as for \textbf{PROP\_DT}.
+\item \textbfMCRH{PROP\_NO\_G\_X0}, \textbfMCRH{PROP\_NO\_G\_Y0}, and
+  \textbfMCRH{PROP\_NO\_G\_Z0}. Propagate the neutron to the corresponding
+  local coordinate plane using straight-line motion, regardless of the global
+  gravitation setting.
 \item \textbfMCRH{ALLOW\_BACKPROP}. Indicates that the next propagation routine
   will not remove the neutron ray, even if negative propagation times
   are found. Subsequent propagations are not affected.

--- a/mccode/nlib/share/mcstas-r.h
+++ b/mccode/nlib/share/mcstas-r.h
@@ -201,6 +201,30 @@ void SCATTER_func(_class_particle *_particle); /* provides function to SCATTER f
   } while(0)
 
 
+/* Propagation variants that always use straight-line motion. */
+#define PROP_NO_G_DT(dt) \
+  do { \
+    if(dt < 0 && allow_backprop == 0) { RESTORE=1; ABSORB; }; \
+    mcPROP_DT(dt); \
+    DISALLOW_BACKPROP; \
+  } while(0)
+
+#define PROP_NO_G_Z0 \
+  do { \
+    mcPROP_Z0; \
+  } while(0)
+
+#define PROP_NO_G_X0 \
+  do { \
+    mcPROP_X0; \
+  } while(0)
+
+#define PROP_NO_G_Y0 \
+  do { \
+    mcPROP_Y0; \
+  } while(0)
+
+
 #ifdef DEBUG
 
 #define DEBUG_STATE() if(!mcdotrace); else \

--- a/mcstas-comps/examples/Tests_grammar/Unittest_PROP_NO_G/Unittest_PROP_NO_G.instr
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_PROP_NO_G/Unittest_PROP_NO_G.instr
@@ -4,9 +4,9 @@
 * Instrument: Unittest_PROP_NO_G
 *
 * %Identification
-* Written by: McStas developers
+* Written by: Mads Bertelsen
 * Date: September 2026
-* Origin: McStas
+* Origin: ESS
 * %INSTRUMENT_SITE: Tests_grammar
 *
 * Test for the PROP_NO_G_DT propagation macro.

--- a/mcstas-comps/examples/Tests_grammar/Unittest_PROP_NO_G/Unittest_PROP_NO_G.instr
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_PROP_NO_G/Unittest_PROP_NO_G.instr
@@ -9,21 +9,18 @@
 * Origin: McStas
 * %INSTRUMENT_SITE: Tests_grammar
 *
-* Unittest for the PROP_NO_G_* propagation macros.
+* Test for the PROP_NO_G_DT propagation macro.
 *
 * %Description
-* Verifies straight-line propagation with global gravity enabled and checks
-* that PROP_NO_G_DT retains the normal back-propagation behavior.
+* A long-wavelength beam is focused onto a small detector 10 m away. The
+* intermediate Arm uses PROP_NO_G_DT, so the beam should remain focused even
+* when gravity is enabled.
 *
-* %Example: Backprop=0 -g Detector: PropNoGMonitor_I=1
-* %Example: Backprop=1 -g Detector: PropNoGMonitor_I=1
-*
-* %Parameters
-* Backprop: [1] Flag to allow the final negative propagation
+* %Example: -g Detector: PropNoGMonitor_I=7.95774e-8
 *
 * %End
 *******************************************************************************/
-DEFINE INSTRUMENT Unittest_PROP_NO_G(int Backprop=0)
+DEFINE INSTRUMENT Unittest_PROP_NO_G()
 
 TRACE
 
@@ -32,91 +29,23 @@ COMPONENT Origin = Progress_bar()
 
 COMPONENT Source = Source_simple(
     radius = 0.01,
-    dist = 1,
-    focus_xw = 0.1,
-    focus_yh = 0.1,
-    lambda0 = 5,
+    dist = 10,
+    focus_xw = 0.01,
+    focus_yh = 0.01,
+    lambda0 = 30,
     dlambda = 0,
     flux = 0)
   AT (0, 0, 0) RELATIVE Origin
-EXTEND %{
-  x = 0; y = 0; z = 0;
-  vx = 1; vy = 1; vz = 1; t = 0;
-  p = 1.0/mcget_ncount();
-%}
 
 COMPONENT PropNoG = Arm()
   AT (0, 0, 0) RELATIVE Source
 EXTEND %{
-  int failed = 0;
-  const double tolerance = 1e-12;
-
-  p = 1.0/mcget_ncount();
-
-  x = 1; y = 1; z = 1;
-  vx = 2; vy = 3; vz = 4; t = 0;
-  PROP_NO_G_DT(0.5);
-  if (fabs(x - 2) > tolerance || fabs(y - 2.5) > tolerance ||
-      fabs(z - 3) > tolerance || fabs(t - 0.5) > tolerance ||
-      fabs(vx - 2) > tolerance || fabs(vy - 3) > tolerance ||
-      fabs(vz - 4) > tolerance)
-    failed = 1;
-
-  x = 1; y = 1; z = 1;
-  vx = -2; vy = 3; vz = 4; t = 0;
-  PROP_NO_G_X0;
-  if (fabs(x) > tolerance || fabs(y - 2.5) > tolerance ||
-      fabs(z - 3) > tolerance || fabs(t - 0.5) > tolerance ||
-      fabs(vx + 2) > tolerance || fabs(vy - 3) > tolerance ||
-      fabs(vz - 4) > tolerance)
-    failed = 1;
-
-  x = 1; y = 1; z = 1;
-  vx = 2; vy = -3; vz = 4; t = 0;
-  PROP_NO_G_Y0;
-  if (fabs(x - 5.0/3.0) > tolerance || fabs(y) > tolerance ||
-      fabs(z - 7.0/3.0) > tolerance || fabs(t - 1.0/3.0) > tolerance ||
-      fabs(vx - 2) > tolerance || fabs(vy + 3) > tolerance ||
-      fabs(vz - 4) > tolerance)
-    failed = 1;
-
-  x = 1; y = 1; z = 1;
-  vx = 2; vy = 3; vz = -4; t = 0;
-  PROP_NO_G_Z0;
-  if (fabs(x - 1.5) > tolerance || fabs(y - 1.75) > tolerance ||
-      fabs(z) > tolerance || fabs(t - 0.25) > tolerance ||
-      fabs(vx - 2) > tolerance || fabs(vy - 3) > tolerance ||
-      fabs(vz + 4) > tolerance)
-    failed = 1;
-
-  if (failed)
-    ABSORB;
-
-  if (INSTRUMENT_GETPAR(Backprop))
-    ALLOW_BACKPROP;
-  PROP_NO_G_DT(-0.1);
-%}
-
-COMPONENT PropNoGCheck = Arm()
-  AT (0, 0, 0) RELATIVE PropNoG
-EXTEND %{
-  const double tolerance = 1e-12;
-  const int backprop = INSTRUMENT_GETPAR(Backprop);
-  const double expected_x = backprop ? 1.3 : 0;
-  const double expected_y = backprop ? 1.45 : 0;
-  const double expected_z = backprop ? 0.4 : 0;
-  const double expected_t = backprop ? 0.15 : 0;
-
-  if (fabs(x - expected_x) > tolerance ||
-      fabs(y - expected_y) > tolerance ||
-      fabs(z - expected_z) > tolerance ||
-      fabs(t - expected_t) > tolerance)
-    ABSORB;
+  PROP_NO_G_DT(10/vz);
 %}
 
 COMPONENT PropNoGMonitor = Monitor(
-    xwidth = 10,
-    yheight = 10)
-  AT (0, 0, 0) RELATIVE PropNoG
+    xwidth = 0.01,
+    yheight = 0.01)
+  AT (0, 0, 10) RELATIVE PropNoG
 
 END

--- a/mcstas-comps/examples/Tests_grammar/Unittest_PROP_NO_G/Unittest_PROP_NO_G.instr
+++ b/mcstas-comps/examples/Tests_grammar/Unittest_PROP_NO_G/Unittest_PROP_NO_G.instr
@@ -1,0 +1,122 @@
+/*******************************************************************************
+*         McStas, neutron ray-tracing package
+*
+* Instrument: Unittest_PROP_NO_G
+*
+* %Identification
+* Written by: McStas developers
+* Date: September 2026
+* Origin: McStas
+* %INSTRUMENT_SITE: Tests_grammar
+*
+* Unittest for the PROP_NO_G_* propagation macros.
+*
+* %Description
+* Verifies straight-line propagation with global gravity enabled and checks
+* that PROP_NO_G_DT retains the normal back-propagation behavior.
+*
+* %Example: Backprop=0 -g Detector: PropNoGMonitor_I=1
+* %Example: Backprop=1 -g Detector: PropNoGMonitor_I=1
+*
+* %Parameters
+* Backprop: [1] Flag to allow the final negative propagation
+*
+* %End
+*******************************************************************************/
+DEFINE INSTRUMENT Unittest_PROP_NO_G(int Backprop=0)
+
+TRACE
+
+COMPONENT Origin = Progress_bar()
+  AT (0, 0, 0) ABSOLUTE
+
+COMPONENT Source = Source_simple(
+    radius = 0.01,
+    dist = 1,
+    focus_xw = 0.1,
+    focus_yh = 0.1,
+    lambda0 = 5,
+    dlambda = 0,
+    flux = 0)
+  AT (0, 0, 0) RELATIVE Origin
+EXTEND %{
+  x = 0; y = 0; z = 0;
+  vx = 1; vy = 1; vz = 1; t = 0;
+  p = 1.0/mcget_ncount();
+%}
+
+COMPONENT PropNoG = Arm()
+  AT (0, 0, 0) RELATIVE Source
+EXTEND %{
+  int failed = 0;
+  const double tolerance = 1e-12;
+
+  p = 1.0/mcget_ncount();
+
+  x = 1; y = 1; z = 1;
+  vx = 2; vy = 3; vz = 4; t = 0;
+  PROP_NO_G_DT(0.5);
+  if (fabs(x - 2) > tolerance || fabs(y - 2.5) > tolerance ||
+      fabs(z - 3) > tolerance || fabs(t - 0.5) > tolerance ||
+      fabs(vx - 2) > tolerance || fabs(vy - 3) > tolerance ||
+      fabs(vz - 4) > tolerance)
+    failed = 1;
+
+  x = 1; y = 1; z = 1;
+  vx = -2; vy = 3; vz = 4; t = 0;
+  PROP_NO_G_X0;
+  if (fabs(x) > tolerance || fabs(y - 2.5) > tolerance ||
+      fabs(z - 3) > tolerance || fabs(t - 0.5) > tolerance ||
+      fabs(vx + 2) > tolerance || fabs(vy - 3) > tolerance ||
+      fabs(vz - 4) > tolerance)
+    failed = 1;
+
+  x = 1; y = 1; z = 1;
+  vx = 2; vy = -3; vz = 4; t = 0;
+  PROP_NO_G_Y0;
+  if (fabs(x - 5.0/3.0) > tolerance || fabs(y) > tolerance ||
+      fabs(z - 7.0/3.0) > tolerance || fabs(t - 1.0/3.0) > tolerance ||
+      fabs(vx - 2) > tolerance || fabs(vy + 3) > tolerance ||
+      fabs(vz - 4) > tolerance)
+    failed = 1;
+
+  x = 1; y = 1; z = 1;
+  vx = 2; vy = 3; vz = -4; t = 0;
+  PROP_NO_G_Z0;
+  if (fabs(x - 1.5) > tolerance || fabs(y - 1.75) > tolerance ||
+      fabs(z) > tolerance || fabs(t - 0.25) > tolerance ||
+      fabs(vx - 2) > tolerance || fabs(vy - 3) > tolerance ||
+      fabs(vz + 4) > tolerance)
+    failed = 1;
+
+  if (failed)
+    ABSORB;
+
+  if (INSTRUMENT_GETPAR(Backprop))
+    ALLOW_BACKPROP;
+  PROP_NO_G_DT(-0.1);
+%}
+
+COMPONENT PropNoGCheck = Arm()
+  AT (0, 0, 0) RELATIVE PropNoG
+EXTEND %{
+  const double tolerance = 1e-12;
+  const int backprop = INSTRUMENT_GETPAR(Backprop);
+  const double expected_x = backprop ? 1.3 : 0;
+  const double expected_y = backprop ? 1.45 : 0;
+  const double expected_z = backprop ? 0.4 : 0;
+  const double expected_t = backprop ? 0.15 : 0;
+
+  if (fabs(x - expected_x) > tolerance ||
+      fabs(y - expected_y) > tolerance ||
+      fabs(z - expected_z) > tolerance ||
+      fabs(t - expected_t) > tolerance)
+    ABSORB;
+%}
+
+COMPONENT PropNoGMonitor = Monitor(
+    xwidth = 10,
+    yheight = 10)
+  AT (0, 0, 0) RELATIVE PropNoG
+
+END

--- a/support/common/editors/mccode.lang
+++ b/support/common/editors/mccode.lang
@@ -397,9 +397,13 @@
         <keyword>RESTORE_NEUTRON</keyword>
         <keyword>PROP_GRAV_DT</keyword>
         <keyword>PROP_DT</keyword>
+        <keyword>PROP_NO_G_DT</keyword>
         <keyword>PROP_Z0</keyword>
         <keyword>PROP_X0</keyword>
         <keyword>PROP_Y0</keyword>
+        <keyword>PROP_NO_G_Z0</keyword>
+        <keyword>PROP_NO_G_X0</keyword>
+        <keyword>PROP_NO_G_Y0</keyword>
         <keyword>vec_prod</keyword>
         <keyword>scalar_prod</keyword>
         <keyword>NORM</keyword>

--- a/support/common/editors/mccode.vim
+++ b/support/common/editors/mccode.vim
@@ -65,10 +65,14 @@
 	\ RESTORE_NEUTRON 
 	\ PROP_GRAV_DT 
 	\ PROP_DT 
+	\ PROP_NO_G_DT
         \ PROP_DL
 	\ PROP_Z0 
 	\ PROP_X0 
 	\ PROP_Y0 
+	\ PROP_NO_G_Z0
+	\ PROP_NO_G_X0
+	\ PROP_NO_G_Y0
 	\ vec_prod 
 	\ scalar_prod 
 	\ NORM 


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

In a few cases it is desirable to propagate the ray without gravity even though it's enabled due to lacking support for gravity, for example in the Union components. That results in not making use of the standard PROP_DT and propagating manually. Here I add a simple set of PROP_NO_G_ functions to explicitly work without gravity.

--------------
### Declaration of use of AI-tools
* [X] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_
OS X 14.6.1 (23G93)

--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [X] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [X] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [X] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [X] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [X] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [ ] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [X] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [ ] Explanation is added in free form text above or below the checklist

--------------



