### PR TITLE
Remove need for Union_init and Union_stop

### DIFF
--- a/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
+++ b/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
@@ -8,25 +8,26 @@ This is a proposed change
 
 The original Union components were developed under McStas 2.X and used global variables for a number 
 of lists that were used to transfer information between components. 
-In McStas and McXtrace 3.X that was no longer possible, so an Union_init and Union_stop component was 
+In McStas and McXtrace 3.X that was no longer possible, so the Union_init and Union_stop component was 
 added, they were required to surround all the Union components used in an instrument. The `Union_init` 
 loaded the required libraries and set up the global variables, then all other Union components would read the
-variables from that component, needing the name on it as an input (standard convention is init), so
-almost always omitted. `Union_stop` added switch statements for process functions, avoiding cases that are
-not actually in the current instrument using the preprocessor. The included files are in share and
-do need updating when new processes / geometries are added. They are called `union-init.c`, `union-lib.c`
-and `union-suffix.c`. 
+variables from that component, needing the name on it as the init parameter. The init parameter had a default
+of `init` so if the `Union_init` instance was given that name, there was no need to specify that parameter. 
+`Union_stop` added switch statements for process functions, avoiding cases that are not actually in the current 
+instrument using the preprocessor. The included files are in share and do need updating when new processes 
+/ geometries are added. They are called `union-init.c`, `union-lib.c` and `union-suffix.c`. 
 
 ## Decision
 
-Let the code generator insert the `union-init.c`, union-lib.c and union-suffix.c files at the
+Let the code generator insert the `union-init.c`, `union-lib.c` and `union-suffix.c` files at the
 appropriate positions if a `Union_master` or a `Union_master_GPU` is detected. It works by searching
 for a `Union_master`/`Union_master_GPU` component, if found it adds `read_table-lib.h`, `union-lib.c` 
-and `union-init.c` before SHARE and `union-suffix.c` after SHARE. It also creates a Union define that
-can be used to detect whether Union is active in this instrument.
+and `union-init.c` before all component SHARE sections and `union-suffix.c` after all component SHARE
+sections. It also creates a Union define that can be used to detect whether Union is active in this 
+instrument.
 
-All Union components emit compile errors if the Union define does not yet exist, this is done in each
-component. 
+All Union components emit compile errors if the Union preprocessor macro is not defined, this is done 
+in each component. 
 
 Keep the `Union_init` and `Union_stop` components for a transition period, but they now only contain
 the code emitting the deprecation warning.
@@ -40,20 +41,20 @@ It becomes easier to use the Union components as there is no need to place `Unio
 Instruments using the `init` parameter in any Union component will need that removed as the parameter
 was removed.
 
-Existing instruments that do not use the init parameter for individual components still work and only
-show the deprication warnings. A mismatch between version of the components and code generator
-could lead to problems, but the same preprocessor guards are used. Main issue would be an instrument
-using a folder of new Union components with an old code generator, in that case libraries would not
-be loaded.
+Existing instruments that do not use the init parameter for individual components but has the `Union_init`
+and/or `Union_stop` components still work and only show the deprecation warnings. A mismatch between 
+version of the components and code generator could lead to problems, but the same preprocessor guards are used.
+Main issue would be an instrument using a folder of new Union components with an old code generator, in that case 
+the intentional compile errors would be triggered.
 
-Still easy for developers to find the .c files in share to update them.
+No change in where developers to find the .c files in share to update them.
 
 Cogen would need to be updated if `Union_master` or `Union_master_GPU` name is changed.
 
 ## Behaviour
 
-- In valid use, Union systems no longer need the `Union_init`  and `Union_stop`
-- Using the `Union_init` and `Union_stop` won't break instruments, but show deprication warnings
+- In valid use, Union systems no longer need the `Union_init` and `Union_stop`
+- Using the `Union_init` and `Union_stop` won't break instruments, but show deprecation warnings
 - Using the init parameter in Union components will fail as the parameter is removed
 - Compilation fails if any Union component is used without a `Union_master` or `Union_master_GPU`
 

--- a/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
+++ b/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
@@ -1,0 +1,47 @@
+# Union libraries and globals handled by code generator
+
+## Status
+
+This is a proposed change
+
+## Context
+
+The original Union components were developed under McStas 2.X and used global variables for a number 
+of lists that were used to transfer imformation between components. 
+In McStas 3.X that was no longer possible, so an Union_init and Union_stop method was added, this 
+were required to surround all the Union components used in an instrument. The init part loaded the
+required libraries and set up the global variables, then all other Union components would read the
+variables from that component, needing the name on it as an input (standard convetion is init), so
+almost always omitted. Stop added switch statements for process functions, avoiding cases that are
+not actually in the current instrument using the preprocessor. The included files are in share and
+do need updating when new processes / geometries are added. They are called union-init.c, union-lib.c
+and union-suffix.c.
+
+## Decision
+
+Let the code generator insert the union-init.c, union-lib.c and union-suffix.c files at the
+appropriate positions if a Union_master or a Union_master_GPU is detected.
+
+Keep the Union_init and Union_stop components for a transition period, but they are empty and
+only show a deprication warning.
+
+Remove the init input on all Union components.
+
+Add errors on all non master Union components to let the user know a master is necessary to compile
+the instrument.
+
+## Consequences
+
+It becomes easier to use the Union components as there is no need to place Union_init or Union_stop.
+
+Existing instruments that do not use the init parameter for individual components still work and only
+show the deprication warnings. Using mismatch between version of the components and code generator
+could lead to problems, but the same preprocessor guards are used. Main issue would be an instrument
+using a folder of new Union components with an old code generator, in that case libraries would not
+be loaded.
+
+Still easy for developers to find the .c files in share to update them.
+
+## Behaviour
+
+Simplifies use of Union components by avoiding Union_init and Union_stop.

--- a/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
+++ b/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
@@ -8,7 +8,7 @@ This is a proposed change
 
 The original Union components were developed under McStas 2.X and used global variables for a number 
 of lists that were used to transfer information between components. 
-In McStas / McXtrace 3.X that was no longer possible, so an Union_init and Union_stop method was 
+In McStas and McXtrace 3.X that was no longer possible, so an Union_init and Union_stop component was 
 added, they were required to surround all the Union components used in an instrument. The `Union_init` 
 loaded the required libraries and set up the global variables, then all other Union components would read the
 variables from that component, needing the name on it as an input (standard convention is init), so
@@ -21,9 +21,9 @@ and `union-suffix.c`.
 
 Let the code generator insert the `union-init.c`, union-lib.c and union-suffix.c files at the
 appropriate positions if a `Union_master` or a `Union_master_GPU` is detected. It works by searching
-for a `Union_master` component, if found it adds `read_table-lib.h`, `union-lib.c` and `union-init.c`
-before SHARE and `union-suffix.c` after SHARE. It also creates a Union define that can be used
-to detect whether Union is active in this instrument.
+for a `Union_master`/`Union_master_GPU` component, if found it adds `read_table-lib.h`, `union-lib.c` 
+and `union-init.c` before SHARE and `union-suffix.c` after SHARE. It also creates a Union define that
+can be used to detect whether Union is active in this instrument.
 
 All Union components emit compile errors if the Union define does not yet exist, this is done in each
 component. 
@@ -48,14 +48,14 @@ be loaded.
 
 Still easy for developers to find the .c files in share to update them.
 
-Cogen would need to be updated if Union_master name is changed.
+Cogen would need to be updated if `Union_master` or `Union_master_GPU` name is changed.
 
 ## Behaviour
 
 - In valid use, Union systems no longer need the `Union_init`  and `Union_stop`
 - Using the `Union_init` and `Union_stop` won't break instruments, but show deprication warnings
 - Using the init parameter in Union components will fail as the parameter is removed
-- Compilation fails if any Union component is used without a Union_master
+- Compilation fails if any Union component is used without a `Union_master` or `Union_master_GPU`
 
 
 

--- a/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
+++ b/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
@@ -7,41 +7,55 @@ This is a proposed change
 ## Context
 
 The original Union components were developed under McStas 2.X and used global variables for a number 
-of lists that were used to transfer imformation between components. 
-In McStas 3.X that was no longer possible, so an Union_init and Union_stop method was added, this 
-were required to surround all the Union components used in an instrument. The init part loaded the
-required libraries and set up the global variables, then all other Union components would read the
-variables from that component, needing the name on it as an input (standard convetion is init), so
-almost always omitted. Stop added switch statements for process functions, avoiding cases that are
+of lists that were used to transfer information between components. 
+In McStas / McXtrace 3.X that was no longer possible, so an Union_init and Union_stop method was 
+added, they were required to surround all the Union components used in an instrument. The `Union_init` 
+loaded the required libraries and set up the global variables, then all other Union components would read the
+variables from that component, needing the name on it as an input (standard convention is init), so
+almost always omitted. `Union_stop` added switch statements for process functions, avoiding cases that are
 not actually in the current instrument using the preprocessor. The included files are in share and
-do need updating when new processes / geometries are added. They are called union-init.c, union-lib.c
-and union-suffix.c.
+do need updating when new processes / geometries are added. They are called `union-init.c`, `union-lib.c`
+and `union-suffix.c`. 
 
 ## Decision
 
-Let the code generator insert the union-init.c, union-lib.c and union-suffix.c files at the
-appropriate positions if a Union_master or a Union_master_GPU is detected.
+Let the code generator insert the `union-init.c`, union-lib.c and union-suffix.c files at the
+appropriate positions if a `Union_master` or a `Union_master_GPU` is detected. It works by searching
+for a `Union_master` component, if found it adds `read_table-lib.h`, `union-lib.c` and `union-init.c`
+before SHARE and `union-suffix.c` after SHARE. It also creates a Union define that can be used
+to detect whether Union is active in this instrument.
 
-Keep the Union_init and Union_stop components for a transition period, but they are empty and
-only show a deprication warning.
+All Union components emit compile errors if the Union define does not yet exist, this is done in each
+component. 
+
+Keep the `Union_init` and `Union_stop` components for a transition period, but they now only contain
+the code emitting the deprecation warning.
 
 Remove the init input on all Union components.
 
-Add errors on all non master Union components to let the user know a master is necessary to compile
-the instrument.
-
 ## Consequences
 
-It becomes easier to use the Union components as there is no need to place Union_init or Union_stop.
+It becomes easier to use the Union components as there is no need to place `Union_init` or `Union_stop`.
+
+Instruments using the `init` parameter in any Union component will need that removed as the parameter
+was removed.
 
 Existing instruments that do not use the init parameter for individual components still work and only
-show the deprication warnings. Using mismatch between version of the components and code generator
+show the deprication warnings. A mismatch between version of the components and code generator
 could lead to problems, but the same preprocessor guards are used. Main issue would be an instrument
 using a folder of new Union components with an old code generator, in that case libraries would not
 be loaded.
 
 Still easy for developers to find the .c files in share to update them.
 
+Cogen would need to be updated if Union_master name is changed.
+
 ## Behaviour
 
-Simplifies use of Union components by avoiding Union_init and Union_stop.
+- In valid use, Union systems no longer need the `Union_init`  and `Union_stop`
+- Using the `Union_init` and `Union_stop` won't break instruments, but show deprication warnings
+- Using the init parameter in Union components will fail as the parameter is removed
+- Compilation fails if any Union component is used without a Union_master
+
+
+

--- a/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
+++ b/docs/GRAMMAR/ADR-records/ADR_20260909_UNION_GLOBALS.md
@@ -8,14 +8,14 @@ This is a proposed change
 
 The original Union components were developed under McStas 2.X and used global variables for a number 
 of lists that were used to transfer information between components. 
-In McStas and McXtrace 3.X that was no longer possible, so the Union_init and Union_stop component was 
-added, they were required to surround all the Union components used in an instrument. The `Union_init` 
+In McStas and McXtrace 3.X that was no longer possible, so the `Union_init` and `Union_stop` component were 
+added. They were required to surround all the Union components used in an instrument. The `Union_init` 
 loaded the required libraries and set up the global variables, then all other Union components would read the
 variables from that component, needing the name on it as the init parameter. The init parameter had a default
 of `init` so if the `Union_init` instance was given that name, there was no need to specify that parameter. 
-`Union_stop` added switch statements for process functions, avoiding cases that are not actually in the current 
-instrument using the preprocessor. The included files are in share and do need updating when new processes 
-/ geometries are added. They are called `union-init.c`, `union-lib.c` and `union-suffix.c`. 
+`Union_stop` component added switch statements for process functions, avoiding cases that are not actually in
+the current instrument using the preprocessor. The included files are in share and do need updating when new 
+processes / geometries are added. They are called `union-init.c`, `union-lib.c` and `union-suffix.c`.
 
 ## Decision
 
@@ -23,8 +23,8 @@ Let the code generator insert the `union-init.c`, `union-lib.c` and `union-suffi
 appropriate positions if a `Union_master` or a `Union_master_GPU` is detected. It works by searching
 for a `Union_master`/`Union_master_GPU` component, if found it adds `read_table-lib.h`, `union-lib.c` 
 and `union-init.c` before all component SHARE sections and `union-suffix.c` after all component SHARE
-sections. It also creates a Union define that can be used to detect whether Union is active in this 
-instrument.
+sections. It also creates a Union preprocessor macro that can be used to detect whether Union is active 
+in this instrument.
 
 All Union components emit compile errors if the Union preprocessor macro is not defined, this is done 
 in each component. 
@@ -41,13 +41,13 @@ It becomes easier to use the Union components as there is no need to place `Unio
 Instruments using the `init` parameter in any Union component will need that removed as the parameter
 was removed.
 
-Existing instruments that do not use the init parameter for individual components but has the `Union_init`
+Existing instruments that do not use the init parameter for individual components but have the `Union_init`
 and/or `Union_stop` components still work and only show the deprecation warnings. A mismatch between 
 version of the components and code generator could lead to problems, but the same preprocessor guards are used.
 Main issue would be an instrument using a folder of new Union components with an old code generator, in that case 
 the intentional compile errors would be triggered.
 
-No change in where developers to find the .c files in share to update them.
+No change the location of .c files in share that needs to be easily accesible to developers.
 
 Cogen would need to be updated if `Union_master` or `Union_master_GPU` name is changed.
 

--- a/docs/manuals/mcstas/union/AF_HB_1D_process.tex
+++ b/docs/manuals/mcstas/union/AF_HB_1D_process.tex
@@ -47,7 +47,6 @@ A\_constant & unitless & Constant from M\&uuml;ller paper 1981, probably somewhe
 J\_interaction & meV & Exchange constant & 1 \\
 packing\_factor & 1 & How dense is the material compared to optimal 0-1 & 1 \\
 interact\_fraction & 1 & How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1) & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/IncoherentPhonon_process.tex
+++ b/docs/manuals/mcstas/union/IncoherentPhonon_process.tex
@@ -49,7 +49,6 @@ nxs & 1 & Number of energy points at which the total cross sections are precompu
 kabsmin & A\textasciicircum{}-1 & Lower cut-off for the neutron wave-vector k & 0.1 \\
 kabsmax & A\textasciicircum{}-1 & Higher cut-off for the neutron wave-vector k & 25 \\
 interact\_fraction & 1 & How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1) & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Incoherent_process.tex
+++ b/docs/manuals/mcstas/union/Incoherent_process.tex
@@ -46,7 +46,6 @@ gamma & meV & Lorentzian width of quasielastic broadening (HWHM) [1] & 0 \\
 packing\_factor & 1 & How dense is the material compared to optimal 0-1 & 1 \\
 unit\_cell\_volume & AA\textasciicircum{}3 & Unit cell volume & 13.8 \\
 interact\_fraction & 1 & How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1) & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Mirror_surface.tex
+++ b/docs/manuals/mcstas/union/Mirror_surface.tex
@@ -51,7 +51,6 @@ Qc & AA-1 & Critical scattering vector & 0.0219 \\
 alpha & AA & Slope of reflectivity & 6.07 \\
 m & 1 & m-value of material. Zero means completely absorbing. & 2 \\
 W & AA-1 & Width of supermirror cut-off & 0.003 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/NCrystal_process.tex
+++ b/docs/manuals/mcstas/union/NCrystal_process.tex
@@ -61,7 +61,6 @@ Parameters in \textbf{boldface} are required; the others are optional.
 cfg & str & NCrystal material configuration string (details \textless{}a href="https://github.com/mctools/ncrystal/wiki/Using-NCrystal"\textgreater{}on this page\textless{}/a\textgreater{}). & "" \\
 packing\_factor & 1 & Material packing factor & 1 \\
 interact\_fraction & 1 & How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1) & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Non_process.tex
+++ b/docs/manuals/mcstas/union/Non_process.tex
@@ -44,7 +44,6 @@ sigma & barns & Scattering cross section & 5.08 \\
 packing\_factor & 1 & How dense is the material compared to optimal 0-1 & 1 \\
 unit\_cell\_volume & AA\textasciicircum{}3 & Unit cell volume & 13.8 \\
 interact\_fraction & 1 & How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1) & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/PhononSimple_process.tex
+++ b/docs/manuals/mcstas/union/PhononSimple_process.tex
@@ -52,7 +52,6 @@ T & K & Temperature & 290 \\
 DW & 1 & Debye-Waller factor & 1 \\
 longitudinal & 0/1 & Simulate longitudinal branches & 1 \\
 transverse & 0/1 & Simulate transverse branches & 1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Template_process.tex
+++ b/docs/manuals/mcstas/union/Template_process.tex
@@ -47,7 +47,6 @@ sigma & barns & Incoherent scattering cross section & 5.08 \\
 packing\_factor & 1 & How dense is the material compared to optimal 0-1 & 1 \\
 unit\_cell\_volume & AA\textasciicircum{}3 & Unit\_cell\_volume & 13.8 \\
 interact\_fraction & 1 & How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1) & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Template_surface.tex
+++ b/docs/manuals/mcstas/union/Template_surface.tex
@@ -53,7 +53,6 @@ Qc & AA-1 & Critical scattering vector & 0.0219 \\
 alpha & AA & Slope of reflectivity & 6.07 \\
 m & 1 & m-value of material. Zero means completely absorbing. & 2 \\
 W & AA-1 & Width of supermirror cut-off & 0.003 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Texture_process.tex
+++ b/docs/manuals/mcstas/union/Texture_process.tex
@@ -42,7 +42,6 @@ order & 1 & Limit scattering to this order & 0 \\
 interact\_fraction & 1 & How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1) & -1 \\
 packing\_factor & 1 & How dense is the material compared to optimal 0-1 & 1 \\
 maxNeutronSaved & 1 & Maximum number of neutron cross sections saved for reusing & 1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_1D_space.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_1D_space.tex
@@ -72,7 +72,6 @@ filename & string & Filename of produced data file & "NULL" \\
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_1D_space_event.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_1D_space_event.tex
@@ -82,7 +82,6 @@ filename & string & Filename of produced data file & "NULL" \\
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_1D_space_tof.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_1D_space_tof.tex
@@ -75,7 +75,6 @@ filename & string & Filename of produced data file & "NULL" \\
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_1D_space_tof_to_lambda.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_1D_space_tof_to_lambda.tex
@@ -106,7 +106,6 @@ filename & string & Filename of produced data file & "NULL" \\
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_1D_time.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_1D_time.tex
@@ -73,7 +73,6 @@ filename & string & Filename of produced data file & "NULL" \\
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_2D_space.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_2D_space.tex
@@ -82,7 +82,6 @@ filename & string & Filename of produced data file & "NULL" \\
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_event.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_event.tex
@@ -72,7 +72,6 @@ zbins & 1 & Number of bins in z direction & 0 \\
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_abs_logger_nD.tex
+++ b/docs/manuals/mcstas/union/Union_abs_logger_nD.tex
@@ -70,7 +70,6 @@ target\_geometry & string & Comma separated list of geometry names that will be 
 order\_total & 1 & Only log rays that have scattered n times, -1 for all orders & -1 \\
 order\_volume & 1 & Only log rays that have scattered n times in the same geometry, -1 for all orders & -1 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then access logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 user1 & str & Variable name of USERVAR to be monitored by user1. & "" \\
 user2 & str & Variable name of USERVAR to be monitored by user2. & "" \\
 user3 & str & Variable name of USERVAR to be monitored by user3. & "" \\

--- a/docs/manuals/mcstas/union/Union_box.tex
+++ b/docs/manuals/mcstas/union/Union_box.tex
@@ -72,7 +72,6 @@ p\_interact & 1 & Probability to interact with this geometry [0-1] & 0 \\
 mask\_string & string & Comma seperated list of geometry names which this geometry should mask & 0 \\
 mask\_setting & string & "All" or "Any", should the masked volume be simulated when the ray is in just one mask, or all. & 0 \\
 number\_of\_activations & 1 & Number of subsequent Union\_master components that will simulate this geometry & 1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_conditional_PSD.tex
+++ b/docs/manuals/mcstas/union/Union_conditional_PSD.tex
@@ -62,7 +62,6 @@ tagging\_extend\_index & 1 & Not currently used & -1 \\
 time\_min & s & Min time (on psd), if not set ignored & 0 \\
 time\_max & s & Max time (on psd), if not set ignored & 0 \\
 overwrite\_logger\_weight & 1 & Default = 0, overwrite = 1 & 0 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_conditional_standard.tex
+++ b/docs/manuals/mcstas/union/Union_conditional_standard.tex
@@ -62,7 +62,6 @@ total\_order\_min & 1 & Min scattering order, if not set ignored & 0 \\
 total\_order\_max & 1 & Max scattering order, if not set ignored & 0 \\
 last\_volume\_index & 1 & Not used yet & -1 \\
 overwrite\_logger\_weight & 1 & Default = 0, overwrite = 1 & 0 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_cone.tex
+++ b/docs/manuals/mcstas/union/Union_cone.tex
@@ -65,7 +65,6 @@ top\_surface & string & Comma seperated string of Union surface definitions defi
 bottom\_surface & string & Comma seperated string of Union surface definitions defined prior to this component, applied to -y bottom face of cone & 0 \\
 all\_face\_surface & string & Comma seperated string of Union surface definitions defined prior to this component, applied to all faces above & 0 \\
 cut\_surface & string & Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts & 0 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_cylinder.tex
+++ b/docs/manuals/mcstas/union/Union_cylinder.tex
@@ -63,7 +63,6 @@ top\_surface & string & Comma seperated string of Union surface definitions defi
 bottom\_surface & string & Comma seperated string of Union surface definitions defined prior to this component, applied to -y bottom face of cylinder & 0 \\
 all\_face\_surface & string & Comma seperated string of Union surface definitions defined prior to this component, applied to all faces above & 0 \\
 cut\_surface & string & Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts & 0 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_init.tex
+++ b/docs/manuals/mcstas/union/Union_init.tex
@@ -1,5 +1,5 @@
 \section{The \texttt{Union\_init} McStas Component}
-Initialize component that needs to be place before any Union component
+Deprecated compatibility component. Union components are initialized automatically.
 
 \subsection*{Identification}
 \begin{itemize}
@@ -16,7 +16,7 @@ sperates geometry and physics within McStas.
 The use of this component requires other components to be used.
 
 1) One specifies a number of processes using process components
-2) These are gathered into material definitions using this component
+2) These are gathered into material definitions using Union_make_material
 3) Geometries are placed using Union_box/cylinder/sphere, assigned a material
 4) A Union_master component placed after all of the above
 

--- a/docs/manuals/mcstas/union/Union_logger_1D.tex
+++ b/docs/manuals/mcstas/union/Union_logger_1D.tex
@@ -62,7 +62,6 @@ order\_total & 1 & Only log rays that scatter for the n'th time, 0 for all order
 order\_volume & 1 & Only log rays that scatter for the n'th time in the same geometry & 0 \\
 order\_volume\_process & 1 & Only log rays that scatter for the n'th time in the same geometry, using the same process & 0 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then acces logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_logger_2DQ.tex
+++ b/docs/manuals/mcstas/union/Union_logger_2DQ.tex
@@ -65,7 +65,6 @@ order\_total & 1 & Only log rays that scatter for the n'th time, 0 for all order
 order\_volume & 1 & Only log rays that scatter for the n'th time in the same geometry & 0 \\
 order\_volume\_process & 1 & Only log rays that scatter for the n'th time in the same geometry, uwsing the same process & 0 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then acces logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_logger_2D_kf.tex
+++ b/docs/manuals/mcstas/union/Union_logger_2D_kf.tex
@@ -66,7 +66,6 @@ order\_total & 1 & Only log rays that scatter for the n'th time, 0 for all order
 order\_volume & 1 & Only log rays that scatter for the n'th time in the same geometry & 0 \\
 order\_volume\_process & 1 & Only log rays that scatter for the n'th time in the same geometry, using the same process & 0 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then acces logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_logger_2D_kf_time.tex
+++ b/docs/manuals/mcstas/union/Union_logger_2D_kf_time.tex
@@ -70,7 +70,6 @@ order\_total & 1 & Only log rays that scatter for the n'th time, 0 for all order
 order\_volume & 1 & Only log rays that scatter for the n'th time in the same geometry & 0 \\
 order\_volume\_process & 1 & Only log rays that scatter for the n'th time in the same geometry, using the same process & 0 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then acces logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_logger_2D_space.tex
+++ b/docs/manuals/mcstas/union/Union_logger_2D_space.tex
@@ -67,7 +67,6 @@ order\_total & 1 & Only log rays that scatter for the n'th time, 0 for all order
 order\_volume & 1 & Only log rays that scatter for the n'th time in the same geometry & 0 \\
 order\_volume\_process & 1 & Only log rays that scatter for the n'th time in the same geometry, using the same process & 0 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then acces logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_logger_2D_space_time.tex
+++ b/docs/manuals/mcstas/union/Union_logger_2D_space_time.tex
@@ -70,7 +70,6 @@ order\_total & 1 & Only log rays that scatter for the n'th time, 0 for all order
 order\_volume & 1 & Only log rays that scatter for the n'th time in the same geometry & 0 \\
 order\_volume\_process & 1 & Only log rays that scatter for the n'th time in the same geometry, using the same process & 0 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then acces logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_logger_3D_space.tex
+++ b/docs/manuals/mcstas/union/Union_logger_3D_space.tex
@@ -71,7 +71,6 @@ order\_total & 1 & Only log rays that scatter for the n'th time, 0 for all order
 order\_volume & 1 & Only log rays that scatter for the n'th time in the same geometry & 0 \\
 order\_volume\_process & 1 & Only log rays that scatter for the n'th time in the same geometry, using the same process & 0 \\
 logger\_conditional\_extend\_index & 1 & If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger\_conditional\_extend", and one would then acces logger\_conditional\_extend[n] if logger\_conditional\_extend\_index is set to n & -1 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_make_material.tex
+++ b/docs/manuals/mcstas/union/Union_make_material.tex
@@ -44,7 +44,6 @@ refraction\_density & g/cm3 & Density of the refracting material. density \textl
 refraction\_sigma\_coh & barn & Coherent cross section of refracting material. Use negative value to indicate a negative coherent scattering length & 0 \\
 refraction\_weight & g/mol & Molar mass of the refracting material & 0 \\
 refraction\_SLD & AA\textasciicircum{}-2 & Scattering length density of material (overwrites sigma\_coh, density and weight) & -1500 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_master.tex
+++ b/docs/manuals/mcstas/union/Union_master.tex
@@ -48,7 +48,6 @@ history\_limit & 1 & Limit the number of unique histories that are saved & 30000
 enable\_conditionals & 0/1 & Use conditionals with this master & 1 \\
 inherit\_number\_of\_scattering\_events & 0/1 & Inherit the number of scattering events from last master & 0 \\
 weight\_ratio\_limit & 1 & Limit on the ratio between initial weight and current, ray absorbed if ratio becomes lower than limit & 1e-90 \\
-init & string & Name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_master_GPU.tex
+++ b/docs/manuals/mcstas/union/Union_master_GPU.tex
@@ -45,7 +45,6 @@ enable\_tagging & 0/1 & Enable tagging of ray history (geometry, scattering proc
 history\_limit & 1 & Limit the number of unique histories that are saved & 300000 \\
 enable\_conditionals & 0/1 & Use conditionals with this master & 1 \\
 inherit\_number\_of\_scattering\_events & 0/1 & Inherit the number of scattering events from last master & 0 \\
-init &  &  & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_mesh.tex
+++ b/docs/manuals/mcstas/union/Union_mesh.tex
@@ -69,7 +69,6 @@ mask\_setting & string & "All" or "Any", should the masked volume be simulated w
 number\_of\_activations & 1 & Number of subsequent Union\_master components that will simulate this geometry & 1 \\
 skip\_convex\_check & 1 & when set to 1, skips the check for whether input .off file is convex. & 0 \\
 coordinate\_scale & 1e-3 & Multiplier that the vertex positions are multiplied by. Set to 1 for input coordinates in meters. Set to 1e-3 for input coordinates in mm. & 1e-3 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_sphere.tex
+++ b/docs/manuals/mcstas/union/Union_sphere.tex
@@ -58,7 +58,6 @@ mask\_setting & string & "All" or "Any", should the masked volume be simulated w
 number\_of\_activations & 1 & Number of subsequent Union\_master components that will simulate this geometry & 1 \\
 surface & string & Comma seperated string of Union surface definitions defined prior to this component & 0 \\
 cut\_surface & string & Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts & 0 \\
-init & string & name of Union\_init component (typically "init", default) & "init" \\
 \bottomrule
 \end{longtable}
 

--- a/docs/manuals/mcstas/union/Union_stop.tex
+++ b/docs/manuals/mcstas/union/Union_stop.tex
@@ -1,5 +1,5 @@
 \section{The \texttt{Union\_stop} McStas Component}
-Stop component that must be placed after all Union components for instrument to compile correctly
+Deprecated compatibility component. Union components are finalized automatically.
 
 \subsection*{Identification}
 \begin{itemize}
@@ -22,6 +22,10 @@ The use of this component requires other components to be used.
 
 Only in step 4 will any simulation happen, and per default all geometries
 defined before the master, but after the previous will be simulated here.
+
+The Union_stop component is optional. The code generator automatically injects
+the Union dispatch switch, and this compatibility component emits a deprecation
+warning when used.
 
 There is a dedicated manual available for the Union_components
 

--- a/mccode/src/cogen.c.in
+++ b/mccode/src/cogen.c.in
@@ -1170,6 +1170,28 @@ void cogen_getparticlevar_fct(struct instr_def *instr)
 }
 
 /*******************************************************************************
+* cogen_instr_uses_union: return 1 if the instrument uses the Union component
+* family. A Union_master (or Union_master_GPU) is always present when Union is
+* used, so its presence triggers auto-injection of the shared Union header/state
+* (front) and the dispatch switch (back).
+*******************************************************************************/
+static int cogen_instr_uses_union(struct instr_def *instr)
+{
+  List_handle liter;
+  struct comp_inst *comp;
+
+  liter = list_iterate(instr->complist);
+  while((comp = list_next(liter)))
+  {
+    if (comp->def && (strcmp(comp->def->name, "Union_master") == 0
+        || strcmp(comp->def->name, "Union_master_GPU") == 0))
+      return 1;
+  }
+  list_iterate_end(liter);
+  return 0;
+}
+
+/*******************************************************************************
 * cogen_decls: write the declaration part from the instrument description
 *   that is the particle definition, the instrument parameters, the DECLARE part,
 *   and all SHARE sections from components.
@@ -1186,6 +1208,7 @@ int cogen_decls(struct instr_def *instr)
   struct instr_formal *i_formal; /* Name of instrument formal parameter. */
   long index = 0;
   int  warnings = 0;
+  int  is_union = cogen_instr_uses_union(instr);
 
   /* a previous call to cogen_header writes the file header */
 
@@ -1196,6 +1219,18 @@ int cogen_decls(struct instr_def *instr)
   coutf("* instrument '%s' and components DECLARE", instr->name);
   cout("***************************************************************************** */");
   cout("");
+
+  /* Union components: auto-inject the shared header and global state before
+  * any component SHARE/DECLARE that uses the Union types or globals. */
+  if (is_union) {
+    cout("");
+    cout("/* Union components: shared header and global state (auto-injected) */");
+    cout("#ifndef Union");
+    cout("#define Union 1");
+    cout("#endif");
+    embed_file("union-lib.c");
+    embed_file("union-init.c");
+  }
 
   /* 1. particle definition */
   /* moved to cogen_header, as this is needed in mccode-r */
@@ -1350,6 +1385,14 @@ int cogen_decls(struct instr_def *instr)
     cout("/*             End of SHARE user declarations for all components              */");
     cout("/* ************************************************************************** */");
     cout("");
+  }
+
+  /* Union components: auto-inject the dispatch switch after all component
+  * SHAREs, so every process/surface DETECTOR macro is already defined. */
+  if (is_union) {
+    cout("");
+    cout("/* Union components: dispatch switch (auto-injected) */");
+    embed_file("union-suffix.c");
   }
 
   /* 5. write component declares */

--- a/mccode/src/cogen.c.in
+++ b/mccode/src/cogen.c.in
@@ -1228,6 +1228,8 @@ int cogen_decls(struct instr_def *instr)
     cout("#ifndef Union");
     cout("#define Union 1");
     cout("#endif");
+    /* union-lib.c uses t_Table in McXtrace Union structures. */
+    embed_file("read_table-lib.h");
     embed_file("union-lib.c");
     embed_file("union-init.c");
   }

--- a/mccode/src/cogen.c.in
+++ b/mccode/src/cogen.c.in
@@ -1192,36 +1192,6 @@ static int cogen_instr_uses_union(struct instr_def *instr)
 }
 
 /*******************************************************************************
-* Reject Union components when the instrument has no Union master before the
-* generated C file reaches the compiler, which would otherwise report a large
-* number of secondary missing-library errors.
-*******************************************************************************/
-static void cogen_validate_union(struct instr_def *instr)
-{
-  if (cogen_instr_uses_union(instr))
-    return;
-
-  List_handle liter = list_iterate(instr->complist);
-  struct comp_inst *comp;
-  while ((comp = list_next(liter))) {
-    List_handle shareiter = list_iterate(comp->def->share_code->lines);
-    char *line;
-    while ((line = list_next(shareiter))) {
-      if (strstr(line, "Union library not loaded")) {
-        fprintf(stderr,
-                "ERROR: Trying to add component %s of type %s which require the Union library to be loaded: Add a Union_master component to load the libraries.\n",
-                comp->name, comp->def->name);
-        list_iterate_end(shareiter);
-        list_iterate_end(liter);
-        exit(1);
-      }
-    }
-    list_iterate_end(shareiter);
-  }
-  list_iterate_end(liter);
-}
-
-/*******************************************************************************
 * cogen_decls: write the declaration part from the instrument description
 *   that is the particle definition, the instrument parameters, the DECLARE part,
 *   and all SHARE sections from components.
@@ -3246,8 +3216,6 @@ void
 cogen(char *output_name, struct instr_def *instr)
 {
   int warnings = 0;
-
-  cogen_validate_union(instr);
 
   /* INITIALISE output file. */
   if(!output_name || !output_name[0] || !strcmp(output_name, "-"))

--- a/mccode/src/cogen.c.in
+++ b/mccode/src/cogen.c.in
@@ -1209,7 +1209,7 @@ static void cogen_validate_union(struct instr_def *instr)
     while ((line = list_next(shareiter))) {
       if (strstr(line, "Union library not loaded")) {
         fprintf(stderr,
-                "Trying to add component %s of type %s which require the Union library to be loaded: Add a Union_master component to load the libraries.\n",
+                "ERROR: Trying to add component %s of type %s which require the Union library to be loaded: Add a Union_master component to load the libraries.\n",
                 comp->name, comp->def->name);
         list_iterate_end(shareiter);
         list_iterate_end(liter);

--- a/mccode/src/cogen.c.in
+++ b/mccode/src/cogen.c.in
@@ -1192,6 +1192,36 @@ static int cogen_instr_uses_union(struct instr_def *instr)
 }
 
 /*******************************************************************************
+* Reject Union components when the instrument has no Union master before the
+* generated C file reaches the compiler, which would otherwise report a large
+* number of secondary missing-library errors.
+*******************************************************************************/
+static void cogen_validate_union(struct instr_def *instr)
+{
+  if (cogen_instr_uses_union(instr))
+    return;
+
+  List_handle liter = list_iterate(instr->complist);
+  struct comp_inst *comp;
+  while ((comp = list_next(liter))) {
+    List_handle shareiter = list_iterate(comp->def->share_code->lines);
+    char *line;
+    while ((line = list_next(shareiter))) {
+      if (strstr(line, "Union library not loaded")) {
+        fprintf(stderr,
+                "Trying to add component %s of type %s which require the Union library to be loaded: Add a Union_master component to load the libraries.\n",
+                comp->name, comp->def->name);
+        list_iterate_end(shareiter);
+        list_iterate_end(liter);
+        exit(1);
+      }
+    }
+    list_iterate_end(shareiter);
+  }
+  list_iterate_end(liter);
+}
+
+/*******************************************************************************
 * cogen_decls: write the declaration part from the instrument description
 *   that is the particle definition, the instrument parameters, the DECLARE part,
 *   and all SHARE sections from components.
@@ -3216,6 +3246,8 @@ void
 cogen(char *output_name, struct instr_def *instr)
 {
   int warnings = 0;
+
+  cogen_validate_union(instr);
 
   /* INITIALISE output file. */
   if(!output_name || !output_name[0] || !strcmp(output_name, "-"))

--- a/mcstas-comps/share/union-init.c
+++ b/mcstas-comps/share/union-init.c
@@ -32,51 +32,62 @@
 * %E
 ******************************************************************************/
 
+#ifndef UNION_INIT_C
+#define UNION_INIT_C
 
 // This file sets up global lists needed for Union components to communicate with each other
 // These all have dynamically allocated memory somewhere in the structure, which is deallocated
 //  by the last Union_master.
+//
+// This file is auto-injected by the code generator (mccode) at the front of the
+//  generated code whenever the instrument uses the Union component family
+//  (i.e. contains a Union_master). It no longer needs to be placed in a
+//  Union_init component. The globals use a 'g_' prefix so they do not collide
+//  with the component-local pointers of the same base name that each Union
+//  component declares.
 
 
 // Initialize global positions / rotations to transform lists
   // These are lists of pointers to positons / rotations, that will be updated from global frame
   //  to the frame of the master component that uses them in that masters initialize section.
-  struct global_positions_to_transform_list_struct global_positions_to_transform_list = {0,NULL};
-  struct global_rotations_to_transform_list_struct global_rotations_to_transform_list = {0,NULL};
+  struct global_positions_to_transform_list_struct g_positions_to_transform_list = {0,NULL};
+  struct global_rotations_to_transform_list_struct g_rotations_to_transform_list = {0,NULL};
 
 // Initialize global_process_list
   // Used to facilitate communication between processes and the other types of Union components
-  struct pointer_to_global_process_list global_process_list = {0,NULL};
+  struct pointer_to_global_process_list g_process_list = {0,NULL};
 
 // Initialize global_material_list
   // Used to facilitate communication between materials and the other types of Union components
-  struct pointer_to_global_material_list global_material_list = {0,NULL};
-  
+  struct pointer_to_global_material_list g_material_list = {0,NULL};
+
 // Initialize global_surface_list
   // Used to facilitate communication between surface components and other types of Union components
-  struct pointer_to_global_surface_list global_surface_list = {0,NULL};
+  struct pointer_to_global_surface_list g_surface_list = {0,NULL};
 
 // Initialize global_geometry_list
   // Used to facilitate communication between geometries and the other types of Union components
-  struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
+  struct pointer_to_global_geometry_list g_geometry_list = {0,NULL};
 
 // Initialize global_logger_lists
   // Used to facilitate communication between loggers and the other types of Union components
-  struct pointer_to_global_logger_list global_all_volume_logger_list = {0,NULL};
-  struct pointer_to_global_logger_list global_specific_volumes_logger_list = {0,NULL};
+  struct pointer_to_global_logger_list g_all_volume_logger_list = {0,NULL};
+  struct pointer_to_global_logger_list g_specific_volumes_logger_list = {0,NULL};
 
 // Initialize global_abs_logger_lists
-  struct pointer_to_global_abs_logger_list global_all_volume_abs_logger_list = {0,NULL};
-  struct pointer_to_global_abs_logger_list global_specific_volumes_abs_logger_list = {0,NULL};
+  struct pointer_to_global_abs_logger_list g_all_volume_abs_logger_list = {0,NULL};
+  struct pointer_to_global_abs_logger_list g_specific_volumes_abs_logger_list = {0,NULL};
 
 // Initialize global_tagging_conditional_list
   // Used to facilitate communication between conditionals and the other types of Union components
-  struct global_tagging_conditional_list_struct global_tagging_conditional_list = {0,0,NULL};
+  struct global_tagging_conditional_list_struct g_tagging_conditional_list = {0,0,NULL};
 
 // Initialize global_master_list
   // Used to facilitate communication between Master components (mainly for deallocation)
-  struct pointer_to_global_master_list global_master_list = {0,NULL};
+  struct pointer_to_global_master_list g_master_list = {0,NULL};
 
 // Initialize global_mantid_min_pixel_id
   // Used for ensuring pixel id's on Mantid monitors do not overlap
-  int global_mantid_min_pixel_id = 0;
+  int g_mantid_min_pixel_id = 0;
+
+#endif /* UNION_INIT_C */

--- a/mcstas-comps/share/union-lib.c
+++ b/mcstas-comps/share/union-lib.c
@@ -9,9 +9,14 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* Functions and structure definitons for Union components.
-*
-******************************************************************************/
+ * Functions and structure definitons for Union components.
+ *
+ ******************************************************************************/
+
+// Include guard: this file is auto-injected by the code generator and must
+// expand exactly once even if referenced more than once.
+#ifndef UNION_LIB_C
+#define UNION_LIB_C
 
 // -------------    Definition of data structures   ---------------------------------------------
 // GPU
@@ -9217,7 +9222,9 @@ void fill_surface_stack(char *input_string, struct pointer_to_global_surface_lis
 
 void overwrite_if_empty(char *input_string, char *overwrite) {
    if (!(input_string && strlen(input_string) && strcmp(input_string, "NULL") && strcmp(input_string, "0"))) {
-	   strcpy(input_string, overwrite);
+       strcpy(input_string, overwrite);
    }
 }
+
+#endif /* UNION_LIB_C */
 

--- a/mcstas-comps/share/union-suffix.c
+++ b/mcstas-comps/share/union-suffix.c
@@ -6,6 +6,11 @@ update Union master to use the flexible functions
 deal with loggers and conditionals
 */
 
+// Include guard: auto-injected by the code generator (once); keeps the
+// dispatch functions from being defined twice during transition.
+#ifndef UNION_SUFFIX_C
+#define UNION_SUFFIX_C
+
 int physics_my(enum process choice, double *my,double *k_initial, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
 
     int output = 0; // Error return value
@@ -169,3 +174,5 @@ int physics_surface(struct surface_process_struct *surface,                 // s
     #endif
     return output;
 }
+
+#endif /* UNION_SUFFIX_C */

--- a/mcstas-comps/union/AF_HB_1D_process.comp
+++ b/mcstas-comps/union/AF_HB_1D_process.comp
@@ -349,7 +349,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/AF_HB_1D_process.comp
+++ b/mcstas-comps/union/AF_HB_1D_process.comp
@@ -62,7 +62,7 @@ SETTING PARAMETERS(atom_distance=1, number_density=0, unit_cell_volume=0, A_cons
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: AF_HB_1D_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct physical_constants_AF_HB_1D {

--- a/mcstas-comps/union/AF_HB_1D_process.comp
+++ b/mcstas-comps/union/AF_HB_1D_process.comp
@@ -42,7 +42,6 @@
 * atom_distance:     [AA]       Distance between atom's in chain
 * packing_factor:    [1]        How dense is the material compared to optimal 0-1
 * interact_fraction: [1]        How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 * Template_storage          // Important to update this output paramter
@@ -57,7 +56,7 @@
 
 DEFINE COMPONENT AF_HB_1D_process // Remember to change the name of process here
 
-SETTING PARAMETERS(atom_distance=1, number_density=0, unit_cell_volume=0, A_constant=1, J_interaction=1, packing_factor=1, interact_fraction=-1, string init="init")
+SETTING PARAMETERS(atom_distance=1, number_density=0, unit_cell_volume=0, A_constant=1, J_interaction=1, packing_factor=1, interact_fraction=-1)
 
 
 SHARE

--- a/mcstas-comps/union/AF_HB_1D_process.comp
+++ b/mcstas-comps/union/AF_HB_1D_process.comp
@@ -63,7 +63,7 @@ SETTING PARAMETERS(atom_distance=1, number_density=0, unit_cell_volume=0, A_cons
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this AF_HB_1D_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct physical_constants_AF_HB_1D {

--- a/mcstas-comps/union/IncoherentPhonon_process.comp
+++ b/mcstas-comps/union/IncoherentPhonon_process.comp
@@ -5178,12 +5178,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "IncoherentPhonon_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
 
   fprintf (IncoherentPhonon_storage.filep, "Initialization done\n");

--- a/mcstas-comps/union/IncoherentPhonon_process.comp
+++ b/mcstas-comps/union/IncoherentPhonon_process.comp
@@ -71,7 +71,7 @@ SETTING PARAMETERS(double T=394, double density=6.0, double M=50.94,
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: IncoherentPhonon_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   #ifndef INCOHERENTPHONON

--- a/mcstas-comps/union/IncoherentPhonon_process.comp
+++ b/mcstas-comps/union/IncoherentPhonon_process.comp
@@ -43,7 +43,6 @@
 * kabsmin:           [A^-1]   Lower cut-off for the neutron wave-vector k
 * kabsmax:           [A^-1]   Higher cut-off for the neutron wave-vector k
 * interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -64,7 +63,7 @@ SETTING PARAMETERS(double T=394, double density=6.0, double M=50.94,
                   string DOSfn=NULL,
 		   int nphe_exact=1, int nphe_approx=0, int approx=0, int mph_resum=0, 
 		   int nxs=1000, double kabsmin=0.1, double kabsmax=25,
-		   int interact_fraction=-1, string init="init")
+		   int interact_fraction=-1)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */

--- a/mcstas-comps/union/IncoherentPhonon_process.comp
+++ b/mcstas-comps/union/IncoherentPhonon_process.comp
@@ -72,7 +72,7 @@ SETTING PARAMETERS(double T=394, double density=6.0, double M=50.94,
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this IncoherentPhonon_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   #ifndef INCOHERENTPHONON

--- a/mcstas-comps/union/Incoherent_process.comp
+++ b/mcstas-comps/union/Incoherent_process.comp
@@ -173,13 +173,8 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Incoherent_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
-  add_element_to_process_list (global_process_list, global_process_element);
+   struct pointer_to_global_process_list* global_process_list = &g_process_list;
+   add_element_to_process_list (global_process_list, global_process_element);
  %}
 
 TRACE

--- a/mcstas-comps/union/Incoherent_process.comp
+++ b/mcstas-comps/union/Incoherent_process.comp
@@ -41,7 +41,6 @@
 * packing_factor:    [1]     How dense is the material compared to optimal 0-1
 * unit_cell_volume:  [AA^3]  Unit cell volume
 * interact_fraction: [1]     How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -53,7 +52,7 @@
 
 DEFINE COMPONENT Incoherent_process
 
-SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volume=13.8, interact_fraction=-1, string init="init")
+SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volume=13.8, interact_fraction=-1)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -173,8 +172,8 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-   struct pointer_to_global_process_list* global_process_list = &g_process_list;
-   add_element_to_process_list (global_process_list, global_process_element);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  add_element_to_process_list (global_process_list, global_process_element);
  %}
 
 TRACE

--- a/mcstas-comps/union/Incoherent_process.comp
+++ b/mcstas-comps/union/Incoherent_process.comp
@@ -61,7 +61,7 @@ SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volu
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Incoherent_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct Incoherent_physics_storage_struct {

--- a/mcstas-comps/union/Incoherent_process.comp
+++ b/mcstas-comps/union/Incoherent_process.comp
@@ -60,7 +60,7 @@ SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volu
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Incoherent_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct Incoherent_physics_storage_struct {

--- a/mcstas-comps/union/Inhomogenous_incoherent_process.comp
+++ b/mcstas-comps/union/Inhomogenous_incoherent_process.comp
@@ -372,12 +372,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Incoherent_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
 %}
 

--- a/mcstas-comps/union/Inhomogenous_incoherent_process.comp
+++ b/mcstas-comps/union/Inhomogenous_incoherent_process.comp
@@ -144,7 +144,7 @@ SHARE
   %include "tinyexpr.h"
   %include "tinyexpr.c"
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Inhomogenous_incoherent_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct Inhomogenous_incoherent_struct {

--- a/mcstas-comps/union/Inhomogenous_incoherent_process.comp
+++ b/mcstas-comps/union/Inhomogenous_incoherent_process.comp
@@ -115,7 +115,6 @@
 * number_of_sample_points [1]       Number of points that are sampled along the neutron path through a material
 * interact_fraction:      [1]       How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
 * verbose                 [1]       Flag that prints out the values calculated in the cross section calculation
-* init:                   [string]  name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -134,8 +133,8 @@ SETTING PARAMETERS( sigma=0, string sigma_expr = "",
                     f_QE=0,
                     number_of_sample_points = 20, 
                     interact_fraction=-1, 
-                    int verbose = 0,
-                    string init="init")
+                     int verbose = 0
+                    )
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */

--- a/mcstas-comps/union/Inhomogenous_incoherent_process.comp
+++ b/mcstas-comps/union/Inhomogenous_incoherent_process.comp
@@ -145,7 +145,7 @@ SHARE
   %include "tinyexpr.h"
   %include "tinyexpr.c"
   #ifndef Union
-  #error "The Union_init component must be included before this Incoherent_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct Inhomogenous_incoherent_struct {

--- a/mcstas-comps/union/Mirror_surface.comp
+++ b/mcstas-comps/union/Mirror_surface.comp
@@ -192,12 +192,7 @@ INITIALIZE
   global_surface_element.component_index = INDEX_CURRENT_COMP;
   global_surface_element.p_surface_process = &This_surface;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Mirror_surface:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_surface_list* global_surface_list = COMP_GETPAR3 (Union_init, init, global_surface_list);
+  struct pointer_to_global_surface_list* global_surface_list = &g_surface_list;
   add_element_to_surface_list (global_surface_list, global_surface_element);
  %}
 

--- a/mcstas-comps/union/Mirror_surface.comp
+++ b/mcstas-comps/union/Mirror_surface.comp
@@ -46,7 +46,6 @@
 * m:                  [1]      m-value of material. Zero means completely absorbing.
 * W:                  [AA-1]   Width of supermirror cut-off
 * reflect:            [str]    Name of reflectivity file. Format q(Angs-1) R(0-1)
-* init:               [string] Name of Union_init component (typically "init", default)
 *
 * %L
 *
@@ -55,7 +54,7 @@
 
 DEFINE COMPONENT Mirror_surface // Remember to change the name of process here
 
-SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.003, string init="init")
+SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.003)
 
 
 SHARE
@@ -202,4 +201,3 @@ TRACE
 %}
 
 END
-

--- a/mcstas-comps/union/Mirror_surface.comp
+++ b/mcstas-comps/union/Mirror_surface.comp
@@ -61,7 +61,7 @@ SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.00
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Mirror_surface component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/Mirror_surface.comp
+++ b/mcstas-comps/union/Mirror_surface.comp
@@ -60,7 +60,7 @@ SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.00
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Mirror_surface requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/NCrystal_process.comp
+++ b/mcstas-comps/union/NCrystal_process.comp
@@ -415,12 +415,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "NCrystal_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/NCrystal_process.comp
+++ b/mcstas-comps/union/NCrystal_process.comp
@@ -119,7 +119,7 @@ DEPENDENCY "@NCRYSTALFLAGS@"
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: NCrystal_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   #if defined(WIN32) || defined(_WIN32)

--- a/mcstas-comps/union/NCrystal_process.comp
+++ b/mcstas-comps/union/NCrystal_process.comp
@@ -74,7 +74,6 @@
 * INPUT PARAMETERS:
 * cfg:               [str]    NCrystal material configuration string (details <a href="https://github.com/mctools/ncrystal/wiki/Using-NCrystal">on this page</a>).
 * interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 * NCrystal_storage          // Storage used to communicate with the probability and scattering function
@@ -114,7 +113,7 @@
 
 DEFINE COMPONENT NCrystal_process // Remember to change the name of process here
 
-SETTING PARAMETERS(string cfg = "", interact_fraction=-1, string init="init")
+SETTING PARAMETERS(string cfg = "", interact_fraction=-1)
 DEPENDENCY "@NCRYSTALFLAGS@"
 
 SHARE
@@ -215,8 +214,9 @@ SHARE
     ekin = vsq2ekin * K2V * k_mag * K2V * k_mag;
     ekin_final = 0.0;
     // Call NCrystal library, dirout and delta_ekin is updated
-    ncrystal_samplescatter (data_transfer.pointer_to_a_NCrystal_physics_storage_struct->stored_params.scat, ekin, (const double (*)[3]) & dir, &ekin_final, &dirout);
-	
+    ncrystal_samplescatter (data_transfer.pointer_to_a_NCrystal_physics_storage_struct->stored_params.scat, ekin, (const double (*)[3]) & dir, &ekin_final,
+                            &dirout);
+
     if (ekin_final <= 0) {
       // not expected to happen much, but an interaction could in principle bring the neutron to rest.
       return 0; // Eqivalent to ABSORB

--- a/mcstas-comps/union/NCrystal_process.comp
+++ b/mcstas-comps/union/NCrystal_process.comp
@@ -120,7 +120,7 @@ DEPENDENCY "@NCRYSTALFLAGS@"
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this NCrystal_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   #if defined(WIN32) || defined(_WIN32)

--- a/mcstas-comps/union/Non_process.comp
+++ b/mcstas-comps/union/Non_process.comp
@@ -160,12 +160,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Non_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/Non_process.comp
+++ b/mcstas-comps/union/Non_process.comp
@@ -39,7 +39,6 @@
 * unit_cell_volume: [AA^3]   Unit cell volume
 * packing_factor:    [1]        How dense is the material compared to optimal 0-1
 * interact_fraction: [1]        How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 * Non_storage          
@@ -52,7 +51,7 @@
 
 DEFINE COMPONENT Non_process // Remember to change the name of process here
 
-SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1, string init="init")
+SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1)
 
 
 SHARE

--- a/mcstas-comps/union/Non_process.comp
+++ b/mcstas-comps/union/Non_process.comp
@@ -57,7 +57,7 @@ SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fr
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Non_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // Very important to add a pointer to this struct in the union-lib.c file

--- a/mcstas-comps/union/Non_process.comp
+++ b/mcstas-comps/union/Non_process.comp
@@ -58,7 +58,7 @@ SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fr
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Non_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // Very important to add a pointer to this struct in the union-lib.c file

--- a/mcstas-comps/union/PhononSimple_process.comp
+++ b/mcstas-comps/union/PhononSimple_process.comp
@@ -530,12 +530,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "PhononSimple_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/PhononSimple_process.comp
+++ b/mcstas-comps/union/PhononSimple_process.comp
@@ -64,7 +64,7 @@ SETTING PARAMETERS(packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1,a
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: PhononSimple_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // Very important to add a pointer to this struct in the union-lib.c file

--- a/mcstas-comps/union/PhononSimple_process.comp
+++ b/mcstas-comps/union/PhononSimple_process.comp
@@ -65,7 +65,7 @@ SETTING PARAMETERS(packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1,a
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this PhononSimple_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // Very important to add a pointer to this struct in the union-lib.c file

--- a/mcstas-comps/union/PhononSimple_process.comp
+++ b/mcstas-comps/union/PhononSimple_process.comp
@@ -46,7 +46,6 @@
 * transverse:        [0/1]    Simulate transverse branches
 * packing_factor:    [1]      How dense is the material compared to optimal 0-1
 * interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] Name of Union_init component (typically "init", default)
 * DW:                [1]      Debye-Waller factor
 * CALCULATED PARAMETERS:
 * PhononSimple_storage      // Important to update this output paramter
@@ -59,7 +58,7 @@
 
 DEFINE COMPONENT PhononSimple_process
 
-SETTING PARAMETERS(packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1,a=4.95,c=10,M=207.2,b=9.4,T=290,DW=1,longitudinal=1,transverse=1, string init="init")
+SETTING PARAMETERS(packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1,a=4.95,c=10,M=207.2,b=9.4,T=290,DW=1,longitudinal=1,transverse=1)
 
 
 SHARE
@@ -390,7 +389,7 @@ SHARE
     // my_constant = V_rho*DW*K2V*K2V*VS2E*2*VS2E*K2V*b*b/M // done in initialize
 
     //*my = (double)
-    //nf*k_final/k_length*kappa2/fabs(omega)*nbose_union(omega,T)*k_final/J_factor*data_transfer.pointer_to_a_PhononSimple_storage_struct->my_constant;
+    // nf*k_final/k_length*kappa2/fabs(omega)*nbose_union(omega,T)*k_final/J_factor*data_transfer.pointer_to_a_PhononSimple_storage_struct->my_constant;
 
     *my = (double)nf * k_final / k_length * pol_weight_factor / fabs (omega) * nbose_union (omega, T) * k_final / J_factor
           * data_transfer.pointer_to_a_PhononSimple_storage_struct->my_constant;

--- a/mcstas-comps/union/Powder_process.comp
+++ b/mcstas-comps/union/Powder_process.comp
@@ -833,12 +833,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Powder_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/Powder_process.comp
+++ b/mcstas-comps/union/Powder_process.comp
@@ -67,7 +67,7 @@ SETTING PARAMETERS(string reflections="NULL",packing_factor=1, Vc=0, delta_d_d=0
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Powder_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // Share section of PowderN 8/3 2016 from McStas.org

--- a/mcstas-comps/union/Powder_process.comp
+++ b/mcstas-comps/union/Powder_process.comp
@@ -59,7 +59,7 @@
 
 DEFINE COMPONENT Powder_process
 
-SETTING PARAMETERS(string reflections="NULL",packing_factor=1, Vc=0, delta_d_d=0, DW=0, nb_atoms=1, d_phi=0, density=0, weight=0, barns=1, Strain=0, interact_fraction=-1, vector format={0, 0, 0, 0, 0, 0, 0, 0, 0}, string init="init")
+SETTING PARAMETERS(string reflections="NULL",packing_factor=1, Vc=0, delta_d_d=0, DW=0, nb_atoms=1, d_phi=0, density=0, weight=0, barns=1, Strain=0, interact_fraction=-1, vector format={0, 0, 0, 0, 0, 0, 0, 0, 0})
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */

--- a/mcstas-comps/union/Powder_process.comp
+++ b/mcstas-comps/union/Powder_process.comp
@@ -67,7 +67,7 @@ SETTING PARAMETERS(string reflections="NULL",packing_factor=1, Vc=0, delta_d_d=0
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Powder_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // Share section of PowderN 8/3 2016 from McStas.org

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -1162,12 +1162,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Single_crystal_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -90,7 +90,7 @@ SETTING PARAMETERS(string reflections=0, delta_d_d=1e-4,
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Single_crystal_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -90,7 +90,7 @@ SETTING PARAMETERS(string reflections=0, delta_d_d=1e-4,
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Single_crystal_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/Single_crystal_process.comp
+++ b/mcstas-comps/union/Single_crystal_process.comp
@@ -84,7 +84,7 @@ SETTING PARAMETERS(string reflections=0, delta_d_d=1e-4,
             bx = 0, by = 0, bz = 0,
             cx = 0, cy = 0, cz = 0,
 	    aa=0, bb=0, cc=0, order=0, RX=0, RY=0, RZ=0, powder=0, PG=0,
-            interact_fraction=-1, packing_factor=1, string init="init")
+            interact_fraction=-1, packing_factor=1)
 
 
 SHARE

--- a/mcstas-comps/union/Template_process.comp
+++ b/mcstas-comps/union/Template_process.comp
@@ -174,12 +174,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Template_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/Template_process.comp
+++ b/mcstas-comps/union/Template_process.comp
@@ -42,7 +42,6 @@
 * packing_factor:    [1]      How dense is the material compared to optimal 0-1
 * unit_cell_volume:  [AA^3]   Unit_cell_volume
 * interact_fraction: [1]      How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 * Template_storage          // Important to update this output paramter
@@ -55,7 +54,7 @@
 
 DEFINE COMPONENT Template_process // Remember to change the name of process here
 
-SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1, string init="init")
+SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fraction=-1)
 
 
 SHARE

--- a/mcstas-comps/union/Template_process.comp
+++ b/mcstas-comps/union/Template_process.comp
@@ -61,7 +61,7 @@ SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fr
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Template_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // Very important to add a pointer to this struct in the union-lib.c file

--- a/mcstas-comps/union/Template_process.comp
+++ b/mcstas-comps/union/Template_process.comp
@@ -60,7 +60,7 @@ SETTING PARAMETERS(sigma=5.08,packing_factor=1,unit_cell_volume=13.8,interact_fr
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Template_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // Very important to add a pointer to this struct in the union-lib.c file

--- a/mcstas-comps/union/Template_surface.comp
+++ b/mcstas-comps/union/Template_surface.comp
@@ -191,12 +191,7 @@ INITIALIZE
   global_surface_element.component_index = INDEX_CURRENT_COMP;
   global_surface_element.p_surface_process = &This_surface;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Template_surface:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_surface_list* global_surface_list = COMP_GETPAR3 (Union_init, init, global_surface_list);
+  struct pointer_to_global_surface_list* global_surface_list = &g_surface_list;
   add_element_to_surface_list (global_surface_list, global_surface_element);
  %}
 

--- a/mcstas-comps/union/Template_surface.comp
+++ b/mcstas-comps/union/Template_surface.comp
@@ -62,7 +62,7 @@ SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.00
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Template_surface requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/Template_surface.comp
+++ b/mcstas-comps/union/Template_surface.comp
@@ -63,7 +63,7 @@ SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.00
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Template_surface component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/Template_surface.comp
+++ b/mcstas-comps/union/Template_surface.comp
@@ -48,7 +48,6 @@
 * m:                  [1]      m-value of material. Zero means completely absorbing.
 * W:                  [AA-1]   Width of supermirror cut-off
 * reflect:            [str]    Name of reflectivity file. Format q(Angs-1) R(0-1)
-* init:               [string] Name of Union_init component (typically "init", default)
 *
 * %L
 *
@@ -57,7 +56,7 @@
 
 DEFINE COMPONENT Template_surface // Remember to change the name of process here
 
-SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.003, string init="init")
+SETTING PARAMETERS(string reflect=0, R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.003)
 
 
 SHARE

--- a/mcstas-comps/union/Texture_process.comp
+++ b/mcstas-comps/union/Texture_process.comp
@@ -2427,12 +2427,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Texture_process:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
   add_element_to_process_list (global_process_list, global_process_element);
  %}
 

--- a/mcstas-comps/union/Texture_process.comp
+++ b/mcstas-comps/union/Texture_process.comp
@@ -60,7 +60,7 @@ SETTING PARAMETERS(string crystal_fn=0, string fcoef_fn=0, int lmax_user=-1,
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Texture_process component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/Texture_process.comp
+++ b/mcstas-comps/union/Texture_process.comp
@@ -59,7 +59,7 @@ SETTING PARAMETERS(string crystal_fn=0, string fcoef_fn=0, int lmax_user=-1,
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Texture_process requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   %include "read_table-lib"

--- a/mcstas-comps/union/Texture_process.comp
+++ b/mcstas-comps/union/Texture_process.comp
@@ -36,7 +36,6 @@
 * fcoef_fn:          [s]      Path to a text file containing the Fourier coefficients of the ODF. It must have five columns: l m n Real(Clmn) Imag(Clmn)
 * lmax_user:         [1]      Cut-off for the Fourier series. If negative, the program uses all the coefficients provided in the file fcoef_fn
 * maxNeutronSaved:   [1]      Maximum number of neutron cross sections saved for reusing
-* init:              [string] Name of Union_init component (typically "init", default)
 * barns:             [1]      Flag to indicate if |F|^2 from 'crystal_fn' is in barns or fm^2. barns=1 for laz and isotropic constant elastic scattering (reflections=NULL), barns=0 for lau type files
 * order:             [1]      Limit scattering to this order
 *
@@ -54,7 +53,7 @@ DEFINE COMPONENT Texture_process // Remember to change the name of process here
 
 SETTING PARAMETERS(string crystal_fn=0, string fcoef_fn=0, int lmax_user=-1,
             barns = 0, order = 0, interact_fraction = -1, packing_factor = 1,
-	        int maxNeutronSaved = 1, string init="init")
+	        int maxNeutronSaved = 1)
 
 
 SHARE

--- a/mcstas-comps/union/Union_abs_logger_1D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space.comp
@@ -89,7 +89,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_1D_space requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_1D_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_1D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space.comp
@@ -90,7 +90,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_abs_logger_1D_space component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_1D_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_1D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space.comp
@@ -442,13 +442,8 @@ INITIALIZE
   if (!this_abs_storage.temp_1D_abs_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_1D_space: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_1D_space:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_abs_storage.position);
@@ -486,8 +481,8 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -508,7 +503,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_1D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space.comp
@@ -66,8 +66,7 @@
 * order_total:     [1] Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:              [string] name of Union_init component (typically "init", default)
-* nowritefile:     [1]      If set, logger will skip writing to disk
+ * nowritefile:     [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -82,7 +81,7 @@ DEFINE COMPONENT Union_abs_logger_1D_space
 
 SETTING PARAMETERS(string target_geometry="NULL",
                    yheight, n=100,
-                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -540,4 +539,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
@@ -494,14 +494,9 @@ INITIALIZE
 
   sprintf (this_abs_storage.Vars.option, "mantid square x limits=[-0.0005,0.0005] bins=3 y limits=[%f %f] bins=%i", -0.5 * yheight, 0.5 * yheight, n);
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_1D_space_event:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
   // Need to tell the monitor from what integer its pixel id range starts, and it necessary to avoid overlaps.
   // global_mantid_min_pixel_id is initialized as 0, and each monitor adds its number of pixels to avoid overlap.
-  int global_mantid_min_pixel_id = (int)COMP_GETPAR3 (Union_init, init, global_mantid_min_pixel_id);
+  int global_mantid_min_pixel_id = g_mantid_min_pixel_id;
   sprintf (option_string_part, ", neutron pixel min=%i t, list all neutrons", global_mantid_min_pixel_id);
   global_mantid_min_pixel_id += 3 * n;
 
@@ -532,8 +527,8 @@ INITIALIZE
   if (!this_abs_storage.temp_abs_1D_event_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_1D_space_event: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_abs_storage.position);
@@ -583,8 +578,8 @@ INITIALIZE
   abs_logger_list_element.component_index = INDEX_CURRENT_COMP;
   abs_logger_list_element.abs_logger = &this_abs_logger;
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each available process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -605,7 +600,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
@@ -76,8 +76,7 @@
 * order_total:     [1] Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:              [string] name of Union_init component (typically "init", default)
-* nowritefile:     [1]      If set, logger will skip writing to disk
+ * nowritefile:     [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -91,7 +90,7 @@
 DEFINE COMPONENT Union_abs_logger_1D_space_event
 
 SETTING PARAMETERS(string target_geometry="NULL", yheight, int n, int fake_event=0,
-                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */

--- a/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
@@ -99,7 +99,7 @@ SETTING PARAMETERS(string target_geometry="NULL", yheight, int n, int fake_event
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_abs_logger_1D_space_event component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // Internally avoids double import

--- a/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_event.comp
@@ -98,7 +98,7 @@ SETTING PARAMETERS(string target_geometry="NULL", yheight, int n, int fake_event
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_1D_space_event requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // Internally avoids double import

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
@@ -94,7 +94,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_abs_logger_1D_space_tof component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_1D_time_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
@@ -503,13 +503,8 @@ INITIALIZE
   if (!this_abs_storage.temp_1D_time_abs_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_1D_space_tof: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_1D_space_tof:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_abs_storage.position);
@@ -547,8 +542,8 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -569,7 +564,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
@@ -69,8 +69,7 @@
 * order_total:     [1] Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:              [string] name of Union_init component (typically "init", default)
-* nowritefile:     [1]      If set, logger will skip writing to disk
+ * nowritefile:     [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -86,7 +85,7 @@ DEFINE COMPONENT Union_abs_logger_1D_space_tof
 SETTING PARAMETERS(string target_geometry="NULL",
                    yheight, n=0.2,
                    time_min=0, time_max=1, time_bins=100,
-                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -602,4 +601,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof.comp
@@ -93,7 +93,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_1D_space_tof requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_1D_time_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
@@ -127,7 +127,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_1D_space_tof_to_lambda requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_1D_time_to_lambda_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
@@ -128,7 +128,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_abs_logger_1D_space_tof_to_lambda component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_1D_time_to_lambda_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
@@ -708,14 +708,8 @@ INITIALIZE
   if (!this_abs_storage.temp_1D_time_to_lambda_abs_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_1D_space_tof_to_lambda: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_1D_space_tof_to_lambda:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP,
-             init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
 
   this_abs_storage.position = POS_A_CURRENT_COMP;
@@ -751,8 +745,8 @@ INITIALIZE
   abs_logger_list_element.component_index = INDEX_CURRENT_COMP;
   abs_logger_list_element.abs_logger = &this_abs_logger;
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -773,7 +767,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_space_tof_to_lambda.comp
@@ -100,8 +100,7 @@
 * order_total:        [1]      Only log rays that have scattered n times, -1 for all orders
 * order_volume:       [1]      Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:               [string] Name of Union_init component (typically "init", default)
-* nowritefile:        [1]      If set, logger will skip writing to disk
+ * nowritefile:        [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -120,7 +119,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
                    lambda_m_min=-1, lambda_m_max=-1, lambda_m_bins=-1,
                    lambda_t_min=-1, lambda_t_max=-1, lambda_t_bins=-1,
                    relative_measured=0, relative_min=0.5, relative_max=1.5, relative_bins=100,
-                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -805,4 +804,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_abs_logger_1D_time.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_time.comp
@@ -68,7 +68,6 @@
 * order_total:     [1] Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1] Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:            [string] name of Union_init component (typically "init", default)
 * time_min:        [s] Minimum time to log
 * time_max:        [s] Maximum time to log
 * nowritefile:     [1]      If set, logger will skip writing to disk
@@ -86,7 +85,7 @@ DEFINE COMPONENT Union_abs_logger_1D_time
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS(string target_geometry="NULL",
                    time_min=0, time_max, n=100,
-                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, int nowritefile=0)
 OUTPUT PARAMETERS ()
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */

--- a/mcstas-comps/union/Union_abs_logger_1D_time.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_time.comp
@@ -94,7 +94,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_abs_logger_1D_time component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_time_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_1D_time.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_time.comp
@@ -435,11 +435,6 @@ INITIALIZE
   if (!this_abs_storage.temp_time_abs_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_1D_time: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_1D_time:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
   // printf("past direction choices sanitation \n");
 
   // Book keeping
@@ -470,8 +465,8 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each available process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -492,7 +487,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_1D_time.comp
+++ b/mcstas-comps/union/Union_abs_logger_1D_time.comp
@@ -93,7 +93,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_1D_time requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_time_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_2D_space.comp
@@ -101,8 +101,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #define Union $Revision: 0.8 $
-  #error "The Union_init component must be included before this Union_abs_logger_2D_space component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_2D_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_2D_space.comp
@@ -100,7 +100,7 @@ SETTING PARAMETERS(string target_geometry="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_2D_space requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_2D_abs_data_element_struct {

--- a/mcstas-comps/union/Union_abs_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_2D_space.comp
@@ -76,8 +76,7 @@
 * order_total:     [1]      Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1]      Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:            [string] Name of Union_init component (typically "init", default)
-* nowritefile:     [1]      If set, logger will skip writing to disk
+ * nowritefile:     [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -93,7 +92,7 @@ DEFINE COMPONENT Union_abs_logger_2D_space
 SETTING PARAMETERS(string target_geometry="NULL",
                    string D_direction_1="x", D1_min=-0.2, D1_max=5, n1=0.2,
                    string D_direction_2="z", D2_min=-0.2, D2_max=5, n2=0.2,
-                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   string filename="NULL", order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -662,4 +661,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_abs_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_abs_logger_2D_space.comp
@@ -564,13 +564,8 @@ INITIALIZE
   if (!this_abs_storage.temp_2D_abs_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_2D_space: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_2D_space:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_abs_storage.position);
@@ -608,8 +603,8 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -630,7 +625,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_event.comp
@@ -72,8 +72,7 @@
 * xbins:           [1] Number of bins along x in logging volume
 * ybins:           [1] Number of bins along y in logging volume
 * zbns:            [1] Number of bins along z in logging volume
-* init:            [string] Name of Union_init component (typically "init", default)
-* nowritefile:     [1]      If set, logger will skip writing to disk
+ * nowritefile:     [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -88,7 +87,7 @@ DEFINE COMPONENT Union_abs_logger_event
 
 SETTING PARAMETERS(string target_geometry="NULL", string filename="NULL",
                    xwidth=0, xbins=0, yheight=0, ybins=0, zdepth=0, zbins=0,
-                   order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -718,4 +717,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_abs_logger_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_event.comp
@@ -95,7 +95,7 @@ SETTING PARAMETERS(string target_geometry="NULL", string filename="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_event requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // Internally avoids double import

--- a/mcstas-comps/union/Union_abs_logger_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_event.comp
@@ -628,13 +628,8 @@ INITIALIZE
   if (!this_abs_storage.temp_abs_event_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_event: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_event:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_abs_storage.position);
@@ -661,8 +656,8 @@ INITIALIZE
   abs_logger_list_element.component_index = INDEX_CURRENT_COMP;
   abs_logger_list_element.abs_logger = &this_abs_logger;
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -683,7 +678,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_event.comp
+++ b/mcstas-comps/union/Union_abs_logger_event.comp
@@ -96,7 +96,7 @@ SETTING PARAMETERS(string target_geometry="NULL", string filename="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_abs_logger_event component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // Internally avoids double import

--- a/mcstas-comps/union/Union_abs_logger_nD.comp
+++ b/mcstas-comps/union/Union_abs_logger_nD.comp
@@ -534,13 +534,8 @@ INITIALIZE INHERIT Monitor_nD EXTEND
   if (!this_abs_storage.temp_abs_nD_data.elements)
     exit (fprintf (stderr, "Union_abs_logger_nD: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_abs_logger_nD:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_abs_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_abs_storage.position);
@@ -567,8 +562,8 @@ INITIALIZE INHERIT Monitor_nD EXTEND
   abs_logger_list_element.component_index = INDEX_CURRENT_COMP;
   abs_logger_list_element.abs_logger = &this_abs_logger;
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
   int process_index;
@@ -589,7 +584,7 @@ INITIALIZE INHERIT Monitor_nD EXTEND
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+    struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
     add_element_to_abs_logger_list (global_all_volume_abs_logger_list, abs_logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_abs_logger_nD.comp
+++ b/mcstas-comps/union/Union_abs_logger_nD.comp
@@ -117,7 +117,7 @@
 DEFINE COMPONENT Union_abs_logger_nD
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS(string target_geometry="NULL",
-                   order_total=-1, order_volume=-1, logger_conditional_extend_index=-1)
+                   order_total=-1, order_volume=-1, logger_conditional_extend_index=-1,
 				   string user0="",string user1="", string user2="", string user3="", string user4="",
 		                   string user5="",string user6="", string user7="", string user8="", string user9="",
 				   xwidth=0, yheight=0, zdepth=0,

--- a/mcstas-comps/union/Union_abs_logger_nD.comp
+++ b/mcstas-comps/union/Union_abs_logger_nD.comp
@@ -134,7 +134,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_abs_logger_nD component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   %include "monitor_nd-lib"

--- a/mcstas-comps/union/Union_abs_logger_nD.comp
+++ b/mcstas-comps/union/Union_abs_logger_nD.comp
@@ -64,7 +64,6 @@
 * order_total:     [1]      Only log rays that have scattered n times, -1 for all orders
 * order_volume:    [1]      Only log rays that have scattered n times in the same geometry, -1 for all orders
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then access logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:            [string] Name of Union_init component (typically "init", default)
 * xwidth: [m]            Width of detector.
 * yheight: [m]           Height of detector.
 * zdepth: [m]            Thickness of detector (z).
@@ -118,7 +117,7 @@
 DEFINE COMPONENT Union_abs_logger_nD
 DEFINITION PARAMETERS ()
 SETTING PARAMETERS(string target_geometry="NULL",
-                   order_total=-1, order_volume=-1, logger_conditional_extend_index=-1, string init="init",
+                   order_total=-1, order_volume=-1, logger_conditional_extend_index=-1)
 				   string user0="",string user1="", string user2="", string user3="", string user4="",
 		                   string user5="",string user6="", string user7="", string user8="", string user9="",
 				   xwidth=0, yheight=0, zdepth=0,
@@ -610,4 +609,3 @@ FINALLY INHERIT Monitor_nD EXTEND
 MCDISPLAY INHERIT Monitor_nD
 
 END
-

--- a/mcstas-comps/union/Union_abs_logger_nD.comp
+++ b/mcstas-comps/union/Union_abs_logger_nD.comp
@@ -133,7 +133,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_abs_logger_nD requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   %include "monitor_nd-lib"

--- a/mcstas-comps/union/Union_box.comp
+++ b/mcstas-comps/union/Union_box.comp
@@ -270,12 +270,7 @@ INITIALIZE
     exit (1);
   }
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_box:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_material_list* global_material_list = COMP_GETPAR3 (Union_init, init, global_material_list);
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
   // Use sanitation
   if (global_material_list->num_elements == 0) {
     printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
@@ -286,7 +281,7 @@ INITIALIZE
   this_box_volume.geometry.is_masked_volume = 0;
   this_box_volume.geometry.is_exit_volume = 0;
   this_box_volume.geometry.is_mask_volume = 0;
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
   // check if the volume is a mask, if it is the material string is irelevant.
   if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.
@@ -479,7 +474,7 @@ INITIALIZE
   this_box_volume.geometry.surface_stack_for_each_face[5] = &minus_y_surface_stack;
   this_box_volume.geometry.internal_cut_surface_stack = &cut_surface_stack; // This surface is used if the volume is cut by overlapping of higher priority volume
 
-  struct pointer_to_global_surface_list* global_surface_list = COMP_GETPAR3 (Union_init, init, global_surface_list);
+  struct pointer_to_global_surface_list* global_surface_list = &g_surface_list;
   fill_surface_stack (plus_x_surface, global_surface_list, NAME_CURRENT_COMP, &plus_x_surface_stack);
   fill_surface_stack (minus_x_surface, global_surface_list, NAME_CURRENT_COMP, &minus_x_surface_stack);
   fill_surface_stack (plus_y_surface, global_surface_list, NAME_CURRENT_COMP, &plus_y_surface_stack);

--- a/mcstas-comps/union/Union_box.comp
+++ b/mcstas-comps/union/Union_box.comp
@@ -65,7 +65,6 @@
 * minus_z_surface:       [string] Comma seperated string of Union surface definitions defined prior to this component, applied to -z face of box
 * all_face_surface:      [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all faces above
 * cut_surface:           [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts
-* init:                  [string] name of Union_init component (typically "init", default)
 * CALCULATED PARAMETERS:
 *
 * %L
@@ -82,7 +81,7 @@ SETTING PARAMETERS(string material_string=0, priority,
 				   string plus_x_surface=0, string minus_x_surface=0,
 				   string plus_y_surface=0, string minus_y_surface=0,
 				   string all_face_surface=0, string cut_surface=0, 
-				   p_interact = 0, string mask_string=0, string mask_setting=0, number_of_activations=1, string init="init")
+				   p_interact = 0, string mask_string=0, string mask_setting=0, number_of_activations=1)
 
 SHARE
 %{
@@ -503,4 +502,3 @@ TRACE
 %}
 
 END
-

--- a/mcstas-comps/union/Union_box.comp
+++ b/mcstas-comps/union/Union_box.comp
@@ -87,7 +87,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_box requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   void

--- a/mcstas-comps/union/Union_box.comp
+++ b/mcstas-comps/union/Union_box.comp
@@ -88,7 +88,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "The Union_init component must be included before this Union_box component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   void

--- a/mcstas-comps/union/Union_conditional_PSD.comp
+++ b/mcstas-comps/union/Union_conditional_PSD.comp
@@ -257,13 +257,8 @@ INITIALIZE
   }
   this_conditional_data.PSD_half_yheight = 0.5 * yheight;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_conditional_PSD:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_conditional_data.PSD_position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_conditional_data.PSD_position);
@@ -277,7 +272,7 @@ INITIALIZE
   // Set the data union to be for this specific type of conditional, and supply it with a pointer to its static data
   this_data_union.p_PSD = &this_conditional_data;
 
-  struct global_tagging_conditional_list_struct* global_tagging_conditional_list = COMP_GETPAR3 (Union_init, init, global_tagging_conditional_list);
+  struct global_tagging_conditional_list_struct* global_tagging_conditional_list = &g_tagging_conditional_list;
 
   if (master_tagging == 1) {
     // Apply this conditional to the next master components tagging system
@@ -306,10 +301,10 @@ INITIALIZE
                                       &conditional_function_PSD, &this_data_union);
   }
 
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
-  struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
-  struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
+  struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
+  struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
 
   // Need to find the loggers which need to have this conditional applied
   if (target_loggers && strlen (target_loggers) && strcmp (target_loggers, "NULL") && strcmp (target_loggers, "0")) {

--- a/mcstas-comps/union/Union_conditional_PSD.comp
+++ b/mcstas-comps/union/Union_conditional_PSD.comp
@@ -81,7 +81,7 @@ SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int taggi
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_conditional_PSD requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   int

--- a/mcstas-comps/union/Union_conditional_PSD.comp
+++ b/mcstas-comps/union/Union_conditional_PSD.comp
@@ -58,7 +58,6 @@
 * overwrite_logger_weight: [1]   Default = 0, overwrite = 1
 * end_volume:           [1]      Not used yet
 * last_volume_index:    [1]      Not used yet
-* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 * this_material:            Structure that contains information on this material
@@ -74,7 +73,7 @@
 
 DEFINE COMPONENT Union_conditional_PSD
 
-SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int tagging_extend_index = -1, xwidth, yheight,time_min=0, time_max=0, overwrite_logger_weight=0, string init="init") // E limit, |k| limit, volumes to have visited, processes that was used, end volume, last process
+SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int tagging_extend_index = -1, xwidth, yheight,time_min=0, time_max=0, overwrite_logger_weight=0) // E limit, |k| limit, volumes to have visited, processes that was used, end volume, last process
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -283,8 +282,8 @@ INITIALIZE
       new_tagging_element = malloc (sizeof (struct global_tagging_conditional_element_struct));
       new_tagging_element->extend_index = tagging_extend_index;
       new_tagging_element->conditional_list.num_elements = 0;
-	  new_tagging_element->conditional_list.p_data_unions = NULL;		  
-      new_tagging_element->conditional_list.conditional_functions = NULL;	  
+      new_tagging_element->conditional_list.p_data_unions = NULL;
+      new_tagging_element->conditional_list.conditional_functions = NULL;
       strcpy (new_tagging_element->name, NAME_CURRENT_COMP);
 
       // printf("adding new element to global_tagging_conditional_list \n");
@@ -451,10 +450,9 @@ FINALLY
   // Remember to clean up allocated lists
   free (accepted_loggers_specific.elements);
   free (accepted_loggers_all.elements);
-  free(accepted_abs_loggers_all.elements);
-  free(accepted_abs_loggers_specific.elements);
+  free (accepted_abs_loggers_all.elements);
+  free (accepted_abs_loggers_specific.elements);
   // if (accepted_tagging.num_elements > 0) free(accepted_tagging.elements);
 %}
 
 END
-

--- a/mcstas-comps/union/Union_conditional_PSD.comp
+++ b/mcstas-comps/union/Union_conditional_PSD.comp
@@ -82,7 +82,7 @@ SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int taggi
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_conditional_PSD component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   int

--- a/mcstas-comps/union/Union_conditional_standard.comp
+++ b/mcstas-comps/union/Union_conditional_standard.comp
@@ -313,13 +313,8 @@ INITIALIZE
   this_conditional_data.Total_scat_max = total_order_max;
   this_conditional_data.Total_scat_min = total_order_min;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_conditional_standard:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_conditional_data.test_position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_conditional_data.test_position);
@@ -333,7 +328,7 @@ INITIALIZE
   // Set the data union to be for this specific type of conditional, and supply it with a pointer to its static data
   this_data_union.p_standard = &this_conditional_data;
 
-  struct global_tagging_conditional_list_struct* global_tagging_conditional_list = COMP_GETPAR3 (Union_init, init, global_tagging_conditional_list);
+  struct global_tagging_conditional_list_struct* global_tagging_conditional_list = &g_tagging_conditional_list;
 
   if (master_tagging == 1) {
     // Apply this conditional to the next master components tagging system
@@ -362,10 +357,10 @@ INITIALIZE
                                       &conditional_function_standard, &this_data_union);
   }
 
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
-  struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
-  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
-  struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
+  struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list = &g_specific_volumes_abs_logger_list;
+  struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list = &g_all_volume_abs_logger_list;
 
   // Need to find the loggers which need to have this conditional applied
   if (target_loggers && strlen (target_loggers) && strcmp (target_loggers, "NULL") && strcmp (target_loggers, "0")) {

--- a/mcstas-comps/union/Union_conditional_standard.comp
+++ b/mcstas-comps/union/Union_conditional_standard.comp
@@ -78,7 +78,7 @@ SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int taggi
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_conditional_standard component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   int

--- a/mcstas-comps/union/Union_conditional_standard.comp
+++ b/mcstas-comps/union/Union_conditional_standard.comp
@@ -56,7 +56,6 @@
 * total_order_max:      [1]      Max scattering order, if not set ignored
 * overwrite_logger_weight: [1]   Default = 0, overwrite = 1
 * last_volume_index:    [1]      Not used yet
-* init:                 [string] Name of Union_init component (typically "init", default)
 *
 *
 * CALCULATED PARAMETERS:
@@ -70,7 +69,7 @@
 
 DEFINE COMPONENT Union_conditional_standard
 
-SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int tagging_extend_index = -1, time_min=0, time_max=0, E_min=0, E_max=0, total_order_min=0, total_order_max=0, last_volume_index=-1,overwrite_logger_weight=0, string init="init") // E limit, |k| limit, volumes to have visited, processes that was used, end volume, last process
+SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int tagging_extend_index = -1, time_min=0, time_max=0, E_min=0, E_max=0, total_order_min=0, total_order_max=0, last_volume_index=-1,overwrite_logger_weight=0) // E limit, |k| limit, volumes to have visited, processes that was used, end volume, last process
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -339,8 +338,8 @@ INITIALIZE
       new_tagging_element = malloc (sizeof (struct global_tagging_conditional_element_struct));
       new_tagging_element->extend_index = tagging_extend_index;
       new_tagging_element->conditional_list.num_elements = 0;
-	  new_tagging_element->conditional_list.p_data_unions = NULL;		  
-      new_tagging_element->conditional_list.conditional_functions = NULL;	  
+      new_tagging_element->conditional_list.p_data_unions = NULL;
+      new_tagging_element->conditional_list.conditional_functions = NULL;
       strcpy (new_tagging_element->name, NAME_CURRENT_COMP);
 
       // printf("adding new element to global_tagging_conditional_list \n");
@@ -510,11 +509,10 @@ FINALLY
   // Remember to clean up allocated lists
   free (accepted_loggers_specific.elements);
   free (accepted_loggers_all.elements);
-  free(accepted_abs_loggers_all.elements);
-  free(accepted_abs_loggers_specific.elements);
-  
+  free (accepted_abs_loggers_all.elements);
+  free (accepted_abs_loggers_specific.elements);
+
   // if (accepted_tagging.num_elements > 0) free(accepted_tagging.elements);
 %}
 
 END
-

--- a/mcstas-comps/union/Union_conditional_standard.comp
+++ b/mcstas-comps/union/Union_conditional_standard.comp
@@ -77,7 +77,7 @@ SETTING PARAMETERS(string target_loggers="NULL", int master_tagging=0, int taggi
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_conditional_standard requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   int

--- a/mcstas-comps/union/Union_cone.comp
+++ b/mcstas-comps/union/Union_cone.comp
@@ -245,12 +245,7 @@ INITIALIZE
     exit (1);
   }
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_cone:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_material_list* global_material_list = COMP_GETPAR3 (Union_init, init, global_material_list);
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
   // Use sanitation
   #ifdef MATERIAL_DETECTOR
   if (global_material_list->num_elements == 0) {
@@ -268,7 +263,7 @@ INITIALIZE
   this_cone_volume.geometry.is_masked_volume = 0;
   this_cone_volume.geometry.is_exit_volume = 0;
   this_cone_volume.geometry.is_mask_volume = 0;
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
 
   // Read the material input, or if it lacks, use automatic linking.
   if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
@@ -382,7 +377,7 @@ INITIALIZE
   this_cone_volume.geometry.surface_stack_for_each_face[2] = &bottom_surface_stack;
   this_cone_volume.geometry.internal_cut_surface_stack = &cut_surface_stack; // This surface is used if the volume is cut by overlapping of higher priority volume
 
-  struct pointer_to_global_surface_list* global_surface_list = COMP_GETPAR3 (Union_init, init, global_surface_list);
+  struct pointer_to_global_surface_list* global_surface_list = &g_surface_list;
   fill_surface_stack (curved_surface, global_surface_list, NAME_CURRENT_COMP, &curved_surface_stack);
   fill_surface_stack (top_surface, global_surface_list, NAME_CURRENT_COMP, &top_surface_stack);
   fill_surface_stack (bottom_surface, global_surface_list, NAME_CURRENT_COMP, &bottom_surface_stack);

--- a/mcstas-comps/union/Union_cone.comp
+++ b/mcstas-comps/union/Union_cone.comp
@@ -82,7 +82,7 @@ SETTING PARAMETERS(string material_string=0, priority, radius=0,radius_top=0,rad
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_cone requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   void

--- a/mcstas-comps/union/Union_cone.comp
+++ b/mcstas-comps/union/Union_cone.comp
@@ -83,7 +83,7 @@ SETTING PARAMETERS(string material_string=0, priority, radius=0,radius_top=0,rad
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_cone component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   void

--- a/mcstas-comps/union/Union_cone.comp
+++ b/mcstas-comps/union/Union_cone.comp
@@ -60,7 +60,6 @@
 * bottom_surface:        [string] Comma seperated string of Union surface definitions defined prior to this component, applied to -y bottom face of cone
 * all_face_surface:      [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all faces above
 * cut_surface:           [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts
-* init:                  [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -74,8 +73,8 @@ DEFINE COMPONENT Union_cone
 SETTING PARAMETERS(string material_string=0, priority, radius=0,radius_top=0,radius_bottom=0, yheight, visualize=1,
                    int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, 
 				   p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1, 
-				   string curved_surface=0, string top_surface=0, string bottom_surface=0, string all_face_surface=0, string cut_surface=0, 
-				   string init="init")
+                   string curved_surface=0, string top_surface=0, string bottom_surface=0, string all_face_surface=0, string cut_surface=0
+				   )
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -452,4 +451,3 @@ TRACE
 %}
 
 END
-

--- a/mcstas-comps/union/Union_cylinder.comp
+++ b/mcstas-comps/union/Union_cylinder.comp
@@ -208,12 +208,7 @@ INITIALIZE
     exit (1);
   }
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_cylinder:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_material_list* global_material_list = COMP_GETPAR3 (Union_init, init, global_material_list);
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
   // Use sanitation
   #ifdef MATERIAL_DETECTOR
   if (global_material_list->num_elements == 0) {
@@ -231,7 +226,7 @@ INITIALIZE
   this_cylinder_volume.geometry.is_masked_volume = 0;
   this_cylinder_volume.geometry.is_exit_volume = 0;
   this_cylinder_volume.geometry.is_mask_volume = 0;
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
 
   // Read the material input, or if it lacks, use automatic linking.
   if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
@@ -346,7 +341,7 @@ INITIALIZE
   this_cylinder_volume.geometry.internal_cut_surface_stack
       = &cut_surface_stack; // This surface is used if the volume is cut by overlapping of higher priority volume
 
-  struct pointer_to_global_surface_list* global_surface_list = COMP_GETPAR3 (Union_init, init, global_surface_list);
+  struct pointer_to_global_surface_list* global_surface_list = &g_surface_list;
   fill_surface_stack (curved_surface, global_surface_list, NAME_CURRENT_COMP, &curved_surface_stack);
   fill_surface_stack (top_surface, global_surface_list, NAME_CURRENT_COMP, &top_surface_stack);
   fill_surface_stack (bottom_surface, global_surface_list, NAME_CURRENT_COMP, &bottom_surface_stack);

--- a/mcstas-comps/union/Union_cylinder.comp
+++ b/mcstas-comps/union/Union_cylinder.comp
@@ -57,7 +57,6 @@
 * bottom_surface:        [string] Comma seperated string of Union surface definitions defined prior to this component, applied to -y bottom face of cylinder
 * all_face_surface:      [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all faces above
 * cut_surface:           [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts
-* init:                  [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -71,8 +70,8 @@ DEFINE COMPONENT Union_cylinder
 SETTING PARAMETERS(string material_string=0, priority, radius, yheight, visualize=1, 
                    int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, 
 				   p_interact=0, string mask_string=0, string mask_setting=0, number_of_activations=1,
-				   string curved_surface=0, string top_surface=0, string bottom_surface=0, string all_face_surface=0, string cut_surface=0, 
-				   string init="init")
+                   string curved_surface=0, string top_surface=0, string bottom_surface=0, string all_face_surface=0, string cut_surface=0
+				   )
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -387,4 +386,3 @@ TRACE
 %}
 
 END
-

--- a/mcstas-comps/union/Union_cylinder.comp
+++ b/mcstas-comps/union/Union_cylinder.comp
@@ -80,7 +80,7 @@ SETTING PARAMETERS(string material_string=0, priority, radius, yheight, visualiz
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_cylinder component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   void

--- a/mcstas-comps/union/Union_cylinder.comp
+++ b/mcstas-comps/union/Union_cylinder.comp
@@ -79,7 +79,7 @@ SETTING PARAMETERS(string material_string=0, priority, radius, yheight, visualiz
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_cylinder requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   void

--- a/mcstas-comps/union/Union_init.comp
+++ b/mcstas-comps/union/Union_init.comp
@@ -47,6 +47,13 @@ SETTING PARAMETERS()
 
 SHARE
 %{
+#ifndef UNION_LIB_C
+/* Compatibility path for code generators without Union auto-injection. */
+#define Union $Revision: 0.8 $
+%include "read_table-lib.h"
+%include "union-lib.c"
+%include "union-init.c"
+#endif
 %}
 
 DECLARE

--- a/mcstas-comps/union/Union_init.comp
+++ b/mcstas-comps/union/Union_init.comp
@@ -9,38 +9,33 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* Initialize component that needs to be place before any Union component
+* Deprecated no-op placeholder, kept for backward compatibility.
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.
-* The use of this component requires other components to be used.
 *
-* 1) One specifies a number of processes using process components
-* 2) These are gathered into material definitions using this component
-* 3) Geometries are placed using Union_box/cylinder/sphere, assigned a material
-* 4) A Union_master component placed after all of the above
+* This component used to be required as the FIRST Union component. It defined
+*  the shared header (union-lib.c) and owned the shared global lists, which the
+*  other Union components reached via COMP_GETPAR3.
 *
-* Only in step 4 will any simulation happen, and per default all geometries
-*  defined before the master, but after the previous will be simulated here.
+* That is no longer needed: the code generator now detects that the instrument
+*  uses Union (by the presence of a Union_master) and auto-injects the shared
+*  header, the global state and the dispatch switch in the right places. The
+*  Union_init and Union_stop components are therefore optional.
 *
-* There is a dedicated manual available for the Union_components
-*
-* Algorithm:
-* Described elsewhere
+* This definition is kept only so that existing instruments that still place a
+*  Union_init component continue to compile. It has no effect.
 *
 * %P
 * INPUT PARAMETERS:
 *
 * CALCULATED PARAMETERS:
 *
-* GLOBAL PARAMETERS:
-* global_material_list:     List of all defined materials, available in the global scope
-*
 * %L
 *
 * %E
-******************************************************************************/
+ ******************************************************************************/
 
 DEFINE COMPONENT Union_init
 
@@ -52,102 +47,14 @@ SETTING PARAMETERS()
 
 SHARE
 %{
-
-  #ifdef Union
-  #error "The Union_init component needs to be the first Union component!"
-  // printf("ERROR: The Union_init component needs to be the first Union component!\n");
-  // exit(1);
-  #else
-  #define Union $Revision: 0.8 $
-  %include "union-lib.c"
-  #endif
 %}
 
 DECLARE
 %{
-  // Initialize global positions / rotations to transform lists
-  // These are lists of pointers to positons / rotations, that will be updated from global frame
-  //  to the frame of the master component that uses them in that masters initialize section.
-  struct global_positions_to_transform_list_struct global_positions_to_transform_list;
-  struct global_rotations_to_transform_list_struct global_rotations_to_transform_list;
-
-  // Initialize global_process_list
-  // Used to facilitate communication between processes and the other types of Union components
-  struct pointer_to_global_process_list global_process_list;
-
-  // Initialize global_material_list
-  // Used to facilitate communication between materials and the other types of Union components
-  struct pointer_to_global_material_list global_material_list;
-
-  // Initialize global_surface_list
-  // Used to facilitate communication between surface components and other types of Union components
-  struct pointer_to_global_surface_list global_surface_list;
-
-  // Initialize global_geometry_list
-  // Used to facilitate communication between geometries and the other types of Union components
-  struct pointer_to_global_geometry_list global_geometry_list;
-
-  // Initialize global_logger_lists
-  // Used to facilitate communication between loggers and the other types of Union components
-  struct pointer_to_global_logger_list global_all_volume_logger_list;
-  struct pointer_to_global_logger_list global_specific_volumes_logger_list;
-
-  // Initialize global_abs_logger_lists
-  struct pointer_to_global_abs_logger_list global_all_volume_abs_logger_list;
-  struct pointer_to_global_abs_logger_list global_specific_volumes_abs_logger_list;
-
-  // Initialize global_tagging_conditional_list
-  // Used to facilitate communication between conditionals and the other types of Union components
-  struct global_tagging_conditional_list_struct global_tagging_conditional_list;
-
-  // Initialize global_master_list
-  // Used to facilitate communication between Master components (mainly for deallocation)
-  struct pointer_to_global_master_list global_master_list;
-
-  // Initialize global_mantid_min_pixel_id
-  // Used for ensuring pixel id's on Mantid monitors do not overlap
-  int global_mantid_min_pixel_id;
 %}
 
 INITIALIZE
 %{
-  global_positions_to_transform_list.num_elements = 0;
-  global_positions_to_transform_list.positions = NULL;
-
-  global_rotations_to_transform_list.num_elements = 0;
-  global_rotations_to_transform_list.rotations = NULL;
-
-  global_process_list.num_elements = 0;
-  global_process_list.elements = NULL;
-
-  global_material_list.num_elements = 0;
-  global_material_list.elements = NULL;
-
-  global_surface_list.num_elements = 0;
-  global_surface_list.elements = NULL;
-
-  global_geometry_list.num_elements = 0;
-  global_geometry_list.elements = NULL;
-
-  global_all_volume_logger_list.num_elements = 0;
-  global_all_volume_logger_list.elements = NULL;
-
-  global_specific_volumes_logger_list.num_elements = 0;
-  global_specific_volumes_logger_list.elements = NULL;
-
-  global_all_volume_abs_logger_list.num_elements = 0;
-  global_all_volume_abs_logger_list.elements = NULL;
-
-  global_specific_volumes_abs_logger_list.num_elements = 0;
-  global_specific_volumes_abs_logger_list.elements = NULL;
-
-  global_tagging_conditional_list.num_elements = 0;
-  global_tagging_conditional_list.elements = NULL;
-
-  global_master_list.num_elements = 0;
-  global_master_list.elements = NULL;
-
-  global_mantid_min_pixel_id = 0;
 %}
 
 TRACE
@@ -159,4 +66,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_init.comp
+++ b/mcstas-comps/union/Union_init.comp
@@ -25,8 +25,8 @@
 *  Union_init and Union_stop components are therefore optional.
 *
 * This definition is kept only so that existing instruments that still place a
- *  Union_init component continue to compile. It emits a deprecation warning
- *  and has no effect.
+*  Union_init component continue to compile. It emits a deprecation warning
+*  and has no effect.
 *
 * %P
 * INPUT PARAMETERS:

--- a/mcstas-comps/union/Union_init.comp
+++ b/mcstas-comps/union/Union_init.comp
@@ -25,7 +25,8 @@
 *  Union_init and Union_stop components are therefore optional.
 *
 * This definition is kept only so that existing instruments that still place a
-*  Union_init component continue to compile. It has no effect.
+ *  Union_init component continue to compile. It emits a deprecation warning
+ *  and has no effect.
 *
 * %P
 * INPUT PARAMETERS:
@@ -45,31 +46,9 @@ SETTING PARAMETERS()
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
 
-SHARE
-%{
-#ifndef UNION_LIB_C
-/* Compatibility path for code generators without Union auto-injection. */
-#define Union $Revision: 0.8 $
-%include "read_table-lib.h"
-%include "union-lib.c"
-%include "union-init.c"
-#endif
-%}
-
-DECLARE
-%{
-%}
-
 INITIALIZE
 %{
-%}
-
-TRACE
-%{
-%}
-
-FINALLY
-%{
+  MPI_MASTER (printf ("WARNING: Union_init is deprecated; Union components initialize automatically.\n"););
 %}
 
 END

--- a/mcstas-comps/union/Union_logger_1D.comp
+++ b/mcstas-comps/union/Union_logger_1D.comp
@@ -79,7 +79,7 @@ SETTING PARAMETERS(string target_geometry="NULL", string target_process="NULL", 
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_logger_1D component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_1D_data_element_struct {

--- a/mcstas-comps/union/Union_logger_1D.comp
+++ b/mcstas-comps/union/Union_logger_1D.comp
@@ -57,8 +57,7 @@
 * order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:                 [string] Name of Union_init component (typically "init", default)
-* nowritefile:          [1]      If set, logger will skip writing to disk
+ * nowritefile:          [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -71,7 +70,7 @@
 
 DEFINE COMPONENT Union_logger_1D
 
-SETTING PARAMETERS(string target_geometry="NULL", string target_process="NULL", min_value, max_value, n1=90, string variable="time",string filename="NULL", order_total=0, order_volume=0, order_volume_process=0, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+SETTING PARAMETERS(string target_geometry="NULL", string target_process="NULL", min_value, max_value, n1=90, string variable="time",string filename="NULL", order_total=0, order_volume=0, order_volume_process=0, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -610,4 +609,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_logger_1D.comp
+++ b/mcstas-comps/union/Union_logger_1D.comp
@@ -78,7 +78,7 @@ SETTING PARAMETERS(string target_geometry="NULL", string target_process="NULL", 
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_logger_1D requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_1D_data_element_struct {

--- a/mcstas-comps/union/Union_logger_1D.comp
+++ b/mcstas-comps/union/Union_logger_1D.comp
@@ -534,13 +534,8 @@ INITIALIZE
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_logger_1D:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
 
   // Need to find the volumes for which the processes should have a reference to this logger
   if (target_geometry && strlen (target_geometry) && strcmp (target_geometry, "NULL") && strcmp (target_geometry, "0")) {
@@ -577,7 +572,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
+    struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
     add_element_to_logger_list (global_all_volume_logger_list, logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_logger_2DQ.comp
+++ b/mcstas-comps/union/Union_logger_2DQ.comp
@@ -59,8 +59,7 @@
 * order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, uwsing the same process
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:                 [string] Name of Union_init component (typically "init", default)
-* nowritefile:          [1]      If set, logger will skip writing to disk
+ * nowritefile:          [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -77,7 +76,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",
     string Q_direction_1="x", Q1_min=-5,Q1_max=5, n1=90,
     string Q_direction_2="z", Q2_min=-5,Q2_max=5, n2=90,
     string filename="NULL", order_total=0, order_volume=0,
-    order_volume_process=0,logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+    order_volume_process=0,logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -607,7 +606,7 @@ INITIALIZE
   logger_list_element.component_index = INDEX_CURRENT_COMP;
   logger_list_element.logger = &this_logger;
 
-  // Global variables retrieved from init component
+  // Global variables from the auto-injected Union state
   struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
 
   rot_copy (this_storage.rotation, ROT_A_CURRENT_COMP);
@@ -690,4 +689,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_logger_2DQ.comp
+++ b/mcstas-comps/union/Union_logger_2DQ.comp
@@ -84,7 +84,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_logger_2DQ requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_2DQ_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2DQ.comp
+++ b/mcstas-comps/union/Union_logger_2DQ.comp
@@ -85,7 +85,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_logger_2DQ component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_2DQ_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2DQ.comp
+++ b/mcstas-comps/union/Union_logger_2DQ.comp
@@ -607,21 +607,16 @@ INITIALIZE
   logger_list_element.component_index = INDEX_CURRENT_COMP;
   logger_list_element.logger = &this_logger;
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_logger_2DQ:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
   // Global variables retrieved from init component
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
 
   rot_copy (this_storage.rotation, ROT_A_CURRENT_COMP);
   add_rotation_pointer_to_list (global_rotations_to_transform_list, &this_storage.rotation);
 
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
 
   // Need to find the volumes for which the processes should have a reference to this logger
   if (target_geometry && strlen (target_geometry) && strcmp (target_geometry, "NULL") && strcmp (target_geometry, "0")) {
@@ -658,7 +653,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
+    struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
     add_element_to_logger_list (global_all_volume_logger_list, logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_logger_2D_kf.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf.comp
@@ -81,7 +81,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_logger_2D_kf requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_2D_kf_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_kf.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf.comp
@@ -609,21 +609,16 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_logger_2D_kf:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
   // Global variables retrieved from init component
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
 
   rot_copy (this_storage.rotation, ROT_A_CURRENT_COMP);
   add_rotation_pointer_to_list (global_rotations_to_transform_list, &this_storage.rotation);
 
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
 
   // Need to find the volumes for which the processes should have a reference to this logger
   if (target_geometry && strlen (target_geometry) && strcmp (target_geometry, "NULL") && strcmp (target_geometry, "0")) {
@@ -660,7 +655,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
+    struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
     add_element_to_logger_list (global_all_volume_logger_list, logger_list_element);
   }
 %}

--- a/mcstas-comps/union/Union_logger_2D_kf.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf.comp
@@ -60,8 +60,7 @@
 * order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:                 [string] Name of Union_init component (typically "init", default)
-* nowritefile:          [1]      If set, logger will skip writing to disk
+ * nowritefile:          [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -74,7 +73,7 @@
 
 DEFINE COMPONENT Union_logger_2D_kf
 
-SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q1_min=-5, Q1_max=5, Q2_min=-5, Q2_max=5, string Q_direction_1="x", string Q_direction_2="z",string filename="NULL", n1=90, n2=90, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q1_min=-5, Q1_max=5, Q2_min=-5, Q2_max=5, string Q_direction_1="x", string Q_direction_2="z",string filename="NULL", n1=90, n2=90, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -692,4 +691,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_logger_2D_kf.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf.comp
@@ -82,7 +82,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_logger_2D_kf component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_2D_kf_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_kf_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf_time.comp
@@ -64,8 +64,7 @@
 * order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:                 [string] Name of Union_init component (typically "init", default)
-* nowritefile:          [1]      If set, logger will skip writing to disk
+ * nowritefile:          [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -78,7 +77,7 @@
 
 DEFINE COMPONENT Union_logger_2D_kf_time
 
-SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q1_min=-5, Q1_max=5, Q2_min=-5, Q2_max=5, time_min=0, time_max=1,string Q_direction_1="x", string Q_direction_2="z",string filename="NULL", n1=90, n2=90, time_bins=10, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q1_min=-5, Q1_max=5, Q2_min=-5, Q2_max=5, time_min=0, time_max=1,string Q_direction_1="x", string Q_direction_2="z",string filename="NULL", n1=90, n2=90, time_bins=10, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -678,7 +677,7 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  // Global variables retrieved from init component
+  // Global variables from the auto-injected Union state
   struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
 
   rot_copy (this_storage.rotation, ROT_A_CURRENT_COMP);
@@ -767,4 +766,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_logger_2D_kf_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf_time.comp
@@ -678,21 +678,16 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_logger_2D_kf_time:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
   // Global variables retrieved from init component
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
 
   rot_copy (this_storage.rotation, ROT_A_CURRENT_COMP);
   add_rotation_pointer_to_list (global_rotations_to_transform_list, &this_storage.rotation);
 
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
 
   // Need to find the volumes for which the processes should have a reference to this logger
   if (target_geometry && strlen (target_geometry) && strcmp (target_geometry, "NULL") && strcmp (target_geometry, "0")) {
@@ -729,7 +724,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
+    struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
     add_element_to_logger_list (global_all_volume_logger_list, logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_logger_2D_kf_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf_time.comp
@@ -85,7 +85,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_logger_2D_kf_time requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_2D_kf_t_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_kf_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_kf_time.comp
@@ -86,7 +86,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL", Q
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_logger_2D_kf_time component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_2D_kf_t_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_logger_2D_space.comp
@@ -86,7 +86,7 @@ SETTING PARAMETERS(string target_geometry="NULL", string target_process="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_logger_2D_space component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_2DS_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_logger_2D_space.comp
@@ -609,13 +609,8 @@ INITIALIZE
   if (!this_storage.temp_2DS_data.elements)
     exit (fprintf (stderr, "Union_logger_2D_space: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_logger_2D_space:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   // Test position and rotation stored in a data storage, and pointers assigned to transform lists
   this_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_storage.position);
@@ -653,8 +648,8 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
 
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
@@ -693,7 +688,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
+    struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
     add_element_to_logger_list (global_all_volume_logger_list, logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_logger_2D_space.comp
@@ -85,7 +85,7 @@ SETTING PARAMETERS(string target_geometry="NULL", string target_process="NULL",
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_logger_2D_space requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_2DS_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_space.comp
+++ b/mcstas-comps/union/Union_logger_2D_space.comp
@@ -61,8 +61,7 @@
 * order_volume:    [1]      Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process: [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:            [string] Name of Union_init component (typically "init", default)
-* nowritefile:     [1]      If set, logger will skip writing to disk
+ * nowritefile:     [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -78,7 +77,7 @@ DEFINE COMPONENT Union_logger_2D_space
 SETTING PARAMETERS(string target_geometry="NULL", string target_process="NULL",
                    string D_direction_1="x", D1_min=-5, D1_max=5, n1=90,
                    string D_direction_2="z", D2_min=-5, D2_max=5, n2=90,
-                   string filename="NULL", order_total=0, order_volume=0, order_volume_process=0, logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+                   string filename="NULL", order_total=0, order_volume=0, order_volume_process=0, logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -725,4 +724,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_logger_2D_space_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_space_time.comp
@@ -64,8 +64,7 @@
 * order_volume:         [1]      Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process: [1]      Only log rays that scatter for the n'th time in the same geometry, using the same process
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:                 [string] Name of Union_init component (typically "init", default)
-* nowritefile:          [1]      If set, logger will skip writing to disk
+ * nowritefile:          [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -78,7 +77,7 @@
 
 DEFINE COMPONENT Union_logger_2D_space_time
 
-SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1_min=-5,D1_max=5,D2_min=-5,D2_max=5,time_min=0,time_max=1,string D_direction_1="x", string D_direction_2="z",string filename="NULL", n1=90, n2=90, time_bins=10, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1_min=-5,D1_max=5,D2_min=-5,D2_max=5,time_min=0,time_max=1,string D_direction_1="x", string D_direction_2="z",string filename="NULL", n1=90, n2=90, time_bins=10, order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -790,4 +789,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_logger_2D_space_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_space_time.comp
@@ -85,7 +85,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_logger_2D_space_time requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_2DS_t_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_space_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_space_time.comp
@@ -86,7 +86,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_logger_2D_space_time component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_2DS_t_data_element_struct {

--- a/mcstas-comps/union/Union_logger_2D_space_time.comp
+++ b/mcstas-comps/union/Union_logger_2D_space_time.comp
@@ -669,13 +669,8 @@ INITIALIZE
   if (!this_storage.temp_2DS_t_data.elements)
     exit (fprintf (stderr, "Union_logger_2D_space_time: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_logger_2D_space_time:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
   this_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_storage.position);
 
@@ -715,8 +710,8 @@ INITIALIZE
 
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
   // Need to find the volumes for which the processes should have a reference to this logger
   if (target_geometry && strlen (target_geometry) && strcmp (target_geometry, "NULL") && strcmp (target_geometry, "0")) {
     // Certain volumes were selected, find the indicies in the global_geometry_list
@@ -752,7 +747,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
+    struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
     add_element_to_logger_list (global_all_volume_logger_list, logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/union/Union_logger_3D_space.comp
@@ -728,14 +728,9 @@ INITIALIZE
   if (!this_storage.temp_3DS_data.elements)
     exit (fprintf (stderr, "Union_logger_3D_space: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_logger_3D:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
   // Global variables retrieved from init component
-  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
 
   this_storage.position = POS_A_CURRENT_COMP;
   add_position_pointer_to_list (global_positions_to_transform_list, &this_storage.position);
@@ -775,8 +770,8 @@ INITIALIZE
   // printf("past logger_list_element assignment \n");
 
   // Get global variables from init component
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
 
   // In order to run the logger at the right times, pointers to this logger is stored in each volume it logs,
   //  and additionally for each avaiable process. If a process is not logged, the pointer is simply not stored.
@@ -815,7 +810,7 @@ INITIALIZE
   } else {
     // Send to global_all_volumes_logger_list
     // Here there is no system for selecting processes as well
-    struct pointer_to_global_logger_list* global_all_volume_logger_list = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
+    struct pointer_to_global_logger_list* global_all_volume_logger_list = &g_all_volume_logger_list;
     add_element_to_logger_list (global_all_volume_logger_list, logger_list_element);
   }
  %}

--- a/mcstas-comps/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/union/Union_logger_3D_space.comp
@@ -66,8 +66,7 @@
 * order_volume:         [1] Only log rays that scatter for the n'th time in the same geometry
 * order_volume_process: [1] Only log rays that scatter for the n'th time in the same geometry, using the same process
 * logger_conditional_extend_index: [1] If a conditional is used with this logger, the result of each conditional calculation can be made available in extend as a array called "logger_conditional_extend", and one would then acces logger_conditional_extend[n] if logger_conditional_extend_index is set to n
-* init:                 [string] name of Union_init component (typically "init", default)
-* nowritefile:          [1]      If set, logger will skip writing to disk
+ * nowritefile:          [1]      If set, logger will skip writing to disk
 *
 * CALCULATED PARAMETERS:
 *
@@ -80,7 +79,7 @@
 
 DEFINE COMPONENT Union_logger_3D_space
 
-SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1_min=-1,D1_max=1,D2_min=-1,D2_max=1,D3_min=-1,D3_max=1,string D_direction_1="x", string D_direction_2="z", string D_direction_3="z",string filename="NULL", n1=90, n2=90, n3=10,  order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, string init="init", int nowritefile=0)
+SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1_min=-1,D1_max=1,D2_min=-1,D2_max=1,D3_min=-1,D3_max=1,string D_direction_1="x", string D_direction_2="z", string D_direction_3="z",string filename="NULL", n1=90, n2=90, n3=10,  order_total=0,order_volume=0,order_volume_process=0,logger_conditional_extend_index=-1, int nowritefile=0)
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -728,7 +727,7 @@ INITIALIZE
   if (!this_storage.temp_3DS_data.elements)
     exit (fprintf (stderr, "Union_logger_3D_space: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
 
-  // Global variables retrieved from init component
+  // Global variables from the auto-injected Union state
   struct global_positions_to_transform_list_struct* global_positions_to_transform_list = &g_positions_to_transform_list;
   struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list = &g_rotations_to_transform_list;
 
@@ -769,7 +768,7 @@ INITIALIZE
 
   // printf("past logger_list_element assignment \n");
 
-  // Get global variables from init component
+  // Get global variables from the auto-injected Union state
   struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
   struct pointer_to_global_logger_list* global_specific_volumes_logger_list = &g_specific_volumes_logger_list;
 
@@ -853,4 +852,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/union/Union_logger_3D_space.comp
@@ -88,7 +88,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_logger_3D_space component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct temp_3DS_data_element_struct {

--- a/mcstas-comps/union/Union_logger_3D_space.comp
+++ b/mcstas-comps/union/Union_logger_3D_space.comp
@@ -87,7 +87,7 @@ SETTING PARAMETERS(string target_geometry="NULL",string target_process="NULL",D1
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_logger_3D_space requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct temp_3DS_data_element_struct {

--- a/mcstas-comps/union/Union_make_material.comp
+++ b/mcstas-comps/union/Union_make_material.comp
@@ -198,13 +198,8 @@ INITIALIZE
     exit (1);
   }
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_make_material:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-
-  struct pointer_to_global_process_list* global_process_list = COMP_GETPAR3 (Union_init, init, global_process_list);
-  struct pointer_to_global_material_list* global_material_list = COMP_GETPAR3 (Union_init, init, global_material_list);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
 
   if (absorber == 0) {
     if (process_string && strlen (process_string) && strcmp (process_string, "NULL") && strcmp (process_string, "0")) {
@@ -294,8 +289,8 @@ FINALLY
   if (accepted_processes.num_elements > 0)
     free (accepted_processes.elements);
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  struct pointer_to_global_master_list* global_master_list = COMP_GETPAR3 (Union_init, init, global_master_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_master_list* global_master_list = &g_master_list;
 
   // Checking if any Union volumes are defined after the master component
   #ifdef MASTER_DETECTOR

--- a/mcstas-comps/union/Union_make_material.comp
+++ b/mcstas-comps/union/Union_make_material.comp
@@ -62,7 +62,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "The Union_init component must be included before this Union_make_material component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // This function checks if global_process_element should be included in this material when using automatic linking, returns 1 if yes, 0 if no.

--- a/mcstas-comps/union/Union_make_material.comp
+++ b/mcstas-comps/union/Union_make_material.comp
@@ -38,7 +38,6 @@
 * refraction_density:   [g/cm3]  Density of the refracting material. density < 0 means the material is outside/before the shape.
 * refraction_weight:    [g/mol]  Molar mass of the refracting material
 * refraction_SLD:       [AA^-2]  Scattering length density of material (overwrites sigma_coh, density and weight)
-* init:                 [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 * this_material:            Structure that contains information on this material
@@ -55,8 +54,8 @@
 DEFINE COMPONENT Union_make_material
 
 SETTING PARAMETERS(string process_string="NULL", my_absorption,absorber=0, 
-                   refraction_density=0, refraction_sigma_coh=0, refraction_weight=0,  refraction_SLD=-1500,
-				   string init="init")
+                    refraction_density=0, refraction_sigma_coh=0, refraction_weight=0,  refraction_SLD=-1500
+			   )
 
 SHARE
 %{
@@ -327,4 +326,3 @@ FINALLY
 %}
 
 END
-

--- a/mcstas-comps/union/Union_make_material.comp
+++ b/mcstas-comps/union/Union_make_material.comp
@@ -61,7 +61,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_make_material requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // This function checks if global_process_element should be included in this material when using automatic linking, returns 1 if yes, 0 if no.

--- a/mcstas-comps/union/Union_master.comp
+++ b/mcstas-comps/union/Union_master.comp
@@ -301,23 +301,19 @@ DECLARE
 
 INITIALIZE
 %{
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_master:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
   // Unpack global lists
-  global_positions_to_transform_list_master = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  global_rotations_to_transform_list_master = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
-  global_process_list_master = COMP_GETPAR3 (Union_init, init, global_process_list);
-  global_material_list_master = COMP_GETPAR3 (Union_init, init, global_material_list);
-  global_surface_list_master = COMP_GETPAR3 (Union_init, init, global_surface_list);
-  global_geometry_list_master = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  global_all_volume_logger_list_master = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
-  global_specific_volumes_logger_list_master = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
-  global_all_volume_abs_logger_list_master = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
-  global_specific_volumes_abs_logger_list_master = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
-  global_tagging_conditional_list_master = COMP_GETPAR3 (Union_init, init, global_tagging_conditional_list);
-  global_master_list_master = COMP_GETPAR3 (Union_init, init, global_master_list);
+  global_positions_to_transform_list_master = &g_positions_to_transform_list;
+  global_rotations_to_transform_list_master = &g_rotations_to_transform_list;
+  global_process_list_master = &g_process_list;
+  global_material_list_master = &g_material_list;
+  global_surface_list_master = &g_surface_list;
+  global_geometry_list_master = &g_geometry_list;
+  global_all_volume_logger_list_master = &g_all_volume_logger_list;
+  global_specific_volumes_logger_list_master = &g_specific_volumes_logger_list;
+  global_all_volume_abs_logger_list_master = &g_all_volume_abs_logger_list;
+  global_specific_volumes_abs_logger_list_master = &g_specific_volumes_abs_logger_list;
+  global_tagging_conditional_list_master = &g_tagging_conditional_list;
+  global_master_list_master = &g_master_list;
 
   // It is possible to surpress warnings on starting volume by setting this to 1
   starting_volume_warning = 0;

--- a/mcstas-comps/union/Union_master.comp
+++ b/mcstas-comps/union/Union_master.comp
@@ -42,7 +42,6 @@
 *   enable_conditionals:                 [0/1] Use conditionals with this master
 *   inherit_number_of_scattering_events: [0/1] Inherit the number of scattering events from last master
 *   weight_ratio_limit:                  [1]   Limit on the ratio between initial weight and current, ray absorbed if ratio becomes lower than limit
-*   init:                                [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -63,8 +62,8 @@ SETTING PARAMETERS(int enable_refraction = 1,
                    history_limit=300000,
                    enable_conditionals=1,
                    inherit_number_of_scattering_events=0,
-                   weight_ratio_limit=1e-90,
-                   string init="init")
+                    weight_ratio_limit=1e-90
+                   )
 
 NOACC
 
@@ -1804,14 +1803,15 @@ TRACE
                 selected_sampling = i;
                 break;
               }
-              abs_weight_factor *= (current_p_physics->total_mus[selected_sampling] - mu_at_speed * current_p_physics->dist) / current_p_physics->total_mus[selected_sampling];
+              abs_weight_factor
+                  *= (current_p_physics->total_mus[selected_sampling] - mu_at_speed * current_p_physics->dist) / current_p_physics->total_mus[selected_sampling];
 
               // printf("\nSelected_sampling = %d\n", selected_sampling);
 
               // printf("dist i = %g\tdist=%g\n", dist_i, dist);
-              double sampled_dist
-                  = safety_distance
-                    - log (1.0 - rand01 () * (1.0 - exp (-current_p_physics->total_mus[selected_sampling]))) / current_p_physics->total_mus[selected_sampling] * current_p_physics->dist;
+              double sampled_dist = safety_distance
+                                    - log (1.0 - rand01 () * (1.0 - exp (-current_p_physics->total_mus[selected_sampling])))
+                                          / current_p_physics->total_mus[selected_sampling] * current_p_physics->dist;
               length_to_scattering = current_p_physics->cumul_dists[selected_sampling] - current_p_physics->dist / 2 + sampled_dist;
             }
             // Select process
@@ -1945,7 +1945,7 @@ TRACE
           // Logging for detector components assosiated with this volume
           for (log_index = 0; log_index < Volumes[current_volume]->abs_loggers.num_elements; log_index++) {
             // This function calls a logger function which in turn stores some data among the passed, and possibly performs some basic data analysis
-			// Position and k_new given in master coordinates, the abs_logger must transform to its coordnate system if required
+            // Position and k_new given in master coordinates, the abs_logger must transform to its coordnate system if required
             Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->function_pointers.active_record_function (
                 &abs_position, k_new, initial_weight * (1.0 - abs_weight_factor), t + t_abs_propagation, scattered_flag[current_volume],
                 number_of_scattering_events, Volumes[current_volume]->abs_loggers.p_abs_logger[log_index], &abs_loggers_with_data_array);

--- a/mcstas-comps/union/Union_master.comp
+++ b/mcstas-comps/union/Union_master.comp
@@ -74,7 +74,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "The Union_init component must be included before this Union_master component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   struct logger_with_data_struct loggers_with_data_array;

--- a/mcstas-comps/union/Union_master.comp
+++ b/mcstas-comps/union/Union_master.comp
@@ -73,7 +73,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_master requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   struct logger_with_data_struct loggers_with_data_array;

--- a/mcstas-comps/union/Union_master_GPU.comp
+++ b/mcstas-comps/union/Union_master_GPU.comp
@@ -224,22 +224,18 @@ DECLARE
 INITIALIZE
 %{
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_master_GPU:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
   // Unpack global lists
-  global_positions_to_transform_list_master = COMP_GETPAR3 (Union_init, init, global_positions_to_transform_list);
-  global_rotations_to_transform_list_master = COMP_GETPAR3 (Union_init, init, global_rotations_to_transform_list);
-  global_process_list_master = COMP_GETPAR3 (Union_init, init, global_process_list);
-  global_material_list_master = COMP_GETPAR3 (Union_init, init, global_material_list);
-  global_geometry_list_master = COMP_GETPAR3 (Union_init, init, global_geometry_list);
-  global_all_volume_logger_list_master = COMP_GETPAR3 (Union_init, init, global_all_volume_logger_list);
-  global_specific_volumes_logger_list_master = COMP_GETPAR3 (Union_init, init, global_specific_volumes_logger_list);
-  global_all_volume_abs_logger_list_master = COMP_GETPAR3 (Union_init, init, global_all_volume_abs_logger_list);
-  global_specific_volumes_abs_logger_list_master = COMP_GETPAR3 (Union_init, init, global_specific_volumes_abs_logger_list);
-  global_tagging_conditional_list_master = COMP_GETPAR3 (Union_init, init, global_tagging_conditional_list);
-  global_master_list_master = COMP_GETPAR3 (Union_init, init, global_master_list);
+  global_positions_to_transform_list_master = &g_positions_to_transform_list;
+  global_rotations_to_transform_list_master = &g_rotations_to_transform_list;
+  global_process_list_master = &g_process_list;
+  global_material_list_master = &g_material_list;
+  global_geometry_list_master = &g_geometry_list;
+  global_all_volume_logger_list_master = &g_all_volume_logger_list;
+  global_specific_volumes_logger_list_master = &g_specific_volumes_logger_list;
+  global_all_volume_abs_logger_list_master = &g_all_volume_abs_logger_list;
+  global_specific_volumes_abs_logger_list_master = &g_specific_volumes_abs_logger_list;
+  global_tagging_conditional_list_master = &g_tagging_conditional_list;
+  global_master_list_master = &g_master_list;
 
   // It is possible to surpress warnings on starting volume by setting this to 1
   // starting_volume_warning = 0;

--- a/mcstas-comps/union/Union_master_GPU.comp
+++ b/mcstas-comps/union/Union_master_GPU.comp
@@ -67,7 +67,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_master_GPU requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   // TEST

--- a/mcstas-comps/union/Union_master_GPU.comp
+++ b/mcstas-comps/union/Union_master_GPU.comp
@@ -39,7 +39,6 @@
 *   history_limit:               [1]Limit the number of unique histories that are saved
 *   enable_conditionals:  [0/1] Use conditionals with this master
 *   inherit_number_of_scattering_events: [0/1] Inherit the number of scattering events from last master
- * init:                             [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -57,8 +56,8 @@ SETTING PARAMETERS(verbal = 1,
                    enable_tagging = 0,
                    history_limit=300000,
                    enable_conditionals=1,
-                   inherit_number_of_scattering_events=0,
-                   string init="init")
+                    inherit_number_of_scattering_events=0
+                   )
 
 
 

--- a/mcstas-comps/union/Union_master_GPU.comp
+++ b/mcstas-comps/union/Union_master_GPU.comp
@@ -68,7 +68,7 @@ SHARE
 %{
 
   #ifndef Union
-  #error "The Union_init component must be included before this Union_master_GPU component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   // TEST
@@ -1044,7 +1044,6 @@ TRACE
   double time_to_scattering;
   double length_to_scattering;
   double length_to_boundery;
-  double length_to_boundery_fp;
   double time_to_boundery;
   int selected_process;
   int scattering_event;

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -660,14 +660,7 @@ INITIALIZE
   focus_initialize (&mesh_vol.geometry, POS_A_COMP_INDEX (INDEX_CURRENT_COMP + target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index, target_x,
                     target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr,
-             "Union_mesh:%s: Error identifying Union_init component,"
-             "%s is not a known component name.\n",
-             NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
-  struct pointer_to_global_material_list* global_material_list = COMP_GETPAR3 (Union_init, init, global_material_list);
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
 
   // Use sanitation
   #ifdef MATERIAL_DETECTOR
@@ -690,7 +683,7 @@ INITIALIZE
   mesh_vol.geometry.is_exit_volume = 0;
   mesh_vol.geometry.is_mask_volume = 0;
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
   //==============================================================================
   //                         Find out what this component masks
   //==============================================================================
@@ -957,7 +950,7 @@ INITIALIZE
   mesh_vol.geometry.surface_stack_for_each_face[0] = &surface_stack;
   mesh_vol.geometry.internal_cut_surface_stack = &cut_surface_stack;
 
-  struct pointer_to_global_surface_list* global_surface_list = COMP_GETPAR3 (Union_init, init, global_surface_list);
+  struct pointer_to_global_surface_list* global_surface_list = &g_surface_list;
   fill_surface_stack (all_surfaces, global_surface_list, NAME_CURRENT_COMP, &surface_stack);
   fill_surface_stack (cut_surface, global_surface_list, NAME_CURRENT_COMP, &cut_surface_stack);
 

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -110,7 +110,7 @@ SHARE
   %include "interoff-lib"
 
   #ifndef Union
-  #error "The Union_init component must be included before this Union_mesh component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   #ifndef ANY_GEOMETRY_DETECTOR_DECLARE

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -109,7 +109,7 @@ SHARE
   %include "interoff-lib"
 
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_mesh requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   #ifndef ANY_GEOMETRY_DETECTOR_DECLARE

--- a/mcstas-comps/union/Union_mesh.comp
+++ b/mcstas-comps/union/Union_mesh.comp
@@ -64,7 +64,6 @@
 * coordinate_scale [1e-3] Multiplier that the vertex positions are multiplied by. Set to 1 for input coordinates in meters. Set to 1e-3 for input coordinates in mm.
 * all_surfaces:       [string] Comma seperated string of Union surface definitions defined prior to this component
 * cut_surface:   [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts
-* init:          [string] name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -95,8 +94,8 @@ SETTING PARAMETERS(string filename = 0,
    string mask_setting=0,
    number_of_activations=1,
    int skip_convex_check = 0,
-   coordinate_scale = 1e-3,
-   string init="init")
+    coordinate_scale = 1e-3
+   )
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -995,4 +994,3 @@ FINALLY
 
 %}
 END
-

--- a/mcstas-comps/union/Union_sphere.comp
+++ b/mcstas-comps/union/Union_sphere.comp
@@ -197,12 +197,8 @@ INITIALIZE
     exit (1);
   }
 
-  if (_getcomp_index (init) < 0) {
-    fprintf (stderr, "Union_sphere:%s: Error identifying Union_init component, %s is not a known component name.\n", NAME_CURRENT_COMP, init);
-    exit (-1);
-  }
   // Get global variable from init component
-  struct pointer_to_global_material_list* global_material_list = COMP_GETPAR3 (Union_init, init, global_material_list);
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
   // Use sanitation
   #ifdef MATERIAL_DETECTOR
   if (global_material_list->num_elements == 0) {
@@ -221,7 +217,7 @@ INITIALIZE
   this_sphere_volume.geometry.is_exit_volume = 0;
   this_sphere_volume.geometry.is_mask_volume = 0;
 
-  struct pointer_to_global_geometry_list* global_geometry_list = COMP_GETPAR3 (Union_init, init, global_geometry_list);
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
   // Read the material input, or if it lacks, use automatic linking.
   if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.
@@ -325,7 +321,7 @@ INITIALIZE
   this_sphere_volume.geometry.internal_cut_surface_stack
       = &cut_surface_stack; // This surface is used if the volume is cut by overlapping of higher priority volume
 
-  struct pointer_to_global_surface_list* global_surface_list = COMP_GETPAR3 (Union_init, init, global_surface_list);
+  struct pointer_to_global_surface_list* global_surface_list = &g_surface_list;
   fill_surface_stack (surface, global_surface_list, NAME_CURRENT_COMP, &surface_stack);
   fill_surface_stack (cut_surface, global_surface_list, NAME_CURRENT_COMP, &cut_surface_stack);
 

--- a/mcstas-comps/union/Union_sphere.comp
+++ b/mcstas-comps/union/Union_sphere.comp
@@ -74,7 +74,7 @@ SETTING PARAMETERS(string material_string=0, priority, radius, visualize=1,
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_sphere requires the Union library. Add a Union_master component to load the libraries."
   #endif
 
   void

--- a/mcstas-comps/union/Union_sphere.comp
+++ b/mcstas-comps/union/Union_sphere.comp
@@ -75,7 +75,7 @@ SETTING PARAMETERS(string material_string=0, priority, radius, visualize=1,
 SHARE
 %{
   #ifndef Union
-  #error "The Union_init component must be included before this Union_sphere component"
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
   #endif
 
   void

--- a/mcstas-comps/union/Union_sphere.comp
+++ b/mcstas-comps/union/Union_sphere.comp
@@ -52,7 +52,6 @@
 * focus_r:               [m]   focusing on circle with this radius
 * surface:               [string] Comma seperated string of Union surface definitions defined prior to this component
 * cut_surface:           [string] Comma seperated string of Union surface definitions defined prior to this component, applied to all internal cuts
-* init:                  [string]    name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -66,8 +65,8 @@ DEFINE COMPONENT Union_sphere
 SETTING PARAMETERS(string material_string=0, priority, radius, visualize=1, 
                    int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, 
 				   p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1, 
-				   string surface=0, string cut_surface=0,
-				   string init="init")
+                   string surface=0, string cut_surface=0
+				   )
 
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
@@ -197,7 +196,7 @@ INITIALIZE
     exit (1);
   }
 
-  // Get global variable from init component
+  // Get global variable from the auto-injected Union state
   struct pointer_to_global_material_list* global_material_list = &g_material_list;
   // Use sanitation
   #ifdef MATERIAL_DETECTOR
@@ -387,4 +386,3 @@ TRACE
 %}
 
 END
-

--- a/mcstas-comps/union/Union_stop.comp
+++ b/mcstas-comps/union/Union_stop.comp
@@ -9,37 +9,33 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* Stop component that must be placed after all Union components for instrument to compile correctly
+* Deprecated no-op placeholder, kept for backward compatibility.
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
 *  sperates geometry and physics within McStas.
-* The use of this component requires other components to be used.
 *
-* 1) One specifies a number of processes using process components
-* 2) These are gathered into material definitions using this component
-* 3) Geometries are placed using Union_box/cylinder/sphere, assigned a material
-* 4) A Union_master component placed after all of the above
+* This component used to be required as the LAST component. It pulled in the
+*  dispatch switch (union-suffix.c) so it would be compiled after all the
+*  process components had defined their PROCESS DETECTOR macros.
 *
-* Only in step 4 will any simulation happen, and per default all geometries
-*  defined before the master, but after the previous will be simulated here.
+* That is no longer needed: the code generator now detects that the instrument
+*  uses Union (by the presence of a Union_master) and auto-injects the dispatch
+*  switch after all the component SHARE sections. The Union_init and
+*  Union_stop components are therefore optional.
 *
-* There is a dedicated manual available for the Union_components
-*
-* Algorithm:
-* Described elsewhere
+* This definition is kept only so that existing instruments that still place a
+*  Union_stop component continue to compile. It has no effect.
 *
 * %P
 * INPUT PARAMETERS:
 *
 * CALCULATED PARAMETERS:
 *
-* GLOBAL PARAMETERS:
-*
 * %L
 *
 * %E
-******************************************************************************/
+ ******************************************************************************/
 
 DEFINE COMPONENT Union_stop
 
@@ -50,11 +46,6 @@ SETTING PARAMETERS()
 
 SHARE
 %{
-  #ifndef Union
-  #error "The Union_init component must be included before this Union_stop component"
-  #endif
-
-  %include "union-suffix.c"
 %}
 
 DECLARE
@@ -66,4 +57,3 @@ INITIALIZE
 %}
 
 END
-

--- a/mcstas-comps/union/Union_stop.comp
+++ b/mcstas-comps/union/Union_stop.comp
@@ -46,6 +46,10 @@ SETTING PARAMETERS()
 
 SHARE
 %{
+#ifndef UNION_SUFFIX_C
+/* Compatibility path for code generators without Union auto-injection. */
+%include "union-suffix.c"
+#endif
 %}
 
 DECLARE

--- a/mcstas-comps/union/Union_stop.comp
+++ b/mcstas-comps/union/Union_stop.comp
@@ -25,7 +25,8 @@
 *  Union_stop components are therefore optional.
 *
 * This definition is kept only so that existing instruments that still place a
-*  Union_stop component continue to compile. It has no effect.
+*  Union_stop component continue to compile. It emits a deprecation warning
+*  and has no effect.
 *
 * %P
 * INPUT PARAMETERS:
@@ -44,20 +45,9 @@ SETTING PARAMETERS()
 
 /* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
 
-SHARE
-%{
-  #ifndef UNION_SUFFIX_C
-  /* Compatibility path for code generators without Union auto-injection. */
-  %include "union-suffix.c"
-  #endif
-%}
-
-DECLARE
-%{
-%}
-
 INITIALIZE
 %{
+  MPI_MASTER (printf ("WARNING: Union_stop is deprecated; Union components finalize automatically.\n"););
 %}
 
 END

--- a/mcstas-comps/union/Union_stop.comp
+++ b/mcstas-comps/union/Union_stop.comp
@@ -46,10 +46,10 @@ SETTING PARAMETERS()
 
 SHARE
 %{
-#ifndef UNION_SUFFIX_C
-/* Compatibility path for code generators without Union auto-injection. */
-%include "union-suffix.c"
-#endif
+  #ifndef UNION_SUFFIX_C
+  /* Compatibility path for code generators without Union auto-injection. */
+  %include "union-suffix.c"
+  #endif
 %}
 
 DECLARE

--- a/mcxtrace-comps/share/union-init.c
+++ b/mcxtrace-comps/share/union-init.c
@@ -32,39 +32,57 @@
 * %E
 ******************************************************************************/
 
+#ifndef UNION_INIT_C
+#define UNION_INIT_C
 
 // This file sets up global lists needed for Union components to communicate with each other
 // These all have dynamically allocated memory somewhere in the structure, which is deallocated
 //  by the last Union_master.
+//
+// This file is auto-injected by the code generator (mccode) at the front of the
+//  generated code whenever the instrument uses the Union component family
+//  (i.e. contains a Union_master). It no longer needs to be placed in a
+//  Union_init component. The globals use a 'g_' prefix so they do not collide
+//  with the component-local pointers of the same base name that each Union
+//  component declares.
+//
+// Note: McXtrace has no surface or mantid pixel lists, so only the lists used
+//  by the McXtrace Union components are declared here.
 
 
 // Initialize global positions / rotations to transform lists
   // These are lists of pointers to positons / rotations, that will be updated from global frame
   //  to the frame of the master component that uses them in that masters initialize section.
-  struct global_positions_to_transform_list_struct global_positions_to_transform_list = {0,NULL};
-  struct global_rotations_to_transform_list_struct global_rotations_to_transform_list = {0,NULL};
+  struct global_positions_to_transform_list_struct g_positions_to_transform_list = {0,NULL};
+  struct global_rotations_to_transform_list_struct g_rotations_to_transform_list = {0,NULL};
 
 // Initialize global_process_list
   // Used to facilitate communication between processes and the other types of Union components
-  struct pointer_to_global_process_list global_process_list = {0,NULL};
+  struct pointer_to_global_process_list g_process_list = {0,NULL};
 
 // Initialize global_material_list
   // Used to facilitate communication between materials and the other types of Union components
-  struct pointer_to_global_material_list global_material_list = {0,NULL};
+  struct pointer_to_global_material_list g_material_list = {0,NULL};
 
 // Initialize global_geometry_list
   // Used to facilitate communication between geometries and the other types of Union components
-  struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
+  struct pointer_to_global_geometry_list g_geometry_list = {0,NULL};
 
 // Initialize global_logger_lists
   // Used to facilitate communication between loggers and the other types of Union components
-  struct pointer_to_global_logger_list global_all_volume_logger_list = {0,NULL};
-  struct pointer_to_global_logger_list global_specific_volumes_logger_list = {0,NULL};
+  struct pointer_to_global_logger_list g_all_volume_logger_list = {0,NULL};
+  struct pointer_to_global_logger_list g_specific_volumes_logger_list = {0,NULL};
+
+// Initialize global_abs_logger_lists
+  struct pointer_to_global_abs_logger_list g_all_volume_abs_logger_list = {0,NULL};
+  struct pointer_to_global_abs_logger_list g_specific_volumes_abs_logger_list = {0,NULL};
 
 // Initialize global_tagging_conditional_list
   // Used to facilitate communication between conditionals and the other types of Union components
-  struct global_tagging_conditional_list_struct global_tagging_conditional_list = {0,0,NULL};
+  struct global_tagging_conditional_list_struct g_tagging_conditional_list = {0,0,NULL};
 
 // Initialize global_master_list
   // Used to facilitate communication between Master components (mainly for deallocation)
-  struct pointer_to_global_master_list global_master_list = {0,NULL};
+  struct pointer_to_global_master_list g_master_list = {0,NULL};
+
+#endif /* UNION_INIT_C */

--- a/mcxtrace-comps/share/union-lib.c
+++ b/mcxtrace-comps/share/union-lib.c
@@ -9,9 +9,14 @@
 * Version: $Revision: 0.1 $
 * Origin: University of Copenhagen
 *
-* Functions and structure definitons for Union components.
-*
-******************************************************************************/
+ * Functions and structure definitons for Union components.
+ *
+ ******************************************************************************/
+
+// Include guard: this file is auto-injected by the code generator and must
+// expand exactly once even if referenced more than once.
+#ifndef UNION_LIB_C
+#define UNION_LIB_C
 
 // -------------    Definition of data structures   ---------------------------------------------
 // GPU
@@ -8473,3 +8478,5 @@ void record_abs_to_file(double *r, double t1, double *r_old, double t2, double w
   }
 
 };
+
+#endif /* UNION_LIB_C */

--- a/mcxtrace-comps/share/union-suffix.c
+++ b/mcxtrace-comps/share/union-suffix.c
@@ -6,6 +6,11 @@ update Union master to use the flexible functions
 deal with loggers and conditionals
 */
 
+// Include guard: auto-injected by the code generator (once); keeps the
+// dispatch functions from being defined twice during transition.
+#ifndef UNION_SUFFIX_C
+#define UNION_SUFFIX_C
+
 int physics_my(enum process choice, double *my,double *k_initial, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
 
     int output = 0; // Error return value
@@ -111,3 +116,5 @@ int physics_scattering(enum process choice, double *k_final, double *k_initial, 
     #endif
     return output;
 }
+
+#endif /* UNION_SUFFIX_C */

--- a/mcxtrace-comps/union/Compton_xrl_process.comp
+++ b/mcxtrace-comps/union/Compton_xrl_process.comp
@@ -61,8 +61,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 #include <xraylib/xraylib.h>
@@ -177,13 +175,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index(init) < 0) {
-    fprintf(stderr,"Compton_xrl_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
-            NAME_CURRENT_COMP, init);
-    exit(-1);
-  }
-
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+  struct pointer_to_global_process_list *global_process_list = &g_process_list;
   add_element_to_process_list(global_process_list, global_process_element);
  %}
 

--- a/mcxtrace-comps/union/Compton_xrl_process.comp
+++ b/mcxtrace-comps/union/Compton_xrl_process.comp
@@ -58,8 +58,7 @@ DEPENDENCY " @XRLFLAGS@ "
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Compton_xrl_process.comp
+++ b/mcxtrace-comps/union/Compton_xrl_process.comp
@@ -38,7 +38,6 @@
 * density: [g/cm^3]   Nominal density of material.
 * element:    [str]   The element (symbol) of the material. Overrides atomno.
 * atomno:       [1]   Atomic number.
-* init:       [str]   Name of Union inititaliser component
 *
 * OUTPUT PARAMETERS:
 *
@@ -50,132 +49,135 @@
 
 DEFINE COMPONENT Compton_xrl_process
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS (density=0,atomno=14, string element="", string init="init")
+SETTING PARAMETERS (density=0,atomno=14, string element="")
 OUTPUT PARAMETERS (This_process,Compton_xrl_storage)
 DEPENDENCY " @XRLFLAGS@ "
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-#include <xraylib/xraylib.h>
+  #include <xraylib/xraylib.h>
 
-struct Compton_xrl_physics_storage_struct{
-  char name[13];
-  int Z;
-  double rho;
-  double sigma;
-};
+  struct Compton_xrl_physics_storage_struct {
+    char name[13];
+    int Z;
+    double rho;
+    double sigma;
+  };
 
-int Compton_xrl_physics_my(double *my, double *k_i, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle){
-  /*get the partial cross section using xraylib*/
-  double k_length = sqrt(k_i[0]*k_i[0]+k_i[1]*k_i[1]+k_i[2]*k_i[2]);
-  double E=K2E*k_length;
+  int
+  Compton_xrl_physics_my (double* my, double* k_i, union data_transfer_union data_transfer, struct focus_data_struct* focus_data, _class_particle* _particle) {
+    /*get the partial cross section using xraylib*/
+    double k_length = sqrt (k_i[0] * k_i[0] + k_i[1] * k_i[1] + k_i[2] * k_i[2]);
+    double E = K2E * k_length;
 
-  /*how to handle the fact that we may be dealing with polarized radiation - goes in data_transfer union?*/
-  /*we have to somehow transfer input data to this function - is this also in data_transfer union? yes. It contains pointers to all the possible physics_storage structs.*/
-  struct Compton_xrl_physics_storage_struct *p = data_transfer.pointer_to_a_Compton_xrl_physics_storage_struct;
+    /*how to handle the fact that we may be dealing with polarized radiation - goes in data_transfer union?*/
+    /*we have to somehow transfer input data to this function - is this also in data_transfer union? yes. It contains pointers to all the possible physics_storage
+     * structs.*/
+    struct Compton_xrl_physics_storage_struct* p = data_transfer.pointer_to_a_Compton_xrl_physics_storage_struct;
 
-  /*call xraylib to get cross_section in cm^2/g - scale by density to get mu in cm^-1 - scale by 10^2 to get mu in m^-1*/
-  p->sigma=CS_Compt(p->Z,E,NULL);
-  *my=p->rho*p->sigma*100;
-  return 1;
-}
+    /*call xraylib to get cross_section in cm^2/g - scale by density to get mu in cm^-1 - scale by 10^2 to get mu in m^-1*/
+    p->sigma = CS_Compt (p->Z, E, NULL);
+    *my = p->rho * p->sigma * 100;
+    return 1;
+  }
 
-int Compton_xrl_physics_scattering(double *k_f, double *k_i, double *weight, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
-  double k_length = sqrt(k_i[0]*k_i[0]+k_i[1]*k_i[1]+k_i[2]*k_i[2]);
-  double E=K2E*k_length;
-  double E0;
+  int
+  Compton_xrl_physics_scattering (double* k_f, double* k_i, double* weight, union data_transfer_union data_transfer, struct focus_data_struct* focus_data,
+                                  _class_particle* _particle) {
+    double k_length = sqrt (k_i[0] * k_i[0] + k_i[1] * k_i[1] + k_i[2] * k_i[2]);
+    double E = K2E * k_length;
+    double E0;
 
-  struct Compton_xrl_physics_storage_struct *p = data_transfer.pointer_to_a_Compton_xrl_physics_storage_struct;
+    struct Compton_xrl_physics_storage_struct* p = data_transfer.pointer_to_a_Compton_xrl_physics_storage_struct;
 
-  /*pick a direction randomly*/
-  Coords k_out;
-  // Here is the focusing system in action, get a vector
-  double solid_angle;
-  focus_data->focusing_function(&k_out,&solid_angle,focus_data);
-  NORM(k_out.x,k_out.y,k_out.z);
-  *weight *= solid_angle*0.25/PI;
+    /*pick a direction randomly*/
+    Coords k_out;
+    // Here is the focusing system in action, get a vector
+    double solid_angle;
+    focus_data->focusing_function (&k_out, &solid_angle, focus_data);
+    NORM (k_out.x, k_out.y, k_out.z);
+    *weight *= solid_angle * 0.25 / PI;
 
-  double theta,dsigma;
-  theta = acos(scalar_prod(k_out.x,k_out.y, k_out.z,k_i[0], k_i[1],k_i[2])/k_length);
+    double theta, dsigma;
+    theta = acos (scalar_prod (k_out.x, k_out.y, k_out.z, k_i[0], k_i[1], k_i[2]) / k_length);
 
-  /*make the call to xraylib to get the partial cross section for the particular scattering triangle defined by k_i, k_f.
-    We rely on a previous call to CS_Compt by _mu-function*/
-  dsigma = DCS_Compt(p->Z,E,theta,NULL);
-  *weight *= dsigma/p->sigma;
-  E0=E;
-  E=ComptonEnergy(E0,theta,NULL);
-  k_length=E*E2K;
-  k_f[0]=k_out.x*k_length;
-  k_f[1]=k_out.y*k_length;
-  k_f[2]=k_out.z*k_length;
-  /*get */
-  return 1;
-}
+    /*make the call to xraylib to get the partial cross section for the particular scattering triangle defined by k_i, k_f.
+      We rely on a previous call to CS_Compt by _mu-function*/
+    dsigma = DCS_Compt (p->Z, E, theta, NULL);
+    *weight *= dsigma / p->sigma;
+    E0 = E;
+    E = ComptonEnergy (E0, theta, NULL);
+    k_length = E * E2K;
+    k_f[0] = k_out.x * k_length;
+    k_f[1] = k_out.y * k_length;
+    k_f[2] = k_out.z * k_length;
+    /*get */
+    return 1;
+  }
 
-#ifndef PROCESS_DETECTOR
-    #define PROCESS_DETECTOR dummy
-#endif
+  #ifndef PROCESS_DETECTOR
+  #define PROCESS_DETECTOR dummy
+  #endif
 
-#ifndef PROCESS_COMPTON_XRL_DETECTOR
-    #define PROCESS_COMPTON_XRL_DETECTOR dummy
-#endif
+  #ifndef PROCESS_COMPTON_XRL_DETECTOR
+  #define PROCESS_COMPTON_XRL_DETECTOR dummy
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_process_element_struct global_process_element;
-struct scattering_process_struct This_process;
+  // Needed for transport to the main component
+  struct global_process_element_struct global_process_element;
+  struct scattering_process_struct This_process;
 
-// Declare for this component, to do calculations on the input / store in the transported data
-struct Compton_xrl_physics_storage_struct Compton_xrl_storage;
-
+  // Declare for this component, to do calculations on the input / store in the transported data
+  struct Compton_xrl_physics_storage_struct Compton_xrl_storage;
 %}
 
 INITIALIZE
 %{
   // Initialize done in the component
-  xrl_error *xe;
-  if(atomno==0 && strlen(element)!=0){
-    Compton_xrl_storage.Z=SymbolToAtomicNumber(element,&xe);
-    snprintf(Compton_xrl_storage.name,3,element);
-  } else if (atomno>0 || atomno<116){
-    Compton_xrl_storage.Z=atomno;
-    snprintf(Compton_xrl_storage.name,3,AtomicNumberToSymbol(atomno,&xe));
-  }else{
-    fprintf(stderr,"ERROR: (%s): Must set either an element by symbol or by atomic number Got (%s,%d).\n",NAME_CURRENT_COMP,element,atomno);
-    exit(-1);
+  xrl_error* xe;
+  if (atomno == 0 && strlen (element) != 0) {
+    Compton_xrl_storage.Z = SymbolToAtomicNumber (element, &xe);
+    snprintf (Compton_xrl_storage.name, 3, element);
+  } else if (atomno > 0 || atomno < 116) {
+    Compton_xrl_storage.Z = atomno;
+    snprintf (Compton_xrl_storage.name, 3, AtomicNumberToSymbol (atomno, &xe));
+  } else {
+    fprintf (stderr, "ERROR: (%s): Must set either an element by symbol or by atomic number Got (%s,%d).\n", NAME_CURRENT_COMP, element, atomno);
+    exit (-1);
   }
-  Compton_xrl_storage.rho=density;
+  Compton_xrl_storage.rho = density;
 
   // The type of the process must be saved in the global enum process
   This_process.eProcess = Compton_xrl;
 
   // Need to specify if this process is isotropic
   This_process.non_isotropic_rot_index = -1; // Yes (powder)
-  //This_process.non_isotropic_rot_index =  1;  // No (single crystal)
+  // This_process.non_isotropic_rot_index =  1;  // No (single crystal)
 
   // Packing the data into a structure that is transported to the main component
-  sprintf(This_process.name,NAME_CURRENT_COMP);
+  sprintf (This_process.name, NAME_CURRENT_COMP);
   This_process.process_p_interact = -1;
   This_process.data_transfer.pointer_to_a_Compton_xrl_physics_storage_struct = &Compton_xrl_storage;
-  //This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
+  // This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
   This_process.probability_for_scattering_function = &Compton_xrl_physics_my;
   This_process.scattering_function = &Compton_xrl_physics_scattering;
 
   // This will be the same for all process's, and can thus be moved to an include.
-  sprintf(global_process_element.name,NAME_CURRENT_COMP);
+  sprintf (global_process_element.name, NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  struct pointer_to_global_process_list *global_process_list = &g_process_list;
-  add_element_to_process_list(global_process_list, global_process_element);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  add_element_to_process_list (global_process_list, global_process_element);
  %}
 
 TRACE
@@ -184,8 +186,7 @@ TRACE
 
 FINALLY
 %{
-// Since the process and it's storage is a static allocation, there is nothing to deallocate
-
+  // Since the process and it's storage is a static allocation, there is nothing to deallocate
 %}
 
 END

--- a/mcxtrace-comps/union/Compton_xrl_process.comp
+++ b/mcxtrace-comps/union/Compton_xrl_process.comp
@@ -57,7 +57,7 @@ DEPENDENCY " @XRLFLAGS@ "
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Compton_xrl_process requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Incoherent_process.comp
+++ b/mcxtrace-comps/union/Incoherent_process.comp
@@ -59,12 +59,10 @@ SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volu
 SHARE
 %{
   #ifndef Union
-  #define Union $Revision: 0.8 $
+   #define Union $Revision: 0.8 $
 
 
-  %include "union-init.c"
-
-  #endif
+   #endif
 
   struct Incoherent_physics_storage_struct {
     // Variables that needs to be transfered between any of the following places:
@@ -163,13 +161,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index(init) < 0) {
-    fprintf(stderr,"Incoherent_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
-            NAME_CURRENT_COMP, init);
-    exit(-1);
-  }
-
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+  struct pointer_to_global_process_list *global_process_list = &g_process_list;
   add_element_to_process_list(global_process_list, global_process_element);
  %}
 

--- a/mcxtrace-comps/union/Incoherent_process.comp
+++ b/mcxtrace-comps/union/Incoherent_process.comp
@@ -58,7 +58,7 @@ SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volu
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Incoherent_process requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Incoherent_process.comp
+++ b/mcxtrace-comps/union/Incoherent_process.comp
@@ -59,8 +59,7 @@ SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volu
 SHARE
 %{
   #ifndef Union
-   #define Union $Revision: 0.8 $
-
+   #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
    #endif
 

--- a/mcxtrace-comps/union/Incoherent_process.comp
+++ b/mcxtrace-comps/union/Incoherent_process.comp
@@ -43,7 +43,6 @@
 * packing_factor: [1]      How dense is the material compared to optimal 0-1
 * unit_cell_volume: [AA^3] Unit_cell_volume
 * interact_fraction: [1]   How large a part of the scattering events should use this process 0-1 (sum of all processes in material = 1)
-* init:              [string] name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 *
@@ -54,14 +53,14 @@
 ******************************************************************************/
 
 DEFINE COMPONENT Incoherent_process
-SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volume=13.8, interact_fraction=-1, string init="init")
+SETTING PARAMETERS(sigma=5.08, f_QE=0, gamma=0, packing_factor=1, unit_cell_volume=13.8, interact_fraction=-1)
 
 SHARE
 %{
   #ifndef Union
-   #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-   #endif
+  #endif
 
   struct Incoherent_physics_storage_struct {
     // Variables that needs to be transfered between any of the following places:
@@ -75,16 +74,20 @@ SHARE
   };
 
   // Function for calculating my in Incoherent case
-  int Incoherent_physics_my(double *my,double *k_initial, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
+  int
+  Incoherent_physics_my (double* my, double* k_initial, union data_transfer_union data_transfer, struct focus_data_struct* focus_data,
+                         _class_particle* _particle) {
     *my = data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering;
     return 1;
   };
 
   // Function for basic incoherent scattering event
-  int Incoherent_physics_scattering (double *k_final, double *k_initial, double *weight, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
+  int
+  Incoherent_physics_scattering (double* k_final, double* k_initial, double* weight, union data_transfer_union data_transfer,
+                                 struct focus_data_struct* focus_data, _class_particle* _particle) {
 
-    //New version of incoherent scattering
-    double k_length = sqrt(k_initial[0]*k_initial[0]+k_initial[1]*k_initial[1]+k_initial[2]*k_initial[2]);
+    // New version of incoherent scattering
+    double k_length = sqrt (k_initial[0] * k_initial[0] + k_initial[1] * k_initial[1] + k_initial[2] * k_initial[2]);
 
     Coords k_out;
     // Here is the focusing system in action, get a vector
@@ -101,22 +104,22 @@ SHARE
       E_f = E_i + dE;
       if (E_f <= 0)
         return 0;
-      k_length = E_f*E2K;
+      k_length = E_f * E2K;
     }
 
     k_final[0] = k_out.x * k_length;
     k_final[1] = k_out.y * k_length;
     k_final[2] = k_out.z * k_length;
     return 1;
-};
+  };
 
-#ifndef PROCESS_DETECTOR
-    #define PROCESS_DETECTOR dummy
-#endif
+  #ifndef PROCESS_DETECTOR
+  #define PROCESS_DETECTOR dummy
+  #endif
 
-#ifndef PROCESS_INCOHERENT_DETECTOR
-    #define PROCESS_INCOHERENT_DETECTOR dummy
-#endif
+  #ifndef PROCESS_INCOHERENT_DETECTOR
+  #define PROCESS_INCOHERENT_DETECTOR dummy
+  #endif
 %}
 
 DECLARE
@@ -128,13 +131,12 @@ DECLARE
   // Declare for this component, to do calculations on the input / store in the transported data
   struct Incoherent_physics_storage_struct Incoherent_storage;
   double effective_my_scattering;
-
 %}
 
 INITIALIZE
 %{
   // Initialize done in the component
-  effective_my_scattering = ((packing_factor/unit_cell_volume) * 100 * sigma);
+  effective_my_scattering = ((packing_factor / unit_cell_volume) * 100 * sigma);
   Incoherent_storage.my_scattering = effective_my_scattering;
 
   Incoherent_storage.QE_sampling_frequency = f_QE;
@@ -145,23 +147,23 @@ INITIALIZE
 
   // Need to specify if this process is isotropic
   This_process.non_isotropic_rot_index = -1; // Yes (powder)
-  //This_process.non_isotropic_rot_index =  1;  // No (single crystal)
+  // This_process.non_isotropic_rot_index =  1;  // No (single crystal)
 
   // Packing the data into a structure that is transported to the main component
-  sprintf(This_process.name,NAME_CURRENT_COMP);
+  sprintf (This_process.name, NAME_CURRENT_COMP);
   This_process.process_p_interact = interact_fraction;
   This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct = &Incoherent_storage;
-  //This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
+  // This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
   This_process.probability_for_scattering_function = &Incoherent_physics_my;
   This_process.scattering_function = &Incoherent_physics_scattering;
 
   // This will be the same for all process's, and can thus be moved to an include.
-  sprintf(global_process_element.name,NAME_CURRENT_COMP);
+  sprintf (global_process_element.name, NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  struct pointer_to_global_process_list *global_process_list = &g_process_list;
-  add_element_to_process_list(global_process_list, global_process_element);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  add_element_to_process_list (global_process_list, global_process_element);
  %}
 
 TRACE

--- a/mcxtrace-comps/union/KN_xrl_process.comp
+++ b/mcxtrace-comps/union/KN_xrl_process.comp
@@ -58,8 +58,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 #include <xraylib/xraylib.h>
@@ -164,13 +162,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index(init) < 0) {
-    fprintf(stderr,"Compton_xrl_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
-            NAME_CURRENT_COMP, init);
-    exit(-1);
-  }
-
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+  struct pointer_to_global_process_list *global_process_list = &g_process_list;
   add_element_to_process_list(global_process_list, global_process_element);
  %}
 

--- a/mcxtrace-comps/union/KN_xrl_process.comp
+++ b/mcxtrace-comps/union/KN_xrl_process.comp
@@ -36,7 +36,6 @@
 * %P
 * INPUT PARAMETERS:
 * density: [g/cm^3]       Nominal density of material.
-* init:       [str]   Name of Union inititaliser component
 * OUTPUT PARAMETERS:
 *
 * %L
@@ -47,122 +46,125 @@
 
 DEFINE COMPONENT KN_xrl_process
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS (density=0, string init="init")
+SETTING PARAMETERS (density=0)
 OUTPUT PARAMETERS (This_process,KN_xrl_storage)
 DEPENDENCY " @XRLFLAGS@ "
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-#include <xraylib/xraylib.h>
+  #include <xraylib/xraylib.h>
 
-struct KN_xrl_physics_storage_struct{
-  char name[13];
-  double rho;
-  double sigma;
-};
+  struct KN_xrl_physics_storage_struct {
+    char name[13];
+    double rho;
+    double sigma;
+  };
 
-int KN_xrl_physics_my(double *my, double *k_i, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle){
-  /*get the partial cross section using xraylib*/
-  double k_length = sqrt(k_i[0]*k_i[0]+k_i[1]*k_i[1]+k_i[2]*k_i[2]);
-  double E=K2E*k_length;
+  int
+  KN_xrl_physics_my (double* my, double* k_i, union data_transfer_union data_transfer, struct focus_data_struct* focus_data, _class_particle* _particle) {
+    /*get the partial cross section using xraylib*/
+    double k_length = sqrt (k_i[0] * k_i[0] + k_i[1] * k_i[1] + k_i[2] * k_i[2]);
+    double E = K2E * k_length;
 
-  /*how to handle the fact that we may be dealing with polarized radiation - goes in data_transfer union?*/
-  /*we have to somehow transfer input data to this function - is this also in data_transfer union? yes. It contains pointers to all the possible physics_storage structs.*/
-  struct KN_xrl_physics_storage_struct *p = data_transfer.pointer_to_a_KN_xrl_physics_storage_struct;
+    /*how to handle the fact that we may be dealing with polarized radiation - goes in data_transfer union?*/
+    /*we have to somehow transfer input data to this function - is this also in data_transfer union? yes. It contains pointers to all the possible physics_storage
+     * structs.*/
+    struct KN_xrl_physics_storage_struct* p = data_transfer.pointer_to_a_KN_xrl_physics_storage_struct;
 
-  /*call xraylib to get cross_section in cm^2/g - scale by density to get mu in cm^-1 - scale by 10^2 to get mu in m^-1*/
-  p->sigma=CS_KN(E,NULL);
-  *my=p->rho*p->sigma*100;
-  return 1;
-}
+    /*call xraylib to get cross_section in cm^2/g - scale by density to get mu in cm^-1 - scale by 10^2 to get mu in m^-1*/
+    p->sigma = CS_KN (E, NULL);
+    *my = p->rho * p->sigma * 100;
+    return 1;
+  }
 
-int KN_xrl_physics_scattering(double *k_f, double *k_i, double *weight, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
-  double k_length = sqrt(k_i[0]*k_i[0]+k_i[1]*k_i[1]+k_i[2]*k_i[2]);
-  double E=K2E*k_length;
-  double E0;
+  int
+  KN_xrl_physics_scattering (double* k_f, double* k_i, double* weight, union data_transfer_union data_transfer, struct focus_data_struct* focus_data,
+                             _class_particle* _particle) {
+    double k_length = sqrt (k_i[0] * k_i[0] + k_i[1] * k_i[1] + k_i[2] * k_i[2]);
+    double E = K2E * k_length;
+    double E0;
 
-  struct KN_xrl_physics_storage_struct *p = data_transfer.pointer_to_a_KN_xrl_physics_storage_struct;
+    struct KN_xrl_physics_storage_struct* p = data_transfer.pointer_to_a_KN_xrl_physics_storage_struct;
 
-  /*pick a direction randomly*/
-  Coords k_out;
-  // Here is the focusing system in action, get a vector
-  double solid_angle;
-  focus_data->focusing_function(&k_out,&solid_angle,focus_data);
-  NORM(k_out.x,k_out.y,k_out.z);
-  *weight *= solid_angle*0.25/PI;
+    /*pick a direction randomly*/
+    Coords k_out;
+    // Here is the focusing system in action, get a vector
+    double solid_angle;
+    focus_data->focusing_function (&k_out, &solid_angle, focus_data);
+    NORM (k_out.x, k_out.y, k_out.z);
+    *weight *= solid_angle * 0.25 / PI;
 
-  double theta,dsigma,eps;
-  theta = acos(scalar_prod(k_out.x,k_out.y, k_out.z,k_i[0], k_i[1],k_i[2])/k_length);
+    double theta, dsigma, eps;
+    theta = acos (scalar_prod (k_out.x, k_out.y, k_out.z, k_i[0], k_i[1], k_i[2]) / k_length);
 
-  /*make the call to xraylib to get the partial cross section for the particular scattering triangle defined by k_i, k_f.
-    We rely on a previous call to CS_KN by _mu-function*/
-  dsigma = DCS_KN(E,theta,NULL);
-  *weight *= dsigma/p->sigma;
-  E0 = E;
-  eps = (E * CELE * 1e3 ) / ( MELECTRON * M_C * M_C);  
-  E *= 1.0/(1.0 + eps*(1-cos(theta)));
-  k_length=E*E2K;
-  k_f[0]=k_out.x*k_length;
-  k_f[1]=k_out.y*k_length;
-  k_f[2]=k_out.z*k_length;
-  /*get */
-  return 1;
-}
+    /*make the call to xraylib to get the partial cross section for the particular scattering triangle defined by k_i, k_f.
+      We rely on a previous call to CS_KN by _mu-function*/
+    dsigma = DCS_KN (E, theta, NULL);
+    *weight *= dsigma / p->sigma;
+    E0 = E;
+    eps = (E * CELE * 1e3) / (MELECTRON * M_C * M_C);
+    E *= 1.0 / (1.0 + eps * (1 - cos (theta)));
+    k_length = E * E2K;
+    k_f[0] = k_out.x * k_length;
+    k_f[1] = k_out.y * k_length;
+    k_f[2] = k_out.z * k_length;
+    /*get */
+    return 1;
+  }
 
-#ifndef PROCESS_DETECTOR
-    #define PROCESS_DETECTOR dummy
-#endif
+  #ifndef PROCESS_DETECTOR
+  #define PROCESS_DETECTOR dummy
+  #endif
 
-#ifndef PROCESS_KN_XRL_DETECTOR
-    #define PROCESS_KN_XRL_DETECTOR dummy
-#endif
+  #ifndef PROCESS_KN_XRL_DETECTOR
+  #define PROCESS_KN_XRL_DETECTOR dummy
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_process_element_struct global_process_element;
-struct scattering_process_struct This_process;
+  // Needed for transport to the main component
+  struct global_process_element_struct global_process_element;
+  struct scattering_process_struct This_process;
 
-// Declare for this component, to do calculations on the input / store in the transported data
-struct KN_xrl_physics_storage_struct KN_xrl_storage;
-
+  // Declare for this component, to do calculations on the input / store in the transported data
+  struct KN_xrl_physics_storage_struct KN_xrl_storage;
 %}
 
 INITIALIZE
 %{
   // Initialize done in the component
-  xrl_error *xe;
-  KN_xrl_storage.rho=density;
+  xrl_error* xe;
+  KN_xrl_storage.rho = density;
 
   // The type of the process must be saved in the global enum process
   This_process.eProcess = KN_xrl;
 
   // Need to specify if this process is isotropic
   This_process.non_isotropic_rot_index = -1; // Yes (powder)
-  //This_process.non_isotropic_rot_index =  1;  // No (single crystal)
+  // This_process.non_isotropic_rot_index =  1;  // No (single crystal)
 
   // Packing the data into a structure that is transported to the main component
-  sprintf(This_process.name,NAME_CURRENT_COMP);
+  sprintf (This_process.name, NAME_CURRENT_COMP);
   This_process.process_p_interact = -1;
   This_process.data_transfer.pointer_to_a_KN_xrl_physics_storage_struct = &KN_xrl_storage;
-  //This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
+  // This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
   This_process.probability_for_scattering_function = &KN_xrl_physics_my;
   This_process.scattering_function = &KN_xrl_physics_scattering;
 
   // This will be the same for all process's, and can thus be moved to an include.
-  sprintf(global_process_element.name,NAME_CURRENT_COMP);
+  sprintf (global_process_element.name, NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  struct pointer_to_global_process_list *global_process_list = &g_process_list;
-  add_element_to_process_list(global_process_list, global_process_element);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  add_element_to_process_list (global_process_list, global_process_element);
  %}
 
 TRACE
@@ -171,8 +173,7 @@ TRACE
 
 FINALLY
 %{
-// Since the process and it's storage is a static allocation, there is nothing to deallocate
-
+  // Since the process and it's storage is a static allocation, there is nothing to deallocate
 %}
 
 END

--- a/mcxtrace-comps/union/KN_xrl_process.comp
+++ b/mcxtrace-comps/union/KN_xrl_process.comp
@@ -54,7 +54,7 @@ DEPENDENCY " @XRLFLAGS@ "
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: KN_xrl_process requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/KN_xrl_process.comp
+++ b/mcxtrace-comps/union/KN_xrl_process.comp
@@ -55,8 +55,7 @@ DEPENDENCY " @XRLFLAGS@ "
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Powder_process.comp
+++ b/mcxtrace-comps/union/Powder_process.comp
@@ -70,8 +70,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 // Share section of PowderN
@@ -822,13 +820,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index(init) < 0) {
-    fprintf(stderr,"Powder_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
-        NAME_CURRENT_COMP, init);
-    exit(-1);
-  }
-
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+  struct pointer_to_global_process_list *global_process_list = &g_process_list;
   add_element_to_process_list(global_process_list, global_process_element);
 %}
 

--- a/mcxtrace-comps/union/Powder_process.comp
+++ b/mcxtrace-comps/union/Powder_process.comp
@@ -60,33 +60,31 @@
 
 DEFINE COMPONENT Powder_process
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(string reflections="NULL", string material="NULL",packing_factor=1, Vc=0, delta_d_d=0, DW=0, nb_atoms=1, density=0, weight=0, barns=1, Strain=0, interact_fraction=-1, vector format={0, 0, 0, 0, 0, 0, 0, 0, 0}, vector mat_format={0,0,0,0,0}, string init="init")
+SETTING PARAMETERS(string reflections="NULL", string material="NULL",packing_factor=1, Vc=0, delta_d_d=0, DW=0, nb_atoms=1, density=0, weight=0, barns=1, Strain=0, interact_fraction=-1, vector format={0, 0, 0, 0, 0, 0, 0, 0, 0}, vector mat_format={0,0,0,0,0})
 OUTPUT PARAMETERS ()
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-// Share section of PowderN
+  // Share section of PowderN
 
   // single reflection data
-struct line_data_union
-    {
-      double F2;                  /* Value of structure factor */
-      double q;                   /* Qvector */
-      int j;                      /* Multiplicity */
-      double DWfactor;            /* Debye-Waller factor */
-      double w;                   /* Intrinsic line width */
-      double Epsilon;             /* Strain=delta_d_d/d shift in ppm */
-    };
+  struct line_data_union {
+    double F2;       /* Value of structure factor */
+    double q;        /* Qvector */
+    int j;           /* Multiplicity */
+    double DWfactor; /* Debye-Waller factor */
+    double w;        /* Intrinsic line width */
+    double Epsilon;  /* Strain=delta_d_d/d shift in ppm */
+  };
 
   // material data
-struct abs_data_union
-  {
+  struct abs_data_union {
     double E;       /*energy (in keV)*/
     double k;       /*wavenumber corresponding to E*/
     double sigma_a; /*absorption cross section for energy E*/
@@ -94,601 +92,641 @@ struct abs_data_union
     double cohinc;  /*coherent +incoherent scattering coefficient*/
   };
   // component data
-struct line_info_struct_union
-{
-  struct line_data_union *list;     /* Reflection array */
-  int  count;                  /* Number of reflections */
-  double Dd;
-  double DWfactor;
-  double V_0;
-  double rho;
-  double at_weight;
-  double at_nb;
-  double sigma_a;
-  double sigma_i;
-  char   compname[256];
-  double flag_barns;
-  int    shape; /* 0 cylinder, 1 box, 2 sphere, 3 OFF file */
-  int    column_order[9]; /* column signification */
-  int    flag_warning;
-  char   type;  /* interaction type of event t=Transmit, i=Incoherent, c=Coherent */
-  double dq;    /* wavevector transfer [Angs-1] */
-  double Epsilon; /* global strain in ppm */
-  double XsectionFactor;
-  double my_s_k2_sum;
-  double my_a;
-  double my_inc;
-  double lfree; // store mean free path for the last event;
-  double *w,*q, *my_s_k2;
-  double radius_i,xwidth_i,yheight_i,zdepth_i;
-  double k; /* last wavenumber (cached) */
-  double Nq;
-  int    nb_reuses, nb_refl, nb_refl_count;
-  double k_min, k_max;
-  double xs_Nq[CHAR_BUF_LENGTH];
-  double xs_sum[CHAR_BUF_LENGTH];
-  unsigned int photon_passed;
-  long   xs_compute, xs_reuse, xs_calls;
-  t_Table mat_table;
-  int mat_column_order[5]; /*column signification for the coeff. in material data file*/
-};
+  struct line_info_struct_union {
+    struct line_data_union* list; /* Reflection array */
+    int count;                    /* Number of reflections */
+    double Dd;
+    double DWfactor;
+    double V_0;
+    double rho;
+    double at_weight;
+    double at_nb;
+    double sigma_a;
+    double sigma_i;
+    char compname[256];
+    double flag_barns;
+    int shape;           /* 0 cylinder, 1 box, 2 sphere, 3 OFF file */
+    int column_order[9]; /* column signification */
+    int flag_warning;
+    char type;      /* interaction type of event t=Transmit, i=Incoherent, c=Coherent */
+    double dq;      /* wavevector transfer [Angs-1] */
+    double Epsilon; /* global strain in ppm */
+    double XsectionFactor;
+    double my_s_k2_sum;
+    double my_a;
+    double my_inc;
+    double lfree; // store mean free path for the last event;
+    double *w, *q, *my_s_k2;
+    double radius_i, xwidth_i, yheight_i, zdepth_i;
+    double k; /* last wavenumber (cached) */
+    double Nq;
+    int nb_reuses, nb_refl, nb_refl_count;
+    double k_min, k_max;
+    double xs_Nq[CHAR_BUF_LENGTH];
+    double xs_sum[CHAR_BUF_LENGTH];
+    unsigned int photon_passed;
+    long xs_compute, xs_reuse, xs_calls;
+    t_Table mat_table;
+    int mat_column_order[5]; /*column signification for the coeff. in material data file*/
+  };
 
-int PN_list_compare_union (void const *a, void const *b)
-{
-  struct line_data_union const *pa = a;
-  struct line_data_union const *pb = b;
-  double s = pa->q - pb->q;
+  int
+  PN_list_compare_union (void const* a, void const* b) {
+    struct line_data_union const* pa = a;
+    struct line_data_union const* pb = b;
+    double s = pa->q - pb->q;
 
-  if (!s) return 0;
-  else    return (s < 0 ? -1 : 1);
-} /* PN_list_compare */
-
-#ifndef CIF2HKL
-#define CIF2HKL
-// hkl_filename = cif2hkl(file, options)
-//   used to convert CIF/CFL/INS file into F2(hkl)
-//   the CIF2HKL env var can point to a cif2hkl executable
-//   else the McCode binary is attempted, then the system.
-char *cif2hkl(const char *infile, const char *options) {
-  char cmd[1024];
-  int  ret = 0;
-  int  found = 0;
-  char *OUTFILE;
-
-  // get filename extension
-  const char *ext = strrchr(infile, '.');
-  if(!ext || ext == infile) return infile;
-  else ext++;
-
-  // return input when no extension or not a CIF/FullProf/ShelX file
-  if ( strcasecmp(ext, "cif")
-      && strcasecmp(ext, "pcr")
-      && strcasecmp(ext, "cfl")
-      && strcasecmp(ext, "shx")
-      && strcasecmp(ext, "ins")
-      && strcasecmp(ext, "res")) return infile;
-
-  OUTFILE = malloc(1024);
-  if (!OUTFILE) return infile;
-
-  strncpy(OUTFILE, tmpnam(NULL), 1024); // create an output temporary file name
-
-  // try in order the CIF2HKL env var, then the system cif2hkl, then the McCode one
-  if (!found && getenv("CIF2HKL")) {
-    snprintf(cmd,  1024, "%s -o %s %s %s",
-        getenv("CIF2HKL"),
-        OUTFILE, options, infile);
-    ret = system(cmd);
-    if (ret != -1 && ret != 127) found = 1;
-  }
-  if (!found) {
-    snprintf(cmd,  1024, "%s%c%s%c%s -o %s %s %s",
-        getenv(FLAVOR_UPPER) ? getenv(FLAVOR_UPPER) : MCXTRACE,
-        MC_PATHSEP_C, "bin", MC_PATHSEP_C, "cif2hkl",
-        OUTFILE, options, infile);
-    ret = system(cmd);
-    if (ret != -1 && ret != 127) found = 1;
-  }
-  // ret = -1:  child process could not be created
-  // ret = 127: shell could not be executed in the child process
-  if (!found) {
-    // try with any cif2hkl command from the system
-    snprintf(cmd,  1024, "%s -o %s %s %s",
-        "cif2hkl", OUTFILE, options, infile);
-    ret = system(cmd);
-  }
-
-  if (ret == -1 || ret == 127) return(NULL);
-
-  // test if the result file has been created
-  FILE *file = fopen(OUTFILE,"r");
-  if (!file) return(NULL);
-  MPI_MASTER(
-      printf("%s: INFO: Converting %s into F2(HKL) list %s\n",
-        __FILE__, infile, OUTFILE);
-      printf ("%s\n",cmd);
-      );
-  fflush(NULL);
-  return(OUTFILE);
-} // cif2hkl
-#endif
-
-int read_line_data_union(char *SC_file, struct line_info_struct_union *info)
-{
-  struct line_data_union *list = NULL;
-  int    size = 0;
-  t_Table sTable; /* sample data table structure from SC_file */
-  int    i=0;
-  int    mult_count  =0;
-  char   flag=0;
-  double q_count=0, j_count=0, F2_count=0;
-  char **parsing;
-  int    list_count=0;
-  double sum_F2=0;
-  char  *filename=NULL;
-
-  if (!SC_file || !strlen(SC_file) || !strcmp(SC_file, "NULL")) {
-    printf("PowderN: %s: Using incoherent elastic scattering only.\n",
-        info->compname);
-    info->count = 0;
-    return(0);
-  }
-  filename = cif2hkl(SC_file, "--mode XRA");
-  long retval = Table_Read(&sTable, filename, 1); /* read 1st block data from SC_file into sTable*/
-  if (retval<0) {
-    fprintf(stderr,"PowderN: Could not open file %s - exiting!\n", filename);
-    exit(-1);
-  }
-
-  /* parsing of header */
-  parsing = Table_ParseHeader(sTable.header,
-      "Vc","V_0",
-      "column_j",
-      "column_d",
-      "column_F2",
-      "column_DW",
-      "column_Dd",
-      "column_inv2d", "column_1/2d", "column_sintheta/lambda",
-      "column_q", /* 10 */
-      "DW", "Debye_Waller",
-      "delta_d/d",
-      "column_F ",
-      "V_rho",
-      "density",
-      "weight",
-      "nb_atoms","multiplicity",
-      NULL);
-
-  if (parsing) {
-    if (parsing[0] && !info->V_0)     info->V_0    =atof(parsing[0]);
-    if (parsing[1] && !info->V_0)     info->V_0    =atof(parsing[1]);
-    if (parsing[2])                   info->column_order[0]=atoi(parsing[2]);
-    if (parsing[3])                   info->column_order[1]=atoi(parsing[3]);
-    if (parsing[4])                   info->column_order[2]=atoi(parsing[4]);
-    if (parsing[5])                   info->column_order[3]=atoi(parsing[5]);
-    if (parsing[6])                  info->column_order[4]=atoi(parsing[6]);
-    if (parsing[7])                  info->column_order[5]=atoi(parsing[7]);
-    if (parsing[8])                  info->column_order[5]=atoi(parsing[8]);
-    if (parsing[9])                  info->column_order[5]=atoi(parsing[9]);
-    if (parsing[10])                  info->column_order[6]=atoi(parsing[10]);
-    if (parsing[11] && info->DWfactor<=0)    info->DWfactor=atof(parsing[11]);
-    if (parsing[12] && info->DWfactor<=0)    info->DWfactor=atof(parsing[12]);
-    if (parsing[13] && info->Dd <0)          info->Dd      =atof(parsing[13]);
-    if (parsing[14])                  info->column_order[7]=atoi(parsing[14]);
-    if (parsing[15] && !info->V_0)    info->V_0    =1/atof(parsing[15]);
-    if (parsing[16] && !info->rho)    info->rho    =atof(parsing[16]);
-    if (parsing[17] && !info->at_weight)     info->at_weight    =atof(parsing[17]);
-    if (parsing[18] && info->at_nb <= 1)  info->at_nb    =atof(parsing[18]);
-    if (parsing[19] && info->at_nb <= 1)  info->at_nb    =atof(parsing[19]);
-    for (i=0; i<=19; i++) if (parsing[i]) free(parsing[i]);
-    free(parsing);
-  }
-
-  if (!sTable.rows)
-    exit(fprintf(stderr, "PowderN: %s: Error: The number of rows in %s "
-          "should be at least %d\n", info->compname, SC_file, 1));
-  else
-    size = sTable.rows;
-
-  Table_Info(sTable);
-  printf("PowderN: %s: Reading %d rows from %s\n",
-      info->compname, size, SC_file);
-
-  if (info->column_order[0] == 4 && info->flag_barns !=0)
-    printf("PowderN: %s: Powder file probably of type Crystallographica/Fullprof (lau)\n"
-        "WARNING: but F2 unit is set to barns=1 (barns). Intensity might be 100 times too high.\n",
-        info->compname);
-  if (info->column_order[0] == 17 && info->flag_barns == 0)
-    printf("PowderN: %s: Powder file probably of type Lazy Pulver (laz)\n"
-        "WARNING: but F2 unit is set to barns=0 (fm^2). Intensity might be 100 times too low.\n",
-        info->compname);
-  /* allocate line_data array */
-  list = (struct line_data_union*) calloc(size, sizeof(struct line_data_union));
-
-  for (i=0; i<size; i++)
-  {
-    /*      printf("Reading in line %i\n",i);*/
-    double j=0, d=0, w=0, q=0, DWfactor=0, F2=0, Epsilon=0;
-    int index;
-
-    if (info->Dd >= 0)      w         = info->Dd;
-    if (info->DWfactor > 0) DWfactor  = info->DWfactor;
-    if (info->Epsilon)      Epsilon   = info->Epsilon*1e-6;
-
-    /* get data from table using columns {j d F2 DW Dd inv2d q F} */
-    /* column indexes start at 1, thus need to substract 1 */
-    if (info->column_order[0] >0)
-      j = Table_Index(sTable, i, info->column_order[0]-1);
-    if (info->column_order[1] >0)
-      d = Table_Index(sTable, i, info->column_order[1]-1);
-    if (info->column_order[2] >0)
-      F2 = Table_Index(sTable, i, info->column_order[2]-1);
-    if (info->column_order[3] >0)
-      DWfactor = Table_Index(sTable, i, info->column_order[3]-1);
-    if (info->column_order[4] >0)
-      w = Table_Index(sTable, i, info->column_order[4]-1);
-    if (info->column_order[5] >0 && !(info->column_order[1] >0)) // Only use if d not read already
-    { d = Table_Index(sTable, i, info->column_order[5]-1);
-      d = (d > 0? 1/d/2 : 0); }
-    if (info->column_order[6] >0 && !(info->column_order[1] >0)) // Only use if d not read already
-    { q = Table_Index(sTable, i, info->column_order[6]-1);
-      d = (q > 0 ? 2*PI/q : 0); }
-    if (info->column_order[7] >0  && !F2)
-    { F2 = Table_Index(sTable, i, info->column_order[7]-1); F2 *= F2; }
-    if (info->column_order[8] >0  && !Epsilon)
-    { Epsilon = Table_Index(sTable, i, info->column_order[8]-1)*1e-6; }
-
-    /* assign and check values */
-    j        = (j > 0 ? j : 0);
-    q        = (d > 0 ? 2*PI/d : 0); /* this is q */
-    if (Epsilon && fabs(Epsilon) < 1e6) {
-      q     -= Epsilon*q; /* dq/q = -delta_d_d/d = -Epsilon */
-    }
-    DWfactor = (DWfactor > 0 ? DWfactor : 1);
-    w        = (w>0 ? w : 0); /* this is q and d relative spreading */
-    F2       = (F2 >= 0 ? F2 : 0);
-    if (j == 0 || q == 0) {
-      printf("PowderN: %s: line %i has invalid definition\n"
-          "         (mult=0 or q=0 or d=0)\n", info->compname, i);
-      continue;
-    }
-    list[list_count].j = j;
-    list[list_count].q = q;
-    list[list_count].DWfactor = DWfactor;
-    list[list_count].w = w;
-    list[list_count].F2= F2;
-    list[list_count].Epsilon = Epsilon;
-    sum_F2 += F2;
-
-    /* adjust multiplicity if j-column + multiple d-spacing lines */
-    /* if  d = previous d, increase line duplication index */
-    if (!q_count)      q_count  = q;
-    if (!j_count)      j_count  = j;
-    if (!F2_count)     F2_count = F2;
-    if (fabs(q_count-q) < 0.0001*fabs(q)
-        && fabs(F2_count-F2) < 0.0001*fabs(F2) && j_count == j) {
-      mult_count++; flag=0; }
-    else flag=1;
-    if (i == size-1) flag=1;
-    /* else if d != previous d : just passed equivalent lines */
-    if (flag) {
-      if (i == size-1) list_count++;
-      /*   if duplication index == previous multiplicity */
-      /*      set back multiplicity of previous lines to 1 */
-      if ((mult_count && list_count>0)
-          && (mult_count == list[list_count-1].j
-            || ((list_count < size) && (i == size - 1)
-              && (mult_count == list[list_count].j))) ) {
-        printf("PowderN: %s: Set multiplicity to 1 for lines [%i:%i]\n"
-            "         (d-spacing %g is duplicated %i times)\n",
-            info->compname, list_count-mult_count, list_count-1, list[list_count-1].q, mult_count);
-        for (index=list_count-mult_count; index<list_count; list[index++].j = 1);
-        mult_count = 1;
-        q_count   = q;
-        j_count   = j;
-        F2_count  = F2;
-      }
-      if (i == size-1) list_count--;
-      flag=0;
-    }
-    list_count++;
-  } /* end for */
-
-  Table_Free(&sTable);
-
-  if (!sum_F2) {
-    MPI_MASTER(
-        fprintf(stderr, "PowderN: %s: ERROR: all %i structure factors in file '%s' are null. Check the reflection list.\n",
-          info->compname, list_count, SC_file);
-        );
-    return(0);
-  }
-
-  /* sort the list with increasing q */
-  qsort(list, list_count, sizeof(struct line_data_union),  PN_list_compare_union);
-
-  printf("PowderN: %s: Read %i reflections from file '%s'\n",
-      info->compname, list_count, SC_file);
-  // remove temporary F2(hkl) file when giving CFL/CIF/ShelX file
-  if (filename && filename != SC_file)
-    unlink(filename);
-
-  info->list  = list;
-  info->count = list_count;
-
-  return(list_count);
-} /* read_line_data_union */
-
-
-/* computes the number of possible reflections (return value), and the total xsection 'sum' */
-/* this routine looks for a pre-computed value in the Nq and sum cache tables               */
-/* when found, the earch starts from the corresponding lower element in the table           */
-int calc_xsect_union(double k, double *q, double *my_s_k2, int count, double *sum,
-    struct line_info_struct_union *line_info) {
-  int    Nq = 0, line=0, line0=0;
-  /*sinth for tthmax=180 is 1.*/
-  double sinth=1.0;//sin(DEG2RAD*tth_max*0.5);
-  *sum=0;
-
-  /* check if a line_info element has been recorded already - not on OpenACC */
-  if (k >= line_info->k_min && k <= line_info->k_max && line_info->photon_passed >= CHAR_BUF_LENGTH) {
-    line = (int)floor(k - line_info->k_min)*CHAR_BUF_LENGTH/(line_info->k_max - line_info->k_min);
-    Nq    = line_info->xs_Nq[line];
-    *sum  = line_info->xs_sum[line];
-    if (!Nq && *sum == 0) {
-      /* not yet set: we compute the sum up to the corresponding wavevector in the table cache */
-      double line_k = line_info->k_min + line*(line_info->k_max - line_info->k_min)/CHAR_BUF_LENGTH;
-      for(line0=0; line0<count; line0++) {
-        if (q[line0] <= 2*line_k*sinth) { /* q < 2*kf: restrict structural range */
-          *sum += my_s_k2[line0];
-          if (Nq < line0+1) Nq=line0+1; /* determine maximum line index which can scatter */
-        } else break;
-      }
-      line_info->xs_Nq[line] = Nq;
-      line_info->xs_sum[line]= *sum;
-      line_info->xs_compute++;
-    } else line_info->xs_reuse++;
-    line0 = Nq;
-  }
-
-  line_info->xs_calls++;
-
-  for(line=line0; line<count; line++) {
-    if (q[line] <= 2*k*sinth) { /* q < 2*kf: restrict structural range */
-      *sum += my_s_k2[line];
-      if (Nq < line+1) Nq=line+1; /* determine maximum line index which can scatter */
-    } else break;
-  }
-
-  return(Nq);
-} /* calc_xsect_union */
-
-struct Powder_physics_storage_struct{
-  // Variables that needs to be transferred between any of the following places:
-  // The initialize in this component
-  // The function for calculating my
-  // The function for calculating scattering
-
-  struct line_info_struct_union *line_info_storage;
-  double my_scattering;
-};
-
-// Function for calculating my in the Powder case
-int Powder_physics_my(double *my,double *k_initial, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
-  int method_switch = 1;
-  // For test
-  int line_v,line0,line,count;
-
-  // Should not interfer with the global variables
-  double kx = k_initial[0];
-  double ky = k_initial[1];
-  double kz = k_initial[2];
-
-  // Not sure one can do this, but I do not see why not
-  struct line_info_struct_union *line_info = data_transfer.pointer_to_a_Powder_physics_storage_struct->line_info_storage;
-
-  double k = sqrt(kx*kx + ky*ky + kz*kz);
-
-  //printf("line_info->k = %f, line_info->k_min = %f, line_info->k_max = %f, line_info->photon_passed = %f\n",line_info->k,line_info->k_min,line_info->k_max,line_info->photon_passed);
-  // Here the maximum and minimum v is recorded, should this be for scattering events or cross section calculations?
-  if (line_info->photon_passed < CHAR_BUF_LENGTH) {
-    if (k < line_info->k_min) line_info->k_min = k;
-    if (k > line_info->k_max) line_info->k_max = k;
-    line_info->photon_passed++;
-  }
-
-  if (method_switch == 1) {
-    // Here the cross section is calculated and stored
-    if ( fabs(k - line_info->k) < 1e-6) {
-      line_info->nb_reuses++;
-    } else {
-      //printf("calling crosssection calculation \n");
-      // int calc_xsect_union(double v, double *qv, double *my_sv2, int count, double *sum, struct line_info_struct *line_info)
-      line_info->Nq = calc_xsect_union(k, line_info->q, line_info->my_s_k2, line_info->count, &line_info->my_s_k2_sum, line_info);
-      line_info->k = k;
-      line_info->nb_refl += line_info->Nq;
-      line_info->nb_refl_count++;
-    }
-  } else {
-    if ( fabs(k - line_info->k) < 1e-6) {
-      line_info->nb_reuses++;
-    } else {
-      //printf("calling cross-section calculation \n");
-      if (k >= line_info->k_min && k <= line_info->k_max && line_info->photon_passed >= CHAR_BUF_LENGTH) {
-        line = (int)floor(k - line_info->k_min)*CHAR_BUF_LENGTH/(line_info->k_max - line_info->k_min);
-        line_info->Nq = line_info->xs_Nq[line];
-        line_info->my_s_k2_sum  = line_info->xs_sum[line];
-        if (!line_info->Nq && line_info->my_s_k2_sum == 0) {
-          /* not yet set: we compute the sum up to the corresponding wavenumber in the table cache */
-          double line_k = line_info->k_min + line*(line_info->k_max - line_info->k_min)/CHAR_BUF_LENGTH;
-          for(line0=0; line0<count; line0++) {
-            if (line_info->q[line0] <= 2*line_k) { /* q < 2*kf: restrict structural range */
-              line_info->my_s_k2_sum += line_info->my_s_k2[line0];
-              if (line_info->Nq < line0+1) line_info->Nq=line0+1; /* determine maximum line index which can scatter */
-            } else break;
-          }
-          line_info->xs_Nq[line] = line_info->Nq;
-          line_info->xs_sum[line]= line_info->my_s_k2_sum;
-          line_info->xs_compute++;
-          //printf("line_info->xs_Nq[line] = %f, line_info->xs_sum[line] = %f, line_info->xs_compute = %d\n",line_info->xs_Nq[line],line_info->xs_sum[line],line_info->xs_compute);
-        } else line_info->xs_reuse++;
-        line0 = line_info->Nq;
-      }
-
-      line_info->xs_calls++;
-
-      for(line=line0; line<count; line++) {
-        if (line_info->q[line] <= 2*k) { /* q < 2*kf: restrict structural range */
-          line_info->my_s_k2_sum += line_info->my_s_k2[line];
-          if (line_info->Nq < line+1) line_info->Nq=line+1; /* determine maximum line index which can scatter */
-        } else break;
-      }
-      line_info->k = k;
-      line_info->nb_refl += line_info->Nq;
-      line_info->nb_refl_count++;
-    }
-  }
-
-  *my = line_info->my_s_k2_sum/(k*k);
-  return 1;
-};
-
-int Powder_physics_scattering(double *k_final, double *k_initial, double *weight, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
-
-  struct line_info_struct_union *line_info = data_transfer.pointer_to_a_Powder_physics_storage_struct->line_info_storage;
-  //double vertical_angular_limit = data_transfer.pointer_to_a_Powder_physics_storage_struct->vertical_angular_limit;
-
-  double kx = k_initial[0];
-  double ky = k_initial[1];
-  double kz = k_initial[2];
-
-  double k = sqrt(kx*kx + ky*ky + kz*kz);
-
-
-
-  int line;
-  double arg;
-  double theta;
-  double alpha,alpha0;
-
-  double kout_x,kout_y,kout_z;
-  double tmp_kx,tmp_ky,tmp_kz;
-  double nx,ny,nz;
-  double my_s_n;
-
-  /* Coherent scattering branch identical to PowderN component*/
-  if (line_info->count > 0) {
-    /* choose line */
-    if (line_info->Nq > 1) line=floor(line_info->Nq*rand01());  /* Select between Nq powder lines */
-    else line = 0;
-    if (line_info->w[line])
-      arg = line_info->q[line]*(1+line_info->w[line]*randnorm())/(2.0*k);
+    if (!s)
+      return 0;
     else
-      arg = line_info->q[line]/(2.0*k);
-    my_s_n = line_info->my_s_k2[line]/(k*k);
-    if(fabs(arg) > 1)
-      return 0;                   /* No bragg scattering possible*/
-    theta = asin(arg);          /* Bragg scattering law */
+      return (s < 0 ? -1 : 1);
+  } /* PN_list_compare */
 
-    /* Choose point on Debye-Scherrer cone */
-    //        if (d_phi_thread)
-    //        { /* relate height of detector to the height on DS cone */
-    //            arg = sin(d_phi_thread*DEG2RAD/2)/sin(2*theta);
-    //            /* If full Debye-Scherrer cone is within d_phi, don't focus */
-    //            if (arg < -1 || arg > 1) d_phi_thread = 0;
-    //            /* Otherwise, determine alpha to rotate from scattering plane
-    //               into d_phi focusing area*/
-    //            else alpha = 2*asin(arg);
-    //        }
-    //
-    //           if (d_phi_thread) {
-    //            /* Focusing */
-    //            alpha = fabs(alpha);
-    //            /* Trick to get scattering for pos/neg theta's */
-    //            alpha0= 2*rand01()*alpha;
-    //            if (alpha0 > alpha) {
-    //                alpha0=M_PI+(alpha0-1.5*alpha);
-    //            } else {
-    //                alpha0=alpha0-0.5*alpha;
-    //            }
-    //            if(focus_flip){
-    //                alpha0+=M_PI_2;
-    //            }
-    //        }
-    //        else
+  #ifndef CIF2HKL
+  #define CIF2HKL
+  // hkl_filename = cif2hkl(file, options)
+  //   used to convert CIF/CFL/INS file into F2(hkl)
+  //   the CIF2HKL env var can point to a cif2hkl executable
+  //   else the McCode binary is attempted, then the system.
+  char*
+  cif2hkl (const char* infile, const char* options) {
+    char cmd[1024];
+    int ret = 0;
+    int found = 0;
+    char* OUTFILE;
 
-    alpha0 = M_PI*randpm1();
+    // get filename extension
+    const char* ext = strrchr (infile, '.');
+    if (!ext || ext == infile)
+      return infile;
+    else
+      ext++;
 
-    /* now find a nearly vertical rotation axis:
-     * Either
-     *  (k along Z) x (X axis) -> nearly Y axis
-     * Or
-     *  (k along X) x (Z axis) -> nearly Y axis
-     */
-    if (fabs(scalar_prod(1,0,0,kx,ky,kz)) < fabs(scalar_prod(0,0,1,kx,ky,kz))) {
-      nx = 1; ny = 0; nz = 0;
+    // return input when no extension or not a CIF/FullProf/ShelX file
+    if (strcasecmp (ext, "cif") && strcasecmp (ext, "pcr") && strcasecmp (ext, "cfl") && strcasecmp (ext, "shx") && strcasecmp (ext, "ins")
+        && strcasecmp (ext, "res"))
+      return infile;
+
+    OUTFILE = malloc (1024);
+    if (!OUTFILE)
+      return infile;
+
+    strncpy (OUTFILE, tmpnam (NULL), 1024); // create an output temporary file name
+
+    // try in order the CIF2HKL env var, then the system cif2hkl, then the McCode one
+    if (!found && getenv ("CIF2HKL")) {
+      snprintf (cmd, 1024, "%s -o %s %s %s", getenv ("CIF2HKL"), OUTFILE, options, infile);
+      ret = system (cmd);
+      if (ret != -1 && ret != 127)
+        found = 1;
+    }
+    if (!found) {
+      snprintf (cmd, 1024, "%s%c%s%c%s -o %s %s %s", getenv (FLAVOR_UPPER) ? getenv (FLAVOR_UPPER) : MCXTRACE, MC_PATHSEP_C, "bin", MC_PATHSEP_C, "cif2hkl",
+                OUTFILE, options, infile);
+      ret = system (cmd);
+      if (ret != -1 && ret != 127)
+        found = 1;
+    }
+    // ret = -1:  child process could not be created
+    // ret = 127: shell could not be executed in the child process
+    if (!found) {
+      // try with any cif2hkl command from the system
+      snprintf (cmd, 1024, "%s -o %s %s %s", "cif2hkl", OUTFILE, options, infile);
+      ret = system (cmd);
+    }
+
+    if (ret == -1 || ret == 127)
+      return (NULL);
+
+    // test if the result file has been created
+    FILE* file = fopen (OUTFILE, "r");
+    if (!file)
+      return (NULL);
+    MPI_MASTER (printf ("%s: INFO: Converting %s into F2(HKL) list %s\n", __FILE__, infile, OUTFILE); printf ("%s\n", cmd););
+    fflush (NULL);
+    return (OUTFILE);
+  } // cif2hkl
+  #endif
+
+  int
+  read_line_data_union (char* SC_file, struct line_info_struct_union* info) {
+    struct line_data_union* list = NULL;
+    int size = 0;
+    t_Table sTable; /* sample data table structure from SC_file */
+    int i = 0;
+    int mult_count = 0;
+    char flag = 0;
+    double q_count = 0, j_count = 0, F2_count = 0;
+    char** parsing;
+    int list_count = 0;
+    double sum_F2 = 0;
+    char* filename = NULL;
+
+    if (!SC_file || !strlen (SC_file) || !strcmp (SC_file, "NULL")) {
+      printf ("PowderN: %s: Using incoherent elastic scattering only.\n", info->compname);
+      info->count = 0;
+      return (0);
+    }
+    filename = cif2hkl (SC_file, "--mode XRA");
+    long retval = Table_Read (&sTable, filename, 1); /* read 1st block data from SC_file into sTable*/
+    if (retval < 0) {
+      fprintf (stderr, "PowderN: Could not open file %s - exiting!\n", filename);
+      exit (-1);
+    }
+
+    /* parsing of header */
+    parsing = Table_ParseHeader (sTable.header, "Vc", "V_0", "column_j", "column_d", "column_F2", "column_DW", "column_Dd", "column_inv2d", "column_1/2d",
+                                 "column_sintheta/lambda", "column_q", /* 10 */
+                                 "DW", "Debye_Waller", "delta_d/d", "column_F ", "V_rho", "density", "weight", "nb_atoms", "multiplicity", NULL);
+
+    if (parsing) {
+      if (parsing[0] && !info->V_0)
+        info->V_0 = atof (parsing[0]);
+      if (parsing[1] && !info->V_0)
+        info->V_0 = atof (parsing[1]);
+      if (parsing[2])
+        info->column_order[0] = atoi (parsing[2]);
+      if (parsing[3])
+        info->column_order[1] = atoi (parsing[3]);
+      if (parsing[4])
+        info->column_order[2] = atoi (parsing[4]);
+      if (parsing[5])
+        info->column_order[3] = atoi (parsing[5]);
+      if (parsing[6])
+        info->column_order[4] = atoi (parsing[6]);
+      if (parsing[7])
+        info->column_order[5] = atoi (parsing[7]);
+      if (parsing[8])
+        info->column_order[5] = atoi (parsing[8]);
+      if (parsing[9])
+        info->column_order[5] = atoi (parsing[9]);
+      if (parsing[10])
+        info->column_order[6] = atoi (parsing[10]);
+      if (parsing[11] && info->DWfactor <= 0)
+        info->DWfactor = atof (parsing[11]);
+      if (parsing[12] && info->DWfactor <= 0)
+        info->DWfactor = atof (parsing[12]);
+      if (parsing[13] && info->Dd < 0)
+        info->Dd = atof (parsing[13]);
+      if (parsing[14])
+        info->column_order[7] = atoi (parsing[14]);
+      if (parsing[15] && !info->V_0)
+        info->V_0 = 1 / atof (parsing[15]);
+      if (parsing[16] && !info->rho)
+        info->rho = atof (parsing[16]);
+      if (parsing[17] && !info->at_weight)
+        info->at_weight = atof (parsing[17]);
+      if (parsing[18] && info->at_nb <= 1)
+        info->at_nb = atof (parsing[18]);
+      if (parsing[19] && info->at_nb <= 1)
+        info->at_nb = atof (parsing[19]);
+      for (i = 0; i <= 19; i++)
+        if (parsing[i])
+          free (parsing[i]);
+      free (parsing);
+    }
+
+    if (!sTable.rows)
+      exit (fprintf (stderr,
+                     "PowderN: %s: Error: The number of rows in %s "
+                     "should be at least %d\n",
+                     info->compname, SC_file, 1));
+    else
+      size = sTable.rows;
+
+    Table_Info (sTable);
+    printf ("PowderN: %s: Reading %d rows from %s\n", info->compname, size, SC_file);
+
+    if (info->column_order[0] == 4 && info->flag_barns != 0)
+      printf ("PowderN: %s: Powder file probably of type Crystallographica/Fullprof (lau)\n"
+              "WARNING: but F2 unit is set to barns=1 (barns). Intensity might be 100 times too high.\n",
+              info->compname);
+    if (info->column_order[0] == 17 && info->flag_barns == 0)
+      printf ("PowderN: %s: Powder file probably of type Lazy Pulver (laz)\n"
+              "WARNING: but F2 unit is set to barns=0 (fm^2). Intensity might be 100 times too low.\n",
+              info->compname);
+    /* allocate line_data array */
+    list = (struct line_data_union*)calloc (size, sizeof (struct line_data_union));
+
+    for (i = 0; i < size; i++) {
+      /*      printf("Reading in line %i\n",i);*/
+      double j = 0, d = 0, w = 0, q = 0, DWfactor = 0, F2 = 0, Epsilon = 0;
+      int index;
+
+      if (info->Dd >= 0)
+        w = info->Dd;
+      if (info->DWfactor > 0)
+        DWfactor = info->DWfactor;
+      if (info->Epsilon)
+        Epsilon = info->Epsilon * 1e-6;
+
+      /* get data from table using columns {j d F2 DW Dd inv2d q F} */
+      /* column indexes start at 1, thus need to substract 1 */
+      if (info->column_order[0] > 0)
+        j = Table_Index (sTable, i, info->column_order[0] - 1);
+      if (info->column_order[1] > 0)
+        d = Table_Index (sTable, i, info->column_order[1] - 1);
+      if (info->column_order[2] > 0)
+        F2 = Table_Index (sTable, i, info->column_order[2] - 1);
+      if (info->column_order[3] > 0)
+        DWfactor = Table_Index (sTable, i, info->column_order[3] - 1);
+      if (info->column_order[4] > 0)
+        w = Table_Index (sTable, i, info->column_order[4] - 1);
+      if (info->column_order[5] > 0 && !(info->column_order[1] > 0)) // Only use if d not read already
+      {
+        d = Table_Index (sTable, i, info->column_order[5] - 1);
+        d = (d > 0 ? 1 / d / 2 : 0);
+      }
+      if (info->column_order[6] > 0 && !(info->column_order[1] > 0)) // Only use if d not read already
+      {
+        q = Table_Index (sTable, i, info->column_order[6] - 1);
+        d = (q > 0 ? 2 * PI / q : 0);
+      }
+      if (info->column_order[7] > 0 && !F2) {
+        F2 = Table_Index (sTable, i, info->column_order[7] - 1);
+        F2 *= F2;
+      }
+      if (info->column_order[8] > 0 && !Epsilon) {
+        Epsilon = Table_Index (sTable, i, info->column_order[8] - 1) * 1e-6;
+      }
+
+      /* assign and check values */
+      j = (j > 0 ? j : 0);
+      q = (d > 0 ? 2 * PI / d : 0); /* this is q */
+      if (Epsilon && fabs (Epsilon) < 1e6) {
+        q -= Epsilon * q; /* dq/q = -delta_d_d/d = -Epsilon */
+      }
+      DWfactor = (DWfactor > 0 ? DWfactor : 1);
+      w = (w > 0 ? w : 0); /* this is q and d relative spreading */
+      F2 = (F2 >= 0 ? F2 : 0);
+      if (j == 0 || q == 0) {
+        printf ("PowderN: %s: line %i has invalid definition\n"
+                "         (mult=0 or q=0 or d=0)\n",
+                info->compname, i);
+        continue;
+      }
+      list[list_count].j = j;
+      list[list_count].q = q;
+      list[list_count].DWfactor = DWfactor;
+      list[list_count].w = w;
+      list[list_count].F2 = F2;
+      list[list_count].Epsilon = Epsilon;
+      sum_F2 += F2;
+
+      /* adjust multiplicity if j-column + multiple d-spacing lines */
+      /* if  d = previous d, increase line duplication index */
+      if (!q_count)
+        q_count = q;
+      if (!j_count)
+        j_count = j;
+      if (!F2_count)
+        F2_count = F2;
+      if (fabs (q_count - q) < 0.0001 * fabs (q) && fabs (F2_count - F2) < 0.0001 * fabs (F2) && j_count == j) {
+        mult_count++;
+        flag = 0;
+      } else
+        flag = 1;
+      if (i == size - 1)
+        flag = 1;
+      /* else if d != previous d : just passed equivalent lines */
+      if (flag) {
+        if (i == size - 1)
+          list_count++;
+        /*   if duplication index == previous multiplicity */
+        /*      set back multiplicity of previous lines to 1 */
+        if ((mult_count && list_count > 0)
+            && (mult_count == list[list_count - 1].j || ((list_count < size) && (i == size - 1) && (mult_count == list[list_count].j)))) {
+          printf ("PowderN: %s: Set multiplicity to 1 for lines [%i:%i]\n"
+                  "         (d-spacing %g is duplicated %i times)\n",
+                  info->compname, list_count - mult_count, list_count - 1, list[list_count - 1].q, mult_count);
+          for (index = list_count - mult_count; index < list_count; list[index++].j = 1)
+            ;
+          mult_count = 1;
+          q_count = q;
+          j_count = j;
+          F2_count = F2;
+        }
+        if (i == size - 1)
+          list_count--;
+        flag = 0;
+      }
+      list_count++;
+    } /* end for */
+
+    Table_Free (&sTable);
+
+    if (!sum_F2) {
+      MPI_MASTER (fprintf (stderr, "PowderN: %s: ERROR: all %i structure factors in file '%s' are null. Check the reflection list.\n", info->compname, list_count,
+                           SC_file););
+      return (0);
+    }
+
+    /* sort the list with increasing q */
+    qsort (list, list_count, sizeof (struct line_data_union), PN_list_compare_union);
+
+    printf ("PowderN: %s: Read %i reflections from file '%s'\n", info->compname, list_count, SC_file);
+    // remove temporary F2(hkl) file when giving CFL/CIF/ShelX file
+    if (filename && filename != SC_file)
+      unlink (filename);
+
+    info->list = list;
+    info->count = list_count;
+
+    return (list_count);
+  } /* read_line_data_union */
+
+  /* computes the number of possible reflections (return value), and the total xsection 'sum' */
+  /* this routine looks for a pre-computed value in the Nq and sum cache tables               */
+  /* when found, the earch starts from the corresponding lower element in the table           */
+  int
+  calc_xsect_union (double k, double* q, double* my_s_k2, int count, double* sum, struct line_info_struct_union* line_info) {
+    int Nq = 0, line = 0, line0 = 0;
+    /*sinth for tthmax=180 is 1.*/
+    double sinth = 1.0; // sin(DEG2RAD*tth_max*0.5);
+    *sum = 0;
+
+    /* check if a line_info element has been recorded already - not on OpenACC */
+    if (k >= line_info->k_min && k <= line_info->k_max && line_info->photon_passed >= CHAR_BUF_LENGTH) {
+      line = (int)floor (k - line_info->k_min) * CHAR_BUF_LENGTH / (line_info->k_max - line_info->k_min);
+      Nq = line_info->xs_Nq[line];
+      *sum = line_info->xs_sum[line];
+      if (!Nq && *sum == 0) {
+        /* not yet set: we compute the sum up to the corresponding wavevector in the table cache */
+        double line_k = line_info->k_min + line * (line_info->k_max - line_info->k_min) / CHAR_BUF_LENGTH;
+        for (line0 = 0; line0 < count; line0++) {
+          if (q[line0] <= 2 * line_k * sinth) { /* q < 2*kf: restrict structural range */
+            *sum += my_s_k2[line0];
+            if (Nq < line0 + 1)
+              Nq = line0 + 1; /* determine maximum line index which can scatter */
+          } else
+            break;
+        }
+        line_info->xs_Nq[line] = Nq;
+        line_info->xs_sum[line] = *sum;
+        line_info->xs_compute++;
+      } else
+        line_info->xs_reuse++;
+      line0 = Nq;
+    }
+
+    line_info->xs_calls++;
+
+    for (line = line0; line < count; line++) {
+      if (q[line] <= 2 * k * sinth) { /* q < 2*kf: restrict structural range */
+        *sum += my_s_k2[line];
+        if (Nq < line + 1)
+          Nq = line + 1; /* determine maximum line index which can scatter */
+      } else
+        break;
+    }
+
+    return (Nq);
+  } /* calc_xsect_union */
+
+  struct Powder_physics_storage_struct {
+    // Variables that needs to be transferred between any of the following places:
+    // The initialize in this component
+    // The function for calculating my
+    // The function for calculating scattering
+
+    struct line_info_struct_union* line_info_storage;
+    double my_scattering;
+  };
+
+  // Function for calculating my in the Powder case
+  int
+  Powder_physics_my (double* my, double* k_initial, union data_transfer_union data_transfer, struct focus_data_struct* focus_data, _class_particle* _particle) {
+    int method_switch = 1;
+    // For test
+    int line_v, line0, line, count;
+
+    // Should not interfer with the global variables
+    double kx = k_initial[0];
+    double ky = k_initial[1];
+    double kz = k_initial[2];
+
+    // Not sure one can do this, but I do not see why not
+    struct line_info_struct_union* line_info = data_transfer.pointer_to_a_Powder_physics_storage_struct->line_info_storage;
+
+    double k = sqrt (kx * kx + ky * ky + kz * kz);
+
+    // printf("line_info->k = %f, line_info->k_min = %f, line_info->k_max = %f, line_info->photon_passed =
+    // %f\n",line_info->k,line_info->k_min,line_info->k_max,line_info->photon_passed);
+    //  Here the maximum and minimum v is recorded, should this be for scattering events or cross section calculations?
+    if (line_info->photon_passed < CHAR_BUF_LENGTH) {
+      if (k < line_info->k_min)
+        line_info->k_min = k;
+      if (k > line_info->k_max)
+        line_info->k_max = k;
+      line_info->photon_passed++;
+    }
+
+    if (method_switch == 1) {
+      // Here the cross section is calculated and stored
+      if (fabs (k - line_info->k) < 1e-6) {
+        line_info->nb_reuses++;
+      } else {
+        // printf("calling crosssection calculation \n");
+        //  int calc_xsect_union(double v, double *qv, double *my_sv2, int count, double *sum, struct line_info_struct *line_info)
+        line_info->Nq = calc_xsect_union (k, line_info->q, line_info->my_s_k2, line_info->count, &line_info->my_s_k2_sum, line_info);
+        line_info->k = k;
+        line_info->nb_refl += line_info->Nq;
+        line_info->nb_refl_count++;
+      }
     } else {
-      nx = 0; ny = 0; nz = 1;
+      if (fabs (k - line_info->k) < 1e-6) {
+        line_info->nb_reuses++;
+      } else {
+        // printf("calling cross-section calculation \n");
+        if (k >= line_info->k_min && k <= line_info->k_max && line_info->photon_passed >= CHAR_BUF_LENGTH) {
+          line = (int)floor (k - line_info->k_min) * CHAR_BUF_LENGTH / (line_info->k_max - line_info->k_min);
+          line_info->Nq = line_info->xs_Nq[line];
+          line_info->my_s_k2_sum = line_info->xs_sum[line];
+          if (!line_info->Nq && line_info->my_s_k2_sum == 0) {
+            /* not yet set: we compute the sum up to the corresponding wavenumber in the table cache */
+            double line_k = line_info->k_min + line * (line_info->k_max - line_info->k_min) / CHAR_BUF_LENGTH;
+            for (line0 = 0; line0 < count; line0++) {
+              if (line_info->q[line0] <= 2 * line_k) { /* q < 2*kf: restrict structural range */
+                line_info->my_s_k2_sum += line_info->my_s_k2[line0];
+                if (line_info->Nq < line0 + 1)
+                  line_info->Nq = line0 + 1; /* determine maximum line index which can scatter */
+              } else
+                break;
+            }
+            line_info->xs_Nq[line] = line_info->Nq;
+            line_info->xs_sum[line] = line_info->my_s_k2_sum;
+            line_info->xs_compute++;
+            // printf("line_info->xs_Nq[line] = %f, line_info->xs_sum[line] = %f, line_info->xs_compute =
+            // %d\n",line_info->xs_Nq[line],line_info->xs_sum[line],line_info->xs_compute);
+          } else
+            line_info->xs_reuse++;
+          line0 = line_info->Nq;
+        }
+
+        line_info->xs_calls++;
+
+        for (line = line0; line < count; line++) {
+          if (line_info->q[line] <= 2 * k) { /* q < 2*kf: restrict structural range */
+            line_info->my_s_k2_sum += line_info->my_s_k2[line];
+            if (line_info->Nq < line + 1)
+              line_info->Nq = line + 1; /* determine maximum line index which can scatter */
+          } else
+            break;
+        }
+        line_info->k = k;
+        line_info->nb_refl += line_info->Nq;
+        line_info->nb_refl_count++;
+      }
     }
-    vec_prod(tmp_kx,tmp_ky,tmp_kz, kx/k,ky/k,kz/k, nx,ny,nz);
 
-    /* k_out = rotate 'k' by 2*theta around tmp_k: Bragg angle */
-    rotate(kout_x,kout_y,kout_z, kx/k,ky/k,kz/k, 2*theta, tmp_kx,tmp_ky,tmp_kz);
+    *my = line_info->my_s_k2_sum / (k * k);
+    return 1;
+  };
 
-    /* tmp_k = rotate k_out by alpha0 around 'k' (Debye-Scherrer cone) */
-    rotate(tmp_kx,tmp_ky,tmp_kz, kout_x,kout_y,kout_z, alpha0, kx, ky, kz);
-    kx = tmp_kx*k;
-    ky = tmp_ky*k;
-    kz = tmp_kz*k;
+  int
+  Powder_physics_scattering (double* k_final, double* k_initial, double* weight, union data_transfer_union data_transfer, struct focus_data_struct* focus_data,
+                             _class_particle* _particle) {
 
-    /*weight the outgoing signal according to polarization*/
-    if (_particle->Ex!=0 || _particle->Ey!=0 || _particle->Ez!=0){
-      double EE=sqrt(_particle->Ex*_particle->Ex + _particle->Ey*_particle->Ey + _particle->Ez*_particle->Ez);
-      double s=scalar_prod(kx,ky,kz,_particle->Ex,_particle->Ey,_particle->Ez)/k/EE;
-      *weight *=(1-s)*(1-s);
-    }else{
-      /*unpolarized light in - means an effective reduction according to only theta*/
-      *weight *=(1+cos(theta)*cos(theta))*0.5;
+    struct line_info_struct_union* line_info = data_transfer.pointer_to_a_Powder_physics_storage_struct->line_info_storage;
+    // double vertical_angular_limit = data_transfer.pointer_to_a_Powder_physics_storage_struct->vertical_angular_limit;
+
+    double kx = k_initial[0];
+    double ky = k_initial[1];
+    double kz = k_initial[2];
+
+    double k = sqrt (kx * kx + ky * ky + kz * kz);
+
+    int line;
+    double arg;
+    double theta;
+    double alpha, alpha0;
+
+    double kout_x, kout_y, kout_z;
+    double tmp_kx, tmp_ky, tmp_kz;
+    double nx, ny, nz;
+    double my_s_n;
+
+    /* Coherent scattering branch identical to PowderN component*/
+    if (line_info->count > 0) {
+      /* choose line */
+      if (line_info->Nq > 1)
+        line = floor (line_info->Nq * rand01 ()); /* Select between Nq powder lines */
+      else
+        line = 0;
+      if (line_info->w[line])
+        arg = line_info->q[line] * (1 + line_info->w[line] * randnorm ()) / (2.0 * k);
+      else
+        arg = line_info->q[line] / (2.0 * k);
+      my_s_n = line_info->my_s_k2[line] / (k * k);
+      if (fabs (arg) > 1)
+        return 0;         /* No bragg scattering possible*/
+      theta = asin (arg); /* Bragg scattering law */
+
+      /* Choose point on Debye-Scherrer cone */
+      //        if (d_phi_thread)
+      //        { /* relate height of detector to the height on DS cone */
+      //            arg = sin(d_phi_thread*DEG2RAD/2)/sin(2*theta);
+      //            /* If full Debye-Scherrer cone is within d_phi, don't focus */
+      //            if (arg < -1 || arg > 1) d_phi_thread = 0;
+      //            /* Otherwise, determine alpha to rotate from scattering plane
+      //               into d_phi focusing area*/
+      //            else alpha = 2*asin(arg);
+      //        }
+      //
+      //           if (d_phi_thread) {
+      //            /* Focusing */
+      //            alpha = fabs(alpha);
+      //            /* Trick to get scattering for pos/neg theta's */
+      //            alpha0= 2*rand01()*alpha;
+      //            if (alpha0 > alpha) {
+      //                alpha0=M_PI+(alpha0-1.5*alpha);
+      //            } else {
+      //                alpha0=alpha0-0.5*alpha;
+      //            }
+      //            if(focus_flip){
+      //                alpha0+=M_PI_2;
+      //            }
+      //        }
+      //        else
+
+      alpha0 = M_PI * randpm1 ();
+
+      /* now find a nearly vertical rotation axis:
+       * Either
+       *  (k along Z) x (X axis) -> nearly Y axis
+       * Or
+       *  (k along X) x (Z axis) -> nearly Y axis
+       */
+      if (fabs (scalar_prod (1, 0, 0, kx, ky, kz)) < fabs (scalar_prod (0, 0, 1, kx, ky, kz))) {
+        nx = 1;
+        ny = 0;
+        nz = 0;
+      } else {
+        nx = 0;
+        ny = 0;
+        nz = 1;
+      }
+      vec_prod (tmp_kx, tmp_ky, tmp_kz, kx / k, ky / k, kz / k, nx, ny, nz);
+
+      /* k_out = rotate 'k' by 2*theta around tmp_k: Bragg angle */
+      rotate (kout_x, kout_y, kout_z, kx / k, ky / k, kz / k, 2 * theta, tmp_kx, tmp_ky, tmp_kz);
+
+      /* tmp_k = rotate k_out by alpha0 around 'k' (Debye-Scherrer cone) */
+      rotate (tmp_kx, tmp_ky, tmp_kz, kout_x, kout_y, kout_z, alpha0, kx, ky, kz);
+      kx = tmp_kx * k;
+      ky = tmp_ky * k;
+      kz = tmp_kz * k;
+
+      /*weight the outgoing signal according to polarization*/
+      if (_particle->Ex != 0 || _particle->Ey != 0 || _particle->Ez != 0) {
+        double EE = sqrt (_particle->Ex * _particle->Ex + _particle->Ey * _particle->Ey + _particle->Ez * _particle->Ez);
+        double s = scalar_prod (kx, ky, kz, _particle->Ex, _particle->Ey, _particle->Ez) / k / EE;
+        *weight *= (1 - s) * (1 - s);
+      } else {
+        /*unpolarized light in - means an effective reduction according to only theta*/
+        *weight *= (1 + cos (theta) * cos (theta)) * 0.5;
+      }
+
+      k_final[0] = kx;
+      k_final[1] = ky;
+      k_final[2] = kz;
+
+      //*weight *= line_info->Nq*my_s_n; //I believe my_s_n is part of the correction for sampling posistion, not to be done here
+      *weight *= line_info->Nq * my_s_n / (line_info->my_s_k2_sum / (k * k));
+      /* Correction in case of d_phi focusing - BUT only when d_phi != 0 */
+      //        if (d_phi_thread) pmul *= alpha/PI;
+
+      line_info->type = 'c';
+      line_info->dq = line_info->q[line];
+
+    } else {
+      /* else transmit <-- No powder lines in file */
+      printf ("Error, need lines in the PowderN input file\n");
     }
+    return 1;
+  };
+  #ifndef PROCESS_DETECTOR
+  #define PROCESS_DETECTOR dummy
+  #endif
 
-    k_final[0] = kx; k_final[1] = ky; k_final[2] = kz;
-
-    //*weight *= line_info->Nq*my_s_n; //I believe my_s_n is part of the correction for sampling posistion, not to be done here
-    *weight *= line_info->Nq * my_s_n /( line_info->my_s_k2_sum /(k*k) );
-    /* Correction in case of d_phi focusing - BUT only when d_phi != 0 */
-    //        if (d_phi_thread) pmul *= alpha/PI;
-
-    line_info->type = 'c';
-    line_info->dq = line_info->q[line];
-
-  } else {
-    /* else transmit <-- No powder lines in file */
-    printf("Error, need lines in the PowderN input file\n");
-  }
-  return 1;
-};
-#ifndef PROCESS_DETECTOR
-    #define PROCESS_DETECTOR dummy
-#endif
-
-#ifndef PROCESS_POWDER_DETECTOR
-    #define PROCESS_POWDER_DETECTOR dummy
-#endif
+  #ifndef PROCESS_POWDER_DETECTOR
+  #define PROCESS_POWDER_DETECTOR dummy
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_process_element_struct global_process_element;
-struct scattering_process_struct This_process;
+  // Needed for transport to the main component
+  struct global_process_element_struct global_process_element;
+  struct scattering_process_struct This_process;
 
-// Declare for this component, to do calculations on the input / store in the transported data
-struct Powder_physics_storage_struct Powder_storage;
-struct line_info_struct_union line_info;
-double effective_my_scattering;
+  // Declare for this component, to do calculations on the input / store in the transported data
+  struct Powder_physics_storage_struct Powder_storage;
+  struct line_info_struct_union line_info;
+  double effective_my_scattering;
 
-double *columns;
-double *mat_columns;
+  double* columns;
+  double* mat_columns;
 %}
 
 INITIALIZE
@@ -696,61 +734,65 @@ INITIALIZE
   // Initialize done in the component
   Powder_storage.my_scattering = effective_my_scattering;
   columns = format;
-  mat_columns =  mat_format;
-  int i=0;
-  struct line_data_union *L;
-  line_info.Dd       = delta_d_d;
+  mat_columns = mat_format;
+  int i = 0;
+  struct line_data_union* L;
+  line_info.Dd = delta_d_d;
   line_info.DWfactor = DW;
-  line_info.V_0      = Vc;
-  line_info.rho      = density;
-  line_info.at_weight= weight;
-  line_info.at_nb    = nb_atoms;
-  line_info.flag_barns=barns;
-  line_info.flag_warning=0;
-  line_info.radius_i =line_info.xwidth_i=line_info.yheight_i=line_info.zdepth_i=0;
-  line_info.k  = 0;
+  line_info.V_0 = Vc;
+  line_info.rho = density;
+  line_info.at_weight = weight;
+  line_info.at_nb = nb_atoms;
+  line_info.flag_barns = barns;
+  line_info.flag_warning = 0;
+  line_info.radius_i = line_info.xwidth_i = line_info.yheight_i = line_info.zdepth_i = 0;
+  line_info.k = 0;
   line_info.Nq = 0;
-  line_info.k_min = FLT_MAX; line_info.k_max = 0;
-  line_info.photon_passed=0;
+  line_info.k_min = FLT_MAX;
+  line_info.k_max = 0;
+  line_info.photon_passed = 0;
   line_info.nb_reuses = line_info.nb_refl = line_info.nb_refl_count = 0;
-  line_info.xs_compute= line_info.xs_reuse= line_info.xs_calls =0;
-  for (i=0; i< 8; i++) {
+  line_info.xs_compute = line_info.xs_reuse = line_info.xs_calls = 0;
+  for (i = 0; i < 8; i++) {
     line_info.column_order[i] = (int)columns[i];
   }
-  for (i=0; i< 4;  i++) {
+  for (i = 0; i < 4; i++) {
     line_info.mat_column_order[i] = (int)mat_columns[i];
   }
-  strncpy(line_info.compname, NAME_CURRENT_COMP, 256);
+  strncpy (line_info.compname, NAME_CURRENT_COMP, 256);
 
-  if (reflections && strlen(reflections) && strcmp(reflections, "NULL") && strcmp(reflections, "0")) {
-    i = read_line_data_union(reflections, &line_info);
+  if (reflections && strlen (reflections) && strcmp (reflections, "NULL") && strcmp (reflections, "0")) {
+    i = read_line_data_union (reflections, &line_info);
     if (i == 0)
-      exit(fprintf(stderr,"Powder_process %s: reflection file %s is not valid.\n"
-                          "ERROR    Please check file format.\n", NAME_CURRENT_COMP, reflections));
+      exit (fprintf (stderr,
+                     "Powder_process %s: reflection file %s is not valid.\n"
+                     "ERROR    Please check file format.\n",
+                     NAME_CURRENT_COMP, reflections));
   }
 
   /* compute the scattering unit density from material weight and density */
   /* the weight of the scattering element is the chemical formula molecular weight
    * times the nb of chemical formulae in the scattering element (nb_atoms) */
-  if (!line_info.V_0 && line_info.at_nb > 0
-    && line_info.at_weight > 0 && line_info.rho > 0) {
+  if (!line_info.V_0 && line_info.at_nb > 0 && line_info.at_weight > 0 && line_info.rho > 0) {
     /* molar volume [cm^3/mol] = weight [g/mol] / density [g/cm^3] */
     /* atom density per Angs^3 = [mol/cm^3] * N_Avogadro *(1e-8)^3 */
-    line_info.V_0 = line_info.at_nb
-      /(line_info.rho/line_info.at_weight/1e24*6.02214199e23);
+    line_info.V_0 = line_info.at_nb / (line_info.rho / line_info.at_weight / 1e24 * 6.02214199e23);
   }
 
   /* the scattering unit cross sections are the chemical formula onces
    * times the nb of chemical formulae in the scattering element */
   if (line_info.at_nb > 0) {
-    line_info.sigma_a *= line_info.at_nb; line_info.sigma_i *= line_info.at_nb;
+    line_info.sigma_a *= line_info.at_nb;
+    line_info.sigma_i *= line_info.at_nb;
   }
 
-  if (line_info.sigma_a<0) line_info.sigma_a=0;
-  if (line_info.sigma_i<0) line_info.sigma_i=0;
+  if (line_info.sigma_a < 0)
+    line_info.sigma_a = 0;
+  if (line_info.sigma_i < 0)
+    line_info.sigma_i = 0;
 
   if (line_info.V_0 <= 0)
-    fprintf(stderr,"PowderN: %s: density/unit cell volume is NULL (Vc). Deactivating component.\n", NAME_CURRENT_COMP);
+    fprintf (stderr, "PowderN: %s: density/unit cell volume is NULL (Vc). Deactivating component.\n", NAME_CURRENT_COMP);
 
   if (line_info.flag_barns) { /* Factor 100 to convert from barns to fm^2 */
     line_info.XsectionFactor = 100;
@@ -761,46 +803,45 @@ INITIALIZE
   if (line_info.V_0 > 0 && i) {
     L = line_info.list;
 
-    line_info.q = malloc(line_info.count*sizeof(double));
-    line_info.w = malloc(line_info.count*sizeof(double));
-    line_info.my_s_k2 = malloc(line_info.count*sizeof(double));
+    line_info.q = malloc (line_info.count * sizeof (double));
+    line_info.w = malloc (line_info.count * sizeof (double));
+    line_info.my_s_k2 = malloc (line_info.count * sizeof (double));
     if (!line_info.q || !line_info.w || !line_info.my_s_k2)
-      exit(fprintf(stderr,"PowderN: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
-    for(i=0; i<line_info.count; i++)
-    {
-        line_info.my_s_k2[i] = 4*PI*PI*PI*packing_factor*(L[i].DWfactor ? L[i].DWfactor : 1)
-                 /(line_info.V_0*line_info.V_0)
-                 *(L[i].j * L[i].F2 / L[i].q)*line_info.XsectionFactor;
+      exit (fprintf (stderr, "PowderN: %s: ERROR allocating memory (init)\n", NAME_CURRENT_COMP));
+    for (i = 0; i < line_info.count; i++) {
+      line_info.my_s_k2[i] = 4 * PI * PI * PI * packing_factor * (L[i].DWfactor ? L[i].DWfactor : 1) / (line_info.V_0 * line_info.V_0)
+                             * (L[i].j * L[i].F2 / L[i].q) * line_info.XsectionFactor;
       line_info.q[i] = L[i].q;
       line_info.w[i] = L[i].w;
     }
   }
 
-  if (material && strlen(material) && strcmp(material, "NULL")) {
+  if (material && strlen (material) && strcmp (material, "NULL")) {
     int status;
-    char **parsing;
-    if( (status=Table_Read(&(line_info.mat_table),material,0))==-1){
-       fprintf(stderr,"PowderN: %s Error reading material data from file %s.\n",NAME_CURRENT_COMP,material);
+    char** parsing;
+    if ((status = Table_Read (&(line_info.mat_table), material, 0)) == -1) {
+      fprintf (stderr, "PowderN: %s Error reading material data from file %s.\n", NAME_CURRENT_COMP, material);
     }
-    parsing=Table_ParseHeader(line_info.mat_table.header,
-       "column_e","column_abs","column_inc","column_cohinc","column_tot",NULL);
+    parsing = Table_ParseHeader (line_info.mat_table.header, "column_e", "column_abs", "column_inc", "column_cohinc", "column_tot", NULL);
 
-    if (parsing){
+    if (parsing) {
       int i;
-      for (i=0;i<5;i++){
-        if (parsing[i]) line_info.mat_column_order[i]=atoi(parsing[i]);
+      for (i = 0; i < 5; i++) {
+        if (parsing[i])
+          line_info.mat_column_order[i] = atoi (parsing[i]);
       }
     }
   }
 
-  //printf("INTIALIZE line_info.v = %f, line_info.v_min = %f, line_info.v_max = %f, line_info.neutron_passed = %f\n",line_info.v,line_info.v_min,line_info.v_max,line_info.neutron_passed);
+  // printf("INTIALIZE line_info.v = %f, line_info.v_min = %f, line_info.v_max = %f, line_info.neutron_passed =
+  // %f\n",line_info.v,line_info.v_min,line_info.v_max,line_info.neutron_passed);
 
   Powder_storage.line_info_storage = &line_info;
-  //Powder_storage.vertical_angular_limit = d_phi;
+  // Powder_storage.vertical_angular_limit = d_phi;
 
   // Need to specify if this process is isotropic
   This_process.non_isotropic_rot_index = -1; // Yes (powder)
-  //This_process.non_isotropic_rot_index =  1;  // No (single crystal)
+  // This_process.non_isotropic_rot_index =  1;  // No (single crystal)
 
   // The type of the process must be saved in the global enum process
   This_process.eProcess = Powder;
@@ -813,14 +854,14 @@ INITIALIZE
 
   // This will be the same for all process's, and can thus be moved to an include.
   This_process.process_p_interact = interact_fraction;
-  sprintf(This_process.name,NAME_CURRENT_COMP);
-  rot_copy(This_process.rotation_matrix,ROT_A_CURRENT_COMP);
-  sprintf(global_process_element.name,NAME_CURRENT_COMP);
+  sprintf (This_process.name, NAME_CURRENT_COMP);
+  rot_copy (This_process.rotation_matrix, ROT_A_CURRENT_COMP);
+  sprintf (global_process_element.name, NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  struct pointer_to_global_process_list *global_process_list = &g_process_list;
-  add_element_to_process_list(global_process_list, global_process_element);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  add_element_to_process_list (global_process_list, global_process_element);
 %}
 
 TRACE
@@ -829,10 +870,10 @@ TRACE
 
 FINALLY
 %{
-  free(line_info.list);
-  free(line_info.q);
-  free(line_info.w);
-  free(line_info.my_s_k2);
+  free (line_info.list);
+  free (line_info.q);
+  free (line_info.w);
+  free (line_info.my_s_k2);
 %}
 
 END

--- a/mcxtrace-comps/union/Powder_process.comp
+++ b/mcxtrace-comps/union/Powder_process.comp
@@ -67,8 +67,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Powder_process.comp
+++ b/mcxtrace-comps/union/Powder_process.comp
@@ -67,7 +67,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Powder_process requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Rayleigh_xrl_process.comp
+++ b/mcxtrace-comps/union/Rayleigh_xrl_process.comp
@@ -60,8 +60,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 #include <xraylib/xraylib.h>
@@ -174,13 +172,7 @@ INITIALIZE
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  if (_getcomp_index(init) < 0) {
-    fprintf(stderr,"Rayleigh_xrl_process:%s: Error identifying Union_init component, %s is not a known component name.\n",
-            NAME_CURRENT_COMP, init);
-    exit(-1);
-  }
-
-  struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
+  struct pointer_to_global_process_list *global_process_list = &g_process_list;
   add_element_to_process_list(global_process_list, global_process_element);
  %}
 

--- a/mcxtrace-comps/union/Rayleigh_xrl_process.comp
+++ b/mcxtrace-comps/union/Rayleigh_xrl_process.comp
@@ -57,8 +57,7 @@ DEPENDENCY " @XRLFLAGS@ "
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Rayleigh_xrl_process.comp
+++ b/mcxtrace-comps/union/Rayleigh_xrl_process.comp
@@ -56,7 +56,7 @@ DEPENDENCY " @XRLFLAGS@ "
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Rayleigh_xrl_process requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Rayleigh_xrl_process.comp
+++ b/mcxtrace-comps/union/Rayleigh_xrl_process.comp
@@ -38,7 +38,6 @@
 * density: [g/cm^3]       Nominal density of material.
 * element: [str]          The element (symbol) of the material. Overrides atomno.
 * atomno: [1]             Atomic number.
-* init:       [str]   Name of Union inititaliser component
 * OUTPUT PARAMETERS:
 *
 * %L
@@ -49,130 +48,133 @@
 
 DEFINE COMPONENT Rayleigh_xrl_process
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS (density=0,atomno=14, string element="", string init="init")
+SETTING PARAMETERS (density=0,atomno=14, string element="")
 OUTPUT PARAMETERS (This_process,Rayleigh_xrl_storage)
 DEPENDENCY " @XRLFLAGS@ "
 /* X-ray parameters: (x,y,z,kx,ky,kz,phi,t,Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-#include <xraylib/xraylib.h>
+  #include <xraylib/xraylib.h>
 
-struct Rayleigh_xrl_physics_storage_struct{
-  char name[13];
-  int Z;
-  double rho;
-  double sigma;
-};
+  struct Rayleigh_xrl_physics_storage_struct {
+    char name[13];
+    int Z;
+    double rho;
+    double sigma;
+  };
 
-int Rayleigh_xrl_physics_my(double *my, double *k_i, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle){
-  /*get the partial cross section using xraylib*/
-  double k_length = sqrt(k_i[0]*k_i[0]+k_i[1]*k_i[1]+k_i[2]*k_i[2]);
-  double E=K2E*k_length;
+  int
+  Rayleigh_xrl_physics_my (double* my, double* k_i, union data_transfer_union data_transfer, struct focus_data_struct* focus_data, _class_particle* _particle) {
+    /*get the partial cross section using xraylib*/
+    double k_length = sqrt (k_i[0] * k_i[0] + k_i[1] * k_i[1] + k_i[2] * k_i[2]);
+    double E = K2E * k_length;
 
-  /*how to handle the fact that we may be dealing with polarized radiation - goes in data_transfer union?*/
-  /*we have to somehow transfer input data to this function - is this also in data_transfer union? yes. It contains pointers to all the possible physics_storage structs.*/
-  struct Rayleigh_xrl_physics_storage_struct *p = data_transfer.pointer_to_a_Rayleigh_xrl_physics_storage_struct;
+    /*how to handle the fact that we may be dealing with polarized radiation - goes in data_transfer union?*/
+    /*we have to somehow transfer input data to this function - is this also in data_transfer union? yes. It contains pointers to all the possible physics_storage
+     * structs.*/
+    struct Rayleigh_xrl_physics_storage_struct* p = data_transfer.pointer_to_a_Rayleigh_xrl_physics_storage_struct;
 
-  /*call xraylib to get cross_section in cm^2/g - scale by density to get mu in cm^-1 - scale by 10^2 to get mu in m^-1*/
-  p->sigma=CS_Rayl(p->Z,E,NULL);
-  *my=p->rho*p->sigma*100;
-  return 1;
-}
+    /*call xraylib to get cross_section in cm^2/g - scale by density to get mu in cm^-1 - scale by 10^2 to get mu in m^-1*/
+    p->sigma = CS_Rayl (p->Z, E, NULL);
+    *my = p->rho * p->sigma * 100;
+    return 1;
+  }
 
-int Rayleigh_xrl_physics_scattering(double *k_f, double *k_i, double *weight, union data_transfer_union data_transfer, struct focus_data_struct *focus_data, _class_particle *_particle) {
-  double k_length = sqrt(k_i[0]*k_i[0]+k_i[1]*k_i[1]+k_i[2]*k_i[2]);
-  double E=K2E*k_length;
-  double E0;
+  int
+  Rayleigh_xrl_physics_scattering (double* k_f, double* k_i, double* weight, union data_transfer_union data_transfer, struct focus_data_struct* focus_data,
+                                   _class_particle* _particle) {
+    double k_length = sqrt (k_i[0] * k_i[0] + k_i[1] * k_i[1] + k_i[2] * k_i[2]);
+    double E = K2E * k_length;
+    double E0;
 
-  struct Rayleigh_xrl_physics_storage_struct *p = data_transfer.pointer_to_a_Rayleigh_xrl_physics_storage_struct;
+    struct Rayleigh_xrl_physics_storage_struct* p = data_transfer.pointer_to_a_Rayleigh_xrl_physics_storage_struct;
 
-  /*pick a direction randomly*/
-  Coords k_out;
-  // Here is the focusing system in action, get a vector
-  double solid_angle;
-  focus_data->focusing_function(&k_out,&solid_angle,focus_data);
-  NORM(k_out.x,k_out.y,k_out.z);
-  *weight *= solid_angle*0.25/PI;
+    /*pick a direction randomly*/
+    Coords k_out;
+    // Here is the focusing system in action, get a vector
+    double solid_angle;
+    focus_data->focusing_function (&k_out, &solid_angle, focus_data);
+    NORM (k_out.x, k_out.y, k_out.z);
+    *weight *= solid_angle * 0.25 / PI;
 
-  double theta,dsigma;
-  theta = acos(scalar_prod(k_out.x,k_out.y, k_out.z,k_i[0], k_i[1],k_i[2])/k_length);
+    double theta, dsigma;
+    theta = acos (scalar_prod (k_out.x, k_out.y, k_out.z, k_i[0], k_i[1], k_i[2]) / k_length);
 
-  /*make the call to xraylib to get the partial cross section for the particular scattering triangle defined by k_i, k_f.
-    We rely on a previous call to CS_Rayl by _mu-function*/
-  dsigma = DCS_Rayl(p->Z,E,theta,NULL);
-  *weight *= dsigma/p->sigma;
-  k_length=E*E2K;
-  k_f[0]=k_out.x*k_length;
-  k_f[1]=k_out.y*k_length;
-  k_f[2]=k_out.z*k_length;
-  /*get */
-  return 1;
-}
+    /*make the call to xraylib to get the partial cross section for the particular scattering triangle defined by k_i, k_f.
+      We rely on a previous call to CS_Rayl by _mu-function*/
+    dsigma = DCS_Rayl (p->Z, E, theta, NULL);
+    *weight *= dsigma / p->sigma;
+    k_length = E * E2K;
+    k_f[0] = k_out.x * k_length;
+    k_f[1] = k_out.y * k_length;
+    k_f[2] = k_out.z * k_length;
+    /*get */
+    return 1;
+  }
 
-#ifndef PROCESS_DETECTOR
-    #define PROCESS_DETECTOR dummy
-#endif
+  #ifndef PROCESS_DETECTOR
+  #define PROCESS_DETECTOR dummy
+  #endif
 
-#ifndef PROCESS_RAYLEIGH_XRL_DETECTOR
-    #define PROCESS_RAYLEIGH_XRL_DETECTOR dummy
-#endif
+  #ifndef PROCESS_RAYLEIGH_XRL_DETECTOR
+  #define PROCESS_RAYLEIGH_XRL_DETECTOR dummy
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_process_element_struct global_process_element;
-struct scattering_process_struct This_process;
+  // Needed for transport to the main component
+  struct global_process_element_struct global_process_element;
+  struct scattering_process_struct This_process;
 
-// Declare for this component, to do calculations on the input / store in the transported data
-struct Rayleigh_xrl_physics_storage_struct Rayleigh_xrl_storage;
-
+  // Declare for this component, to do calculations on the input / store in the transported data
+  struct Rayleigh_xrl_physics_storage_struct Rayleigh_xrl_storage;
 %}
 
 INITIALIZE
 %{
   // Initialize done in the component
-  xrl_error *xe;
-  if(atomno==0 && strlen(element)!=0){
-    Rayleigh_xrl_storage.Z=SymbolToAtomicNumber(element,&xe);
-    snprintf(Rayleigh_xrl_storage.name,3,element);
-  } else if (atomno>0 || atomno<116){
-    Rayleigh_xrl_storage.Z=atomno;
-    snprintf(Rayleigh_xrl_storage.name,3,AtomicNumberToSymbol(atomno,&xe));
-  }else{
-    fprintf(stderr,"ERROR: (%s): Must set either an element by symbol or by atomic number Got (%s,%d).\n",NAME_CURRENT_COMP,element,atomno);
-    exit(-1);
+  xrl_error* xe;
+  if (atomno == 0 && strlen (element) != 0) {
+    Rayleigh_xrl_storage.Z = SymbolToAtomicNumber (element, &xe);
+    snprintf (Rayleigh_xrl_storage.name, 3, element);
+  } else if (atomno > 0 || atomno < 116) {
+    Rayleigh_xrl_storage.Z = atomno;
+    snprintf (Rayleigh_xrl_storage.name, 3, AtomicNumberToSymbol (atomno, &xe));
+  } else {
+    fprintf (stderr, "ERROR: (%s): Must set either an element by symbol or by atomic number Got (%s,%d).\n", NAME_CURRENT_COMP, element, atomno);
+    exit (-1);
   }
-  Rayleigh_xrl_storage.rho=density;
+  Rayleigh_xrl_storage.rho = density;
 
   // The type of the process must be saved in the global enum process
   This_process.eProcess = Rayleigh_xrl;
 
   // Need to specify if this process is isotropic
   This_process.non_isotropic_rot_index = -1; // Yes (powder)
-  //This_process.non_isotropic_rot_index =  1;  // No (single crystal)
+  // This_process.non_isotropic_rot_index =  1;  // No (single crystal)
 
   // Packing the data into a structure that is transported to the main component
-  sprintf(This_process.name,NAME_CURRENT_COMP);
+  sprintf (This_process.name, NAME_CURRENT_COMP);
   This_process.process_p_interact = -1;
   This_process.data_transfer.pointer_to_a_Rayleigh_xrl_physics_storage_struct = &Rayleigh_xrl_storage;
-  //This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
+  // This_process.data_transfer.pointer_to_a_Incoherent_physics_storage_struct->my_scattering = effective_my_scattering;
   This_process.probability_for_scattering_function = &Rayleigh_xrl_physics_my;
   This_process.scattering_function = &Rayleigh_xrl_physics_scattering;
 
   // This will be the same for all process's, and can thus be moved to an include.
-  sprintf(global_process_element.name,NAME_CURRENT_COMP);
+  sprintf (global_process_element.name, NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
 
-  struct pointer_to_global_process_list *global_process_list = &g_process_list;
-  add_element_to_process_list(global_process_list, global_process_element);
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  add_element_to_process_list (global_process_list, global_process_element);
  %}
 
 TRACE
@@ -181,8 +183,7 @@ TRACE
 
 FINALLY
 %{
-// Since the process and it's storage is a static allocation, there is nothing to deallocate
-
+  // Since the process and it's storage is a static allocation, there is nothing to deallocate
 %}
 
 END

--- a/mcxtrace-comps/union/Template_process.comp
+++ b/mcxtrace-comps/union/Template_process.comp
@@ -62,7 +62,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 #include "Union_functions.c"
-#include "union-init.c"
 
 #endif
 
@@ -160,7 +159,7 @@ INITIALIZE
   sprintf(global_process_element.name,NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  add_element_to_process_list(&global_process_list,global_process_element);
+  add_element_to_process_list(&g_process_list,global_process_element);
  %}
 
 TRACE

--- a/mcxtrace-comps/union/Template_process.comp
+++ b/mcxtrace-comps/union/Template_process.comp
@@ -59,7 +59,7 @@ OUTPUT PARAMETERS (This_process,Template_storage,effective_my_scattering)
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Template_process requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Template_process.comp
+++ b/mcxtrace-comps/union/Template_process.comp
@@ -58,92 +58,95 @@ OUTPUT PARAMETERS (This_process,Template_storage,effective_my_scattering)
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-// Very important to add a pointer to this struct in the Union_functions.c file
-struct Template_physics_storage_struct{
+  // Very important to add a pointer to this struct in the Union_functions.c file
+  struct Template_physics_storage_struct {
     // Variables that needs to be transfered between any of the following places:
     // The initialize in this component
     // The function for calculating my
     // The function for calculating scattering
-    
+
     // Avoid duplicates of output parameters and setting parameters in naming
     double my_scattering;
-};
+  };
 
-// Function for calculating my, the inverse penetration depth (for only this scattering process).
-// The input for this function and its order may not be changed, but the names may be updated.
-int Template_physics_my(double *my, double *k_initial, union data_transfer_union data_transfer, struct focus_data_struct *focus_data) {
+  // Function for calculating my, the inverse penetration depth (for only this scattering process).
+  // The input for this function and its order may not be changed, but the names may be updated.
+  int
+  Template_physics_my (double* my, double* k_initial, union data_transfer_union data_transfer, struct focus_data_struct* focus_data) {
     // *k_initial is a pointer to a simple vector with 3 doubles, k[0], k[1], k[2] which describes the wavevector
 
     // Simple case, just retrive the parameter saved from initialize
     *my = data_transfer.pointer_to_a_Template_physics_storage_struct->my_scattering;
     return 1;
-};
+  };
 
-// Function that provides description of a basic scattering event.
-// Do not change the
-int Template_physics_scattering(double *k_final, double *k_initial, double *weight, union data_transfer_union data_transfer, struct focus_data_struct *focus_data) {
+  // Function that provides description of a basic scattering event.
+  // Do not change the
+  int
+  Template_physics_scattering (double* k_final, double* k_initial, double* weight, union data_transfer_union data_transfer,
+                               struct focus_data_struct* focus_data) {
 
     // k_final and k_initial are passed as pointers to double vector[3]
-    double k_length = sqrt(k_initial[0]*k_initial[0]+k_initial[1]*k_initial[1]+k_initial[2]*k_initial[2]);
+    double k_length = sqrt (k_initial[0] * k_initial[0] + k_initial[1] * k_initial[1] + k_initial[2] * k_initial[2]);
 
     Coords k_out;
     // Here is the focusing system in action, get a vector
     double solid_angle;
-    focus_data->focusing_function(&k_out,&solid_angle,focus_data);
-    NORM(k_out.x,k_out.y,k_out.z);
-    *weight *= solid_angle*0.25/PI;
+    focus_data->focusing_function (&k_out, &solid_angle, focus_data);
+    NORM (k_out.x, k_out.y, k_out.z);
+    *weight *= solid_angle * 0.25 / PI;
 
-    k_final[0] = k_out.x*k_length; k_final[1] = k_out.y*k_length; k_final[2] = k_out.z*k_length;
+    k_final[0] = k_out.x * k_length;
+    k_final[1] = k_out.y * k_length;
+    k_final[2] = k_out.z * k_length;
     // A pointer to k_final is returned, and the wavevector will be set to k_final after a scattering event
     return 1; // return 1 is sucess, return 0 is failure, and the ray will be absorbed.
               // failure should not happen, as this function will only be called when
               // the cross section for the current k_initial is above zero.
-    
+
     // There is access to the data_transfer from within the scattering function
     // In this case the only variable is my, but it could be read by:
     // double my = data_transfer.pointer_to_a_Template_physics_storage_struct->my_scattering;
     // One can assume that if the scattering function is running, the my fuction was
     //  executed just before and for the same k_initial.
-    
-};
-
+  };
 %}
 
 DECLARE
 %{
-// Declare for this component, to do calculations on the input / store in the transported data
-struct Template_physics_storage_struct Template_storage; // Replace template with your own name here
+  // Declare for this component, to do calculations on the input / store in the transported data
+  struct Template_physics_storage_struct Template_storage; // Replace template with your own name here
 
-// Variables needed in initialize of this function.
-double effective_my_scattering;
+  // Variables needed in initialize of this function.
+  double effective_my_scattering;
 
-// Needed for transport to the main component, will be the same for all processes
-struct global_process_element_struct global_process_element;
-struct scattering_process_struct This_process;
+  // Needed for transport to the main component, will be the same for all processes
+  struct global_process_element_struct global_process_element;
+  struct scattering_process_struct This_process;
 
-// These lines help with future error correction, and tell other Union components
-//  that at least one process have been defined.
-#ifndef PROCESS_DETECTOR
-    // Obsolete
-	//struct pointer_to_global_process_list global_process_list = {0,NULL};
-	#define PROCESS_DETECTOR dummy
-#endif
+  // These lines help with future error correction, and tell other Union components
+  //  that at least one process have been defined.
+  #ifndef PROCESS_DETECTOR
+  // Obsolete
+  // struct pointer_to_global_process_list global_process_list = {0,NULL};
+  #define PROCESS_DETECTOR dummy
+  #endif
 %}
 
 INITIALIZE
 %{
   // Initialize done in the component
-  effective_my_scattering = ((packing_factor/unit_cell_volume) * 100 * sigma);
+  effective_my_scattering = ((packing_factor / unit_cell_volume) * 100 * sigma);
   Template_storage.my_scattering = effective_my_scattering;
-  
+
   // Need to specify if this process is isotropic
   This_process.non_isotropic_rot_index = -1; // Yes (powder)
-  //This_process.non_isotropic_rot_index =  1;  // No (single crystal)
+  // This_process.non_isotropic_rot_index =  1;  // No (single crystal)
 
   // Packing the data into a structure that is transported to the main component
   This_process.data_transfer.pointer_to_a_Template_physics_storage_struct = &Template_storage;
@@ -151,18 +154,18 @@ INITIALIZE
   This_process.scattering_function = &Template_physics_scattering;
 
   // This will be the same for all process's, and can thus be moved to an include.
-  sprintf(This_process.name,NAME_CURRENT_COMP);
+  sprintf (This_process.name, NAME_CURRENT_COMP);
   This_process.process_p_interact = interact_fraction;
-  rot_copy(This_process.rotation_matrix,ROT_A_CURRENT_COMP);
-  sprintf(global_process_element.name,NAME_CURRENT_COMP);
+  rot_copy (This_process.rotation_matrix, ROT_A_CURRENT_COMP);
+  sprintf (global_process_element.name, NAME_CURRENT_COMP);
   global_process_element.component_index = INDEX_CURRENT_COMP;
   global_process_element.p_scattering_process = &This_process;
-  add_element_to_process_list(&g_process_list,global_process_element);
+  add_element_to_process_list (&g_process_list, global_process_element);
  %}
 
 TRACE
 %{
-    // Trace should be empty, the simulation is done in Union_master
+  // Trace should be empty, the simulation is done in Union_master
 %}
 
 END

--- a/mcxtrace-comps/union/Template_process.comp
+++ b/mcxtrace-comps/union/Template_process.comp
@@ -59,9 +59,7 @@ OUTPUT PARAMETERS (This_process,Template_storage,effective_my_scattering)
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
-#include "Union_functions.c"
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Union_box.comp
+++ b/mcxtrace-comps/union/Union_box.comp
@@ -80,8 +80,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 void mcdisplay_box_function(struct lines_to_draw *lines_to_draw_output,int index, struct geometry_struct **Geometries,int number_of_volumes) {
@@ -247,13 +245,7 @@ if (yheight2 <= 0 && yheight2 != -1) {
 }
 
 // Get global variable from init component
-if (_getcomp_index(init) < 0) {
-fprintf(stderr,"Union_box:%s: Error identifying Union_init component, %s is not a known component name.\n",
-NAME_CURRENT_COMP, init);
-exit(-1);
-}
-
-struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
+struct pointer_to_global_material_list *global_material_list = &g_material_list;
 // Use sanitation
 if (global_material_list->num_elements == 0) {
   printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
@@ -264,7 +256,7 @@ if (global_material_list->num_elements == 0) {
 this_box_volume.geometry.is_masked_volume = 0;
 this_box_volume.geometry.is_exit_volume = 0;
 this_box_volume.geometry.is_mask_volume = 0;
-struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
+struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
 // check if the volume is a mask, if it is the material string is irelevant.
 if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.

--- a/mcxtrace-comps/union/Union_box.comp
+++ b/mcxtrace-comps/union/Union_box.comp
@@ -76,7 +76,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_box requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Union_box.comp
+++ b/mcxtrace-comps/union/Union_box.comp
@@ -58,7 +58,6 @@
 * focus_xh:   [m]   vert. dimension of a rectangular area
 * focus_r:    [m]   focusing on circle with this radius
 * target_index:          [1]      Focuses on component a component this many steps further in the component sequence
-* init:       [str]   Name of Union inititaliser component
 *
 * OUTPUT PARAMETERS:
 *
@@ -69,19 +68,20 @@
 
 DEFINE COMPONENT Union_box
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(string material_string=0, priority, xwidth, yheight, zdepth, xwidth2=-1, yheight2=-1, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact = 0, string mask_string=0, string mask_setting=0,number_of_activations=1, string init="init")
+SETTING PARAMETERS(string material_string=0, priority, xwidth, yheight, zdepth, xwidth2=-1, yheight2=-1, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact = 0, string mask_string=0, string mask_setting=0,number_of_activations=1)
 OUTPUT PARAMETERS ()
 
 /* X-ray parameters: (x,y,z,kx,ky,kz ,phi, t, Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-void mcdisplay_box_function(struct lines_to_draw *lines_to_draw_output,int index, struct geometry_struct **Geometries,int number_of_volumes) {
+  void
+  mcdisplay_box_function (struct lines_to_draw* lines_to_draw_output, int index, struct geometry_struct** Geometries, int number_of_volumes) {
     // Function to call in mcdisplay section of the sample component for this volume
     // One can assume that Volumes[index] refers to a volume with the geometry described in this file
 
@@ -97,343 +97,354 @@ void mcdisplay_box_function(struct lines_to_draw *lines_to_draw_output,int index
 
     Coords center = Geometries[index]->center;
 
-    Coords square1[4],square2[4];
+    Coords square1[4], square2[4];
 
-    square1[0] = coords_add(coords_add(coords_add(center,coords_scalar_mult(z_vector,-0.5*depth)),coords_scalar_mult(x_vector,-0.5*width1)),coords_scalar_mult(y_vector,-0.5*height1));
+    square1[0] = coords_add (coords_add (coords_add (center, coords_scalar_mult (z_vector, -0.5 * depth)), coords_scalar_mult (x_vector, -0.5 * width1)),
+                             coords_scalar_mult (y_vector, -0.5 * height1));
 
-    square1[1] = coords_add(square1[0],coords_scalar_mult(x_vector,width1));
-    square1[2] = coords_add(square1[1],coords_scalar_mult(y_vector,height1));
-    square1[3] = coords_add(square1[0],coords_scalar_mult(y_vector,height1));
+    square1[1] = coords_add (square1[0], coords_scalar_mult (x_vector, width1));
+    square1[2] = coords_add (square1[1], coords_scalar_mult (y_vector, height1));
+    square1[3] = coords_add (square1[0], coords_scalar_mult (y_vector, height1));
 
-    square2[0] = coords_add(coords_add(coords_add(center,coords_scalar_mult(z_vector,0.5*depth)),coords_scalar_mult(x_vector,-0.5*width2)),coords_scalar_mult(y_vector,-0.5*height2));
+    square2[0] = coords_add (coords_add (coords_add (center, coords_scalar_mult (z_vector, 0.5 * depth)), coords_scalar_mult (x_vector, -0.5 * width2)),
+                             coords_scalar_mult (y_vector, -0.5 * height2));
 
-    square2[1] = coords_add(square2[0],coords_scalar_mult(x_vector,width2));
-    square2[2] = coords_add(square2[1],coords_scalar_mult(y_vector,height2));
-    square2[3] = coords_add(square2[0],coords_scalar_mult(y_vector,height2));
+    square2[1] = coords_add (square2[0], coords_scalar_mult (x_vector, width2));
+    square2[2] = coords_add (square2[1], coords_scalar_mult (y_vector, height2));
+    square2[3] = coords_add (square2[0], coords_scalar_mult (y_vector, height2));
 
     struct lines_to_draw lines_to_draw_temp;
     lines_to_draw_temp.number_of_lines = 0;
 
     int iterate;
-    for (iterate=0;iterate<3;iterate++) {
-        lines_to_draw_temp = draw_line_with_highest_priority(square1[iterate],square1[iterate+1],index,Geometries,number_of_volumes,2);
-        merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    for (iterate = 0; iterate < 3; iterate++) {
+      lines_to_draw_temp = draw_line_with_highest_priority (square1[iterate], square1[iterate + 1], index, Geometries, number_of_volumes, 2);
+      merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
     }
-    lines_to_draw_temp = draw_line_with_highest_priority(square1[3],square1[0],index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_line_with_highest_priority (square1[3], square1[0], index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    for (iterate=0;iterate<3;iterate++) {
-        lines_to_draw_temp = draw_line_with_highest_priority(square2[iterate],square2[iterate+1],index,Geometries,number_of_volumes,2);
-        merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    for (iterate = 0; iterate < 3; iterate++) {
+      lines_to_draw_temp = draw_line_with_highest_priority (square2[iterate], square2[iterate + 1], index, Geometries, number_of_volumes, 2);
+      merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
     }
-    lines_to_draw_temp = draw_line_with_highest_priority(square2[3],square2[0],index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_line_with_highest_priority (square2[3], square2[0], index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    for (iterate=0;iterate<4;iterate++) {
-        lines_to_draw_temp = draw_line_with_highest_priority(square1[iterate],square2[iterate],index,Geometries,number_of_volumes,2);
-        merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    for (iterate = 0; iterate < 4; iterate++) {
+      lines_to_draw_temp = draw_line_with_highest_priority (square1[iterate], square2[iterate], index, Geometries, number_of_volumes, 2);
+      merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
     }
-};
+  };
 
-void initialize_box_geometry_from_main_component(struct geometry_struct *box) {
+  void
+  initialize_box_geometry_from_main_component (struct geometry_struct* box) {
     // Function to be called in initialize of the main component
     // This is done as the rotation matrix needs to be relative to the main component instead of global
     // Everything done in initialize in this component file has the rotation matrix relative to global
-    Coords simple_vector = coords_set(1,0,0);
+    Coords simple_vector = coords_set (1, 0, 0);
     Coords rotated_vector;
 
-    rotated_vector = rot_apply(box->rotation_matrix,simple_vector);
-    NORM(rotated_vector.x,rotated_vector.y,rotated_vector.z);
+    rotated_vector = rot_apply (box->rotation_matrix, simple_vector);
+    NORM (rotated_vector.x, rotated_vector.y, rotated_vector.z);
     box->geometry_parameters.p_box_storage->x_vector = rotated_vector;
 
-    simple_vector = coords_set(0,1,0);
-    rotated_vector = rot_apply(box->rotation_matrix,simple_vector);
-    NORM(rotated_vector.x,rotated_vector.y,rotated_vector.z);
+    simple_vector = coords_set (0, 1, 0);
+    rotated_vector = rot_apply (box->rotation_matrix, simple_vector);
+    NORM (rotated_vector.x, rotated_vector.y, rotated_vector.z);
     box->geometry_parameters.p_box_storage->y_vector = rotated_vector;
 
-    simple_vector = coords_set(0,0,1);
-    rotated_vector = rot_apply(box->rotation_matrix,simple_vector);
-    NORM(rotated_vector.x,rotated_vector.y,rotated_vector.z);
+    simple_vector = coords_set (0, 0, 1);
+    rotated_vector = rot_apply (box->rotation_matrix, simple_vector);
+    NORM (rotated_vector.x, rotated_vector.y, rotated_vector.z);
     box->geometry_parameters.p_box_storage->z_vector = rotated_vector;
-};
+  };
 
-struct pointer_to_1d_coords_list box_shell_points(struct geometry_struct *geometry,int max_number_of_points) {
-  // This function returns an array of corner positions for the box in the main coordinate system.
-  // Normally one would limit it to a maximum number of points, but as there are only 8 for the box,
-  //  it is hardcoded to 8. Other geometries can be approximated with a variable number of points.
+  struct pointer_to_1d_coords_list
+  box_shell_points (struct geometry_struct* geometry, int max_number_of_points) {
+    // This function returns an array of corner positions for the box in the main coordinate system.
+    // Normally one would limit it to a maximum number of points, but as there are only 8 for the box,
+    //  it is hardcoded to 8. Other geometries can be approximated with a variable number of points.
 
-  struct pointer_to_1d_coords_list corner_points;
-  corner_points.elements = malloc(8*sizeof(Coords));
-  corner_points.num_elements = 8;
+    struct pointer_to_1d_coords_list corner_points;
+    corner_points.elements = malloc (8 * sizeof (Coords));
+    corner_points.num_elements = 8;
 
-  double depth = geometry->geometry_parameters.p_box_storage->z_depth;
-  double width1 = geometry->geometry_parameters.p_box_storage->x_width1;
-  double width2 = geometry->geometry_parameters.p_box_storage->x_width2;
-  double height1 = geometry->geometry_parameters.p_box_storage->y_height1;
-  double height2 = geometry->geometry_parameters.p_box_storage->y_height2;
+    double depth = geometry->geometry_parameters.p_box_storage->z_depth;
+    double width1 = geometry->geometry_parameters.p_box_storage->x_width1;
+    double width2 = geometry->geometry_parameters.p_box_storage->x_width2;
+    double height1 = geometry->geometry_parameters.p_box_storage->y_height1;
+    double height2 = geometry->geometry_parameters.p_box_storage->y_height2;
 
-  Coords x_vector = geometry->geometry_parameters.p_box_storage->x_vector;
-  Coords y_vector = geometry->geometry_parameters.p_box_storage->y_vector;
-  Coords z_vector = geometry->geometry_parameters.p_box_storage->z_vector;
+    Coords x_vector = geometry->geometry_parameters.p_box_storage->x_vector;
+    Coords y_vector = geometry->geometry_parameters.p_box_storage->y_vector;
+    Coords z_vector = geometry->geometry_parameters.p_box_storage->z_vector;
 
-  Coords center = geometry->center;
+    Coords center = geometry->center;
 
-  corner_points.elements[0] = coords_add(coords_add(coords_add(center,coords_scalar_mult(z_vector,-0.5*depth)),coords_scalar_mult(x_vector,-0.5*width1)),coords_scalar_mult(y_vector,-0.5*height1));
+    corner_points.elements[0]
+        = coords_add (coords_add (coords_add (center, coords_scalar_mult (z_vector, -0.5 * depth)), coords_scalar_mult (x_vector, -0.5 * width1)),
+                      coords_scalar_mult (y_vector, -0.5 * height1));
 
-  corner_points.elements[1] = coords_add(corner_points.elements[0],coords_scalar_mult(x_vector,width1));
-  corner_points.elements[2] = coords_add(corner_points.elements[1],coords_scalar_mult(y_vector,height1));
-  corner_points.elements[3] = coords_add(corner_points.elements[0],coords_scalar_mult(y_vector,height1));
+    corner_points.elements[1] = coords_add (corner_points.elements[0], coords_scalar_mult (x_vector, width1));
+    corner_points.elements[2] = coords_add (corner_points.elements[1], coords_scalar_mult (y_vector, height1));
+    corner_points.elements[3] = coords_add (corner_points.elements[0], coords_scalar_mult (y_vector, height1));
 
-  corner_points.elements[4] = coords_add(coords_add(coords_add(center,coords_scalar_mult(z_vector,0.5*depth)),coords_scalar_mult(x_vector,-0.5*width2)),coords_scalar_mult(y_vector,-0.5*height2));
+    corner_points.elements[4]
+        = coords_add (coords_add (coords_add (center, coords_scalar_mult (z_vector, 0.5 * depth)), coords_scalar_mult (x_vector, -0.5 * width2)),
+                      coords_scalar_mult (y_vector, -0.5 * height2));
 
-  corner_points.elements[5] = coords_add(corner_points.elements[4],coords_scalar_mult(x_vector,width2));
-  corner_points.elements[6] = coords_add(corner_points.elements[5],coords_scalar_mult(y_vector,height2));
-  corner_points.elements[7] = coords_add(corner_points.elements[4],coords_scalar_mult(y_vector,height2));
+    corner_points.elements[5] = coords_add (corner_points.elements[4], coords_scalar_mult (x_vector, width2));
+    corner_points.elements[6] = coords_add (corner_points.elements[5], coords_scalar_mult (y_vector, height2));
+    corner_points.elements[7] = coords_add (corner_points.elements[4], coords_scalar_mult (y_vector, height2));
 
-  return corner_points;
-}
+    return corner_points;
+  }
 
-#ifndef ANY_GEOMETRY_DETECTOR_DECLARE
-    #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
-    //struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
-#endif
-
+  #ifndef ANY_GEOMETRY_DETECTOR_DECLARE
+  #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
+  // struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_geometry_element_struct global_geometry_element;
+  // Needed for transport to the main component
+  struct global_geometry_element_struct global_geometry_element;
 
-int loop_index;
+  int loop_index;
 
-double x_component;
-double y_component;
-double z_component;
+  double x_component;
+  double y_component;
+  double z_component;
 
-struct Volume_struct this_box_volume;
-struct box_storage this_box_storage;
-
+  struct Volume_struct this_box_volume;
+  struct box_storage this_box_storage;
 %}
 
 INITIALIZE
 %{
-// Initializes the focusing system for this volume including input sanitation.
-focus_initialize(&this_box_volume.geometry, POS_A_COMP_INDEX(INDEX_CURRENT_COMP+target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index, target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
+  // Initializes the focusing system for this volume including input sanitation.
+  focus_initialize (&this_box_volume.geometry, POS_A_COMP_INDEX (INDEX_CURRENT_COMP + target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index,
+                    target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
 
-// Input sanitation for this geometry
-if (xwidth <= 0) {
-  printf("\nERROR in Union_box named %s, the xwidth is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
-if (yheight <= 0) {
-  printf("\nERROR in Union_box named %s, yheight is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
-if (zdepth <= 0) {
-  printf("\nERROR in Union_box named %s, zdepth is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
-if (xwidth2 <= 0 && xwidth2 != -1) {
-  printf("\nERROR in Union_box named %s, the xwidth2 is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
-if (yheight2 <= 0 && yheight2 != -1) {
-  printf("\nERROR in Union_box named %s, yheight2 is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
+  // Input sanitation for this geometry
+  if (xwidth <= 0) {
+    printf ("\nERROR in Union_box named %s, the xwidth is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
+  if (yheight <= 0) {
+    printf ("\nERROR in Union_box named %s, yheight is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
+  if (zdepth <= 0) {
+    printf ("\nERROR in Union_box named %s, zdepth is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
+  if (xwidth2 <= 0 && xwidth2 != -1) {
+    printf ("\nERROR in Union_box named %s, the xwidth2 is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
+  if (yheight2 <= 0 && yheight2 != -1) {
+    printf ("\nERROR in Union_box named %s, yheight2 is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
 
-// Get global variable from init component
-struct pointer_to_global_material_list *global_material_list = &g_material_list;
-// Use sanitation
-if (global_material_list->num_elements == 0) {
-  printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
-  printf("       %s was defined before first use of Union_make_material.\n", NAME_CURRENT_COMP);
-  exit(1);
-}
+  // Get global variable from the auto-injected Union state
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
+  // Use sanitation
+  if (global_material_list->num_elements == 0) {
+    printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
+    printf ("       %s was defined before first use of Union_make_material.\n", NAME_CURRENT_COMP);
+    exit (1);
+  }
 
-this_box_volume.geometry.is_masked_volume = 0;
-this_box_volume.geometry.is_exit_volume = 0;
-this_box_volume.geometry.is_mask_volume = 0;
-struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
-// check if the volume is a mask, if it is the material string is irelevant.
-if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {
+  this_box_volume.geometry.is_masked_volume = 0;
+  this_box_volume.geometry.is_exit_volume = 0;
+  this_box_volume.geometry.is_mask_volume = 0;
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  // check if the volume is a mask, if it is the material string is irelevant.
+  if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.
     // In order for a ray to enter a masked volume, it needs to be both in the region covered by that volume AND the mask volume.
     // When more than
     this_box_volume.geometry.mask_mode = 1; // Default is mask mode is ALL
-    if (mask_setting && strlen(mask_setting) && strcmp(mask_setting, "NULL") && strcmp(mask_setting, "0")) {
-        if (strcmp(mask_setting,"ALL") == 0 || strcmp(mask_setting,"All") == 0) this_box_volume.geometry.mask_mode = 1;
-        else if (strcmp(mask_setting,"ANY") == 0 || strcmp(mask_setting,"Any") == 0) this_box_volume.geometry.mask_mode = 2;
-        else {
-            printf("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n",NAME_CURRENT_COMP,mask_setting);
-            exit(1);
-        }
+    if (mask_setting && strlen (mask_setting) && strcmp (mask_setting, "NULL") && strcmp (mask_setting, "0")) {
+      if (strcmp (mask_setting, "ALL") == 0 || strcmp (mask_setting, "All") == 0)
+        this_box_volume.geometry.mask_mode = 1;
+      else if (strcmp (mask_setting, "ANY") == 0 || strcmp (mask_setting, "Any") == 0)
+        this_box_volume.geometry.mask_mode = 2;
+      else {
+        printf ("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n", NAME_CURRENT_COMP, mask_setting);
+        exit (1);
+      }
     }
 
     int found_geometries = 0;
-    for (loop_index=0;loop_index<global_geometry_list->num_elements;loop_index++) {
-        // Add mask list
-        if (1 == manual_linking_function(global_geometry_list->elements[loop_index].name,mask_string)) {
-            add_element_to_int_list(&this_box_volume.geometry.mask_list,global_geometry_list->elements[loop_index].component_index);
-            add_element_to_int_list(&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list,INDEX_CURRENT_COMP);
-            global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
-            if (this_box_volume.geometry.mask_mode == 2)
-                global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
-            if (this_box_volume.geometry.mask_mode == 1) {
-                if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1 && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
-                    // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
-                    global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
-            }
-
-            found_geometries = 1;
+    for (loop_index = 0; loop_index < global_geometry_list->num_elements; loop_index++) {
+      // Add mask list
+      if (1 == manual_linking_function (global_geometry_list->elements[loop_index].name, mask_string)) {
+        add_element_to_int_list (&this_box_volume.geometry.mask_list, global_geometry_list->elements[loop_index].component_index);
+        add_element_to_int_list (&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list, INDEX_CURRENT_COMP);
+        global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
+        if (this_box_volume.geometry.mask_mode == 2)
+          global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
+        if (this_box_volume.geometry.mask_mode == 1) {
+          if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1
+              && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
+            // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
+            global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
         }
+
+        found_geometries = 1;
+      }
     }
     if (found_geometries == 0) {
-        printf("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n",NAME_CURRENT_COMP,mask_string);
-        exit(1);
+      printf ("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n", NAME_CURRENT_COMP, mask_string);
+      exit (1);
     }
-    this_box_volume.p_physics = malloc(sizeof(struct physics_struct));
-    this_box_volume.p_physics->is_vacuum = 0; // Makes this volume a vacuum
-    this_box_volume.p_physics->number_of_processes = (int) 0; // Should not be used.
-    this_box_volume.p_physics->my_a = 0; // Should not be used.
-    sprintf(this_box_volume.p_physics->name,"Mask");
+    this_box_volume.p_physics = malloc (sizeof (struct physics_struct));
+    this_box_volume.p_physics->is_vacuum = 0;                // Makes this volume a vacuum
+    this_box_volume.p_physics->number_of_processes = (int)0; // Should not be used.
+    this_box_volume.p_physics->my_a = 0;                     // Should not be used.
+    sprintf (this_box_volume.p_physics->name, "Mask");
     this_box_volume.geometry.is_mask_volume = 1;
 
-
-// Read the material input, or if it lacks, use automatic linking.
-} else if (material_string && strlen(material_string) && strcmp(material_string, "NULL") && strcmp(material_string, "0")) {
+    // Read the material input, or if it lacks, use automatic linking.
+  } else if (material_string && strlen (material_string) && strcmp (material_string, "NULL") && strcmp (material_string, "0")) {
     // A geometry string was given, use it to determine which material
-    if (0 == strcmp(material_string,"vacuum") || 0 == strcmp(material_string,"Vacuum")) {
-        // One could have a global physics struct for vacuum instead of creating one for each
-        this_box_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_box_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_box_volume.p_physics->number_of_processes = (int) 0;
-        this_box_volume.p_physics->my_a = 0; // Should not be used.
-        sprintf(this_box_volume.p_physics->name,"Vacuum");
-    } else if (0 == strcmp(material_string,"exit") || 0 == strcmp(material_string,"Exit")) {
-        // One could have a global physics struct for vacuum instead of creating one for each
-        this_box_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_box_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_box_volume.p_physics->number_of_processes = (int) 0;
-        this_box_volume.p_physics->my_a = 0; // Should not be used.
-        this_box_volume.geometry.is_exit_volume = 1;
-        sprintf(this_box_volume.p_physics->name,"Exit");
+    if (0 == strcmp (material_string, "vacuum") || 0 == strcmp (material_string, "Vacuum")) {
+      // One could have a global physics struct for vacuum instead of creating one for each
+      this_box_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_box_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_box_volume.p_physics->number_of_processes = (int)0;
+      this_box_volume.p_physics->my_a = 0; // Should not be used.
+      sprintf (this_box_volume.p_physics->name, "Vacuum");
+    } else if (0 == strcmp (material_string, "exit") || 0 == strcmp (material_string, "Exit")) {
+      // One could have a global physics struct for vacuum instead of creating one for each
+      this_box_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_box_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_box_volume.p_physics->number_of_processes = (int)0;
+      this_box_volume.p_physics->my_a = 0; // Should not be used.
+      this_box_volume.geometry.is_exit_volume = 1;
+      sprintf (this_box_volume.p_physics->name, "Exit");
     } else {
-        #ifndef MATERIAL_DETECTOR
-            printf("Need to define a material before refering to it in a geometry %s.\n",NAME_CURRENT_COMP);
-            exit(1);
-        #endif
-        for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++) {
-          if (0 == strcmp(material_string,global_material_list->elements[loop_index].name)) {
-            this_box_volume.p_physics = global_material_list->elements[loop_index].physics;
-            break;
-          }
-          if (loop_index == global_material_list->num_elements-1) {
-            printf("\n");
-            printf("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n",material_string,NAME_CURRENT_COMP);
-            printf("       The materials available at this point (need to be defined before the geometry): \n");
-            for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++)
-              printf("         %s\n",global_material_list->elements[loop_index].name);
-            printf("\n");
-            printf("       It is also possible to use one of the defualt materials avaiable: \n");
-            printf("           Vacuum (for a Volume without scattering or absorption)\n");
-            printf("           Exit (for a Volume where the ray exits the component if it enters)\n");
-            printf("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
-            exit(1);
-          }
+      #ifndef MATERIAL_DETECTOR
+      printf ("Need to define a material before refering to it in a geometry %s.\n", NAME_CURRENT_COMP);
+      exit (1);
+      #endif
+      for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++) {
+        if (0 == strcmp (material_string, global_material_list->elements[loop_index].name)) {
+          this_box_volume.p_physics = global_material_list->elements[loop_index].physics;
+          break;
         }
+        if (loop_index == global_material_list->num_elements - 1) {
+          printf ("\n");
+          printf ("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n", material_string, NAME_CURRENT_COMP);
+          printf ("       The materials available at this point (need to be defined before the geometry): \n");
+          for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++)
+            printf ("         %s\n", global_material_list->elements[loop_index].name);
+          printf ("\n");
+          printf ("       It is also possible to use one of the defualt materials avaiable: \n");
+          printf ("           Vacuum (for a Volume without scattering or absorption)\n");
+          printf ("           Exit (for a Volume where the ray exits the component if it enters)\n");
+          printf ("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
+          exit (1);
+        }
+      }
     }
-} else {
+  } else {
     // Automatic linking, simply using the last defined material.
     #ifndef MATERIAL_DETECTOR
-        printf("Need to define a material before the geometry to use automatic linking %s.\n",NAME_CURRENT_COMP);
-        exit(1);
+    printf ("Need to define a material before the geometry to use automatic linking %s.\n", NAME_CURRENT_COMP);
+    exit (1);
     #endif
-    this_box_volume.p_physics = global_material_list->elements[global_material_list->num_elements-1].physics;
-}
+    this_box_volume.p_physics = global_material_list->elements[global_material_list->num_elements - 1].physics;
+  }
 
-sprintf(this_box_volume.name,NAME_CURRENT_COMP);
-sprintf(this_box_volume.geometry.shape,"box");
-this_box_volume.geometry.eShape = box;
-this_box_volume.geometry.priority_value = priority;
-this_box_volume.geometry.geometry_p_interact = p_interact;
-// Currently the coordinates will be in absolute space.
-this_box_volume.geometry.center = POS_A_CURRENT_COMP;
+  sprintf (this_box_volume.name, NAME_CURRENT_COMP);
+  sprintf (this_box_volume.geometry.shape, "box");
+  this_box_volume.geometry.eShape = box;
+  this_box_volume.geometry.priority_value = priority;
+  this_box_volume.geometry.geometry_p_interact = p_interact;
+  // Currently the coordinates will be in absolute space.
+  this_box_volume.geometry.center = POS_A_CURRENT_COMP;
 
-this_box_storage.z_depth = zdepth;
-this_box_storage.x_width1 = xwidth;
-this_box_storage.y_height1 = yheight;
+  this_box_storage.z_depth = zdepth;
+  this_box_storage.x_width1 = xwidth;
+  this_box_storage.y_height1 = yheight;
 
-this_box_storage.is_rectangle = 0;
-if (xwidth2 < 0 && yheight2 < 0) this_box_storage.is_rectangle = 1;
-if (xwidth == xwidth2 && yheight == yheight2) this_box_storage.is_rectangle = 1;
+  this_box_storage.is_rectangle = 0;
+  if (xwidth2 < 0 && yheight2 < 0)
+    this_box_storage.is_rectangle = 1;
+  if (xwidth == xwidth2 && yheight == yheight2)
+    this_box_storage.is_rectangle = 1;
 
-if (xwidth2 < 0) {
+  if (xwidth2 < 0) {
     this_box_storage.x_width2 = xwidth;
     xwidth2 = xwidth;
-} else this_box_storage.x_width2 = xwidth2;
+  } else
+    this_box_storage.x_width2 = xwidth2;
 
-if (yheight2 < 0) {
+  if (yheight2 < 0) {
     this_box_storage.y_height2 = yheight;
     yheight2 = yheight;
-} else this_box_storage.y_height2 = yheight2;
+  } else
+    this_box_storage.y_height2 = yheight2;
 
+  this_box_storage.normal_vectors[0] = coords_set (0, 0, 1);
+  this_box_storage.normal_vectors[1] = coords_set (0, 0, 1);
 
-this_box_storage.normal_vectors[0] = coords_set(0,0,1);
-this_box_storage.normal_vectors[1] = coords_set(0,0,1);
+  // for sides with y component = 0
+  x_component = 2 * zdepth / sqrt ((xwidth - xwidth2) * (xwidth - xwidth2) + 4 * zdepth * zdepth);
+  z_component = (xwidth - xwidth2) / sqrt (4 * zdepth * zdepth + (xwidth - xwidth2) * (xwidth - xwidth2));
 
-// for sides with y component = 0
-x_component = 2*zdepth/sqrt((xwidth-xwidth2)*(xwidth-xwidth2)+4*zdepth*zdepth);
-z_component = (xwidth-xwidth2)/sqrt(4*zdepth*zdepth+(xwidth-xwidth2)*(xwidth-xwidth2));
+  this_box_storage.normal_vectors[2] = coords_set (x_component, 0, z_component);
+  this_box_storage.normal_vectors[3] = coords_set (-x_component, 0, z_component);
 
-this_box_storage.normal_vectors[2] = coords_set(x_component,0,z_component);
-this_box_storage.normal_vectors[3] = coords_set(-x_component,0,z_component);
+  // for sides with x component = 0
+  y_component = 2 * zdepth / sqrt ((yheight - yheight2) * (yheight - yheight2) + 4 * zdepth * zdepth);
+  z_component = (yheight - yheight2) / sqrt (4 * zdepth * zdepth + (yheight - yheight2) * (yheight - yheight2));
 
-// for sides with x component = 0
-y_component = 2*zdepth/sqrt((yheight-yheight2)*(yheight-yheight2)+4*zdepth*zdepth);
-z_component = (yheight-yheight2)/sqrt(4*zdepth*zdepth+(yheight-yheight2)*(yheight-yheight2));
+  this_box_storage.normal_vectors[4] = coords_set (0, y_component, z_component);
+  this_box_storage.normal_vectors[5] = coords_set (0, -y_component, z_component);
 
-this_box_storage.normal_vectors[4] = coords_set(0,y_component,z_component);
-this_box_storage.normal_vectors[5] = coords_set(0,-y_component,z_component);
+  this_box_volume.geometry.visualization_on = visualize;
 
-this_box_volume.geometry.visualization_on = visualize;
+  this_box_volume.geometry.geometry_parameters.p_box_storage = &this_box_storage;
 
-this_box_volume.geometry.geometry_parameters.p_box_storage = &this_box_storage;
+  // Assign pointers to functions for intersection with the shape, checking if a point is inside the shape
+  if (this_box_storage.is_rectangle == 1) {
+    this_box_volume.geometry.intersect_function = &sample_box_intersect_simple;
+    this_box_volume.geometry.within_function = &r_within_box_simple;
+  } else {
+    this_box_volume.geometry.intersect_function = &sample_box_intersect_advanced;
+    this_box_volume.geometry.within_function = &r_within_box_advanced;
+  }
 
-// Assign pointers to functions for intersection with the shape, checking if a point is inside the shape
-if (this_box_storage.is_rectangle == 1) {
-this_box_volume.geometry.intersect_function = &sample_box_intersect_simple;
-this_box_volume.geometry.within_function = &r_within_box_simple;
-}
-else {
-this_box_volume.geometry.intersect_function = &sample_box_intersect_advanced;
-this_box_volume.geometry.within_function = &r_within_box_advanced;
-}
+  this_box_volume.geometry.shell_points = &box_shell_points;
+  this_box_volume.geometry.mcdisplay_function = &mcdisplay_box_function;
+  this_box_volume.geometry.initialize_from_main_function = &initialize_box_geometry_from_main_component;
+  this_box_volume.geometry.process_rot_allocated = 0;
 
-this_box_volume.geometry.shell_points = &box_shell_points;
-this_box_volume.geometry.mcdisplay_function = &mcdisplay_box_function;
-this_box_volume.geometry.initialize_from_main_function = &initialize_box_geometry_from_main_component;
-this_box_volume.geometry.process_rot_allocated = 0;
+  this_box_volume.geometry.copy_geometry_parameters = &allocate_box_storage_copy;
 
-this_box_volume.geometry.copy_geometry_parameters = &allocate_box_storage_copy;
+  rot_copy (this_box_volume.geometry.rotation_matrix, ROT_A_CURRENT_COMP); // check how ROT_R_CURRENT_COMP would work
+  rot_transpose (ROT_A_CURRENT_COMP, this_box_volume.geometry.transpose_rotation_matrix);
 
-rot_copy(this_box_volume.geometry.rotation_matrix,ROT_A_CURRENT_COMP); //check how ROT_R_CURRENT_COMP would work
-rot_transpose(ROT_A_CURRENT_COMP,this_box_volume.geometry.transpose_rotation_matrix);
+  // Initialize loggers
+  this_box_volume.loggers.num_elements = 0;
+  this_box_volume.abs_loggers.num_elements = 0;
 
-// Initialize loggers
-this_box_volume.loggers.num_elements = 0;
-this_box_volume.abs_loggers.num_elements = 0;
-
-// packing the information into the global_geometry_element, which is then included in the global_geometry_list.
-sprintf(global_geometry_element.name,NAME_CURRENT_COMP);
-global_geometry_element.activation_counter = number_of_activations;
-global_geometry_element.component_index = INDEX_CURRENT_COMP;
-global_geometry_element.Volume = &this_box_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
-//char *test_component;
-//char *sigma_name;
-//COMP_GETPAR(test_component, sigma_name);
-add_element_to_geometry_list(global_geometry_list, global_geometry_element);
+  // packing the information into the global_geometry_element, which is then included in the global_geometry_list.
+  sprintf (global_geometry_element.name, NAME_CURRENT_COMP);
+  global_geometry_element.activation_counter = number_of_activations;
+  global_geometry_element.component_index = INDEX_CURRENT_COMP;
+  global_geometry_element.Volume = &this_box_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
+  // char *test_component;
+  // char *sigma_name;
+  // COMP_GETPAR(test_component, sigma_name);
+  add_element_to_geometry_list (global_geometry_list, global_geometry_element);
 %}
 
 TRACE

--- a/mcxtrace-comps/union/Union_box.comp
+++ b/mcxtrace-comps/union/Union_box.comp
@@ -77,8 +77,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Union_cone.comp
+++ b/mcxtrace-comps/union/Union_cone.comp
@@ -76,8 +76,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 
@@ -226,13 +224,7 @@ if (yheight <= 0) {
   exit(1);
 }
 
-if (_getcomp_index(init) < 0) {
-fprintf(stderr,"Union_cone:%s: Error identifying Union_init component, %s is not a known component name.\n",
-NAME_CURRENT_COMP, init);
-exit(-1);
-}
-
-struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
+struct pointer_to_global_material_list *global_material_list = &g_material_list;
 // Use sanitation
 #ifdef MATERIAL_DETECTOR
 if (global_material_list->num_elements == 0) {
@@ -251,7 +243,7 @@ if (global_material_list->num_elements == 0) {
 this_cone_volume.geometry.is_masked_volume = 0;
 this_cone_volume.geometry.is_exit_volume = 0;
 this_cone_volume.geometry.is_mask_volume = 0;
-struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
+struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
 
 // Read the material input, or if it lacks, use automatic linking.
 if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {

--- a/mcxtrace-comps/union/Union_cone.comp
+++ b/mcxtrace-comps/union/Union_cone.comp
@@ -73,8 +73,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Union_cone.comp
+++ b/mcxtrace-comps/union/Union_cone.comp
@@ -54,7 +54,6 @@
 * focus_xw:              [m]      Horiz. dimension of a rectangular area
 * focus_xh:              [m]      Vert. dimension of a rectangular area
 * focus_r:               [m]      Focusing on circle with this radius
-* init:                  [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *
@@ -65,20 +64,20 @@
 
 DEFINE COMPONENT Union_cone
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(string material_string=0, priority, radius=0,radius_top=0,radius_bottom=0, yheight, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1, string init="init")
+SETTING PARAMETERS(string material_string=0, priority, radius=0,radius_top=0,radius_bottom=0, yheight, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1)
 OUTPUT PARAMETERS ()
 
 /* X-ray parameters: (x,y,z,kx,ky,kz ,phi, t, Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-
-void mcdisplay_cone_function(struct lines_to_draw *lines_to_draw_output,int index, struct geometry_struct **Geometries,int number_of_volumes) {
+  void
+  mcdisplay_cone_function (struct lines_to_draw* lines_to_draw_output, int index, struct geometry_struct** Geometries, int number_of_volumes) {
     // Function to call in mcdisplay section of the sample component for this volume
     // One can assume that Geometries[index] refers to a geometry as described in this file
     // The 4 lines describin the cylinders side are aligned to the local frame of the cylinder,
@@ -92,30 +91,31 @@ void mcdisplay_cone_function(struct lines_to_draw *lines_to_draw_output,int inde
     Coords direction = Geometries[index]->geometry_parameters.p_cone_storage->direction_vector;
     Coords center = Geometries[index]->center;
 
-    Coords bottom_point = coords_add(center,coords_scalar_mult(direction,-0.5*height));
-    Coords top_point = coords_add(center,coords_scalar_mult(direction,0.5*height));
+    Coords bottom_point = coords_add (center, coords_scalar_mult (direction, -0.5 * height));
+    Coords top_point = coords_add (center, coords_scalar_mult (direction, 0.5 * height));
 
     struct lines_to_draw lines_to_draw_temp;
     lines_to_draw_temp.number_of_lines = 0;
 
-    lines_to_draw_temp = draw_circle_with_highest_priority(top_point,direction,radius_top,index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_circle_with_highest_priority (top_point, direction, radius_top, index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    lines_to_draw_temp = draw_circle_with_highest_priority(bottom_point,direction,radius_bottom,index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_circle_with_highest_priority (bottom_point, direction, radius_bottom, index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    Coords point1,point2;
-    int iterate,number_of_points=4;
+    Coords point1, point2;
+    int iterate, number_of_points = 4;
 
-    for (iterate=0;iterate<number_of_points;iterate++) {
-        point1 = point_on_circle(top_point,direction,radius_top,iterate,number_of_points);
-        point2 = point_on_circle(bottom_point,direction,radius_bottom,iterate,number_of_points);
-        lines_to_draw_temp = draw_line_with_highest_priority(point1,point2,index,Geometries,number_of_volumes,2);
-        merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    for (iterate = 0; iterate < number_of_points; iterate++) {
+      point1 = point_on_circle (top_point, direction, radius_top, iterate, number_of_points);
+      point2 = point_on_circle (bottom_point, direction, radius_bottom, iterate, number_of_points);
+      lines_to_draw_temp = draw_line_with_highest_priority (point1, point2, index, Geometries, number_of_volumes, 2);
+      merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
     }
-};
+  };
 
-void initialize_cone_geometry_from_main_component(struct geometry_struct *cone) {
+  void
+  initialize_cone_geometry_from_main_component (struct geometry_struct* cone) {
     // Function to be called in initialize of the main component
     // This is done as the rotation matrix needs to be relative to the main component instead of global
     // Everything done in initialize in this component file has the rotation matrix relative to global
@@ -124,282 +124,284 @@ void initialize_cone_geometry_from_main_component(struct geometry_struct *cone) 
     Coords cone_vector;
 
     // Start with vector that points along the cone in the local frame
-    simple_vector = coords_set(0,1,0);
+    simple_vector = coords_set (0, 1, 0);
 
     // Rotate the direction vector of the cone to the master component frame of reference
-    cone_vector = rot_apply(cone->rotation_matrix,simple_vector);
-    NORM(cone_vector.x,cone_vector.y,cone_vector.z);
+    cone_vector = rot_apply (cone->rotation_matrix, simple_vector);
+    NORM (cone_vector.x, cone_vector.y, cone_vector.z);
     cone->geometry_parameters.p_cone_storage->direction_vector.x = cone_vector.x;
     cone->geometry_parameters.p_cone_storage->direction_vector.y = cone_vector.y;
     cone->geometry_parameters.p_cone_storage->direction_vector.z = cone_vector.z;
     // if (verbal == 1) printf("Cords vector1 = (%f,%f,%f)\n",cone_vector.x,cone_vector.y,
-}
-
-struct pointer_to_1d_coords_list shell_points(struct geometry_struct *geometry,int max_number_of_points) {
-  // Function that returns a number (less than max) of points on the geometry surface
-  // If used, remember to free the space allocated.
-  int points_per_circle = floor(max_number_of_points/2.0);
-
-  struct pointer_to_1d_coords_list cone_shell_array;
-  cone_shell_array.elements = malloc(2*points_per_circle*sizeof(Coords));
-  cone_shell_array.num_elements = 2*points_per_circle;
-
-  Coords cone_direction = geometry->geometry_parameters.p_cone_storage->direction_vector;
-  Coords center = geometry->center;
-  double radius_top = geometry->geometry_parameters.p_cone_storage->cone_radius_top;
-  double radius_bottom = geometry->geometry_parameters.p_cone_storage->cone_radius_bottom;
-  double height = geometry->geometry_parameters.p_cone_storage->height;
-  int number_of_points_in_array = 0;
-
-  Coords cone_top_point = coords_add(center,coords_scalar_mult(cone_direction,0.5*height));
-  Coords cone_bottom_point = coords_add(center,coords_scalar_mult(cone_direction,-0.5*height));
-
-  if (radius_top != 0){
-  	points_on_circle(cone_shell_array.elements,cone_top_point,cone_direction,radius_top,points_per_circle);
-	//printf("\nAdded point on top cone as index %i - %i\n",number_of_points_in_array,number_of_points_in_array + points_per_circle);
-	number_of_points_in_array += points_per_circle;
-} else {
-	// If this radius is 0 then add a single point instead of a circle
-  	cone_shell_array.elements[0] = cone_top_point;
-	//printf("\nAdded point on top cone as index %i\n",0);
-	number_of_points_in_array += 1;
-}
-  // Need to verify this pointer arithimatic works as intended
-  //points_on_circle(cone_shell_array.elements+points_per_circle,cone_bottom_point,cone_direction,radius_bottom,points_per_circle);
-
-  if (radius_bottom != 0){
-  	points_on_circle(cone_shell_array.elements + number_of_points_in_array,cone_bottom_point,cone_direction,radius_bottom,points_per_circle);
-	//printf("\nAdded point on bottom cone as index %i - %i\n",number_of_points_in_array,number_of_points_in_array + points_per_circle);
-	number_of_points_in_array += points_per_circle;
-  } else {
-	// If this radius is 0 then add a single point instead of a circle
-  	cone_shell_array.elements[number_of_points_in_array] = cone_bottom_point;
-	//printf("\nAdded point on bottom cone as index %i\n",number_of_points_in_array);
-	number_of_points_in_array += 1;
   }
-  cone_shell_array.num_elements = number_of_points_in_array;
-  return cone_shell_array;
-}
 
-#ifndef ANY_GEOMETRY_DETECTOR_DECLARE
-    #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
-    //struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
-#endif
+  struct pointer_to_1d_coords_list
+  shell_points (struct geometry_struct* geometry, int max_number_of_points) {
+    // Function that returns a number (less than max) of points on the geometry surface
+    // If used, remember to free the space allocated.
+    int points_per_circle = floor (max_number_of_points / 2.0);
+
+    struct pointer_to_1d_coords_list cone_shell_array;
+    cone_shell_array.elements = malloc (2 * points_per_circle * sizeof (Coords));
+    cone_shell_array.num_elements = 2 * points_per_circle;
+
+    Coords cone_direction = geometry->geometry_parameters.p_cone_storage->direction_vector;
+    Coords center = geometry->center;
+    double radius_top = geometry->geometry_parameters.p_cone_storage->cone_radius_top;
+    double radius_bottom = geometry->geometry_parameters.p_cone_storage->cone_radius_bottom;
+    double height = geometry->geometry_parameters.p_cone_storage->height;
+    int number_of_points_in_array = 0;
+
+    Coords cone_top_point = coords_add (center, coords_scalar_mult (cone_direction, 0.5 * height));
+    Coords cone_bottom_point = coords_add (center, coords_scalar_mult (cone_direction, -0.5 * height));
+
+    if (radius_top != 0) {
+      points_on_circle (cone_shell_array.elements, cone_top_point, cone_direction, radius_top, points_per_circle);
+      // printf("\nAdded point on top cone as index %i - %i\n",number_of_points_in_array,number_of_points_in_array + points_per_circle);
+      number_of_points_in_array += points_per_circle;
+    } else {
+      // If this radius is 0 then add a single point instead of a circle
+      cone_shell_array.elements[0] = cone_top_point;
+      // printf("\nAdded point on top cone as index %i\n",0);
+      number_of_points_in_array += 1;
+    }
+    // Need to verify this pointer arithimatic works as intended
+    // points_on_circle(cone_shell_array.elements+points_per_circle,cone_bottom_point,cone_direction,radius_bottom,points_per_circle);
+
+    if (radius_bottom != 0) {
+      points_on_circle (cone_shell_array.elements + number_of_points_in_array, cone_bottom_point, cone_direction, radius_bottom, points_per_circle);
+      // printf("\nAdded point on bottom cone as index %i - %i\n",number_of_points_in_array,number_of_points_in_array + points_per_circle);
+      number_of_points_in_array += points_per_circle;
+    } else {
+      // If this radius is 0 then add a single point instead of a circle
+      cone_shell_array.elements[number_of_points_in_array] = cone_bottom_point;
+      // printf("\nAdded point on bottom cone as index %i\n",number_of_points_in_array);
+      number_of_points_in_array += 1;
+    }
+    cone_shell_array.num_elements = number_of_points_in_array;
+    return cone_shell_array;
+  }
+
+  #ifndef ANY_GEOMETRY_DETECTOR_DECLARE
+  #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
+  // struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_geometry_element_struct global_geometry_element;
+  // Needed for transport to the main component
+  struct global_geometry_element_struct global_geometry_element;
 
-int loop_index;
-int loop_2_index;
-int material_index;
+  int loop_index;
+  int loop_2_index;
+  int material_index;
 
-struct Volume_struct this_cone_volume;
-struct cone_storage this_cone_storage;
+  struct Volume_struct this_cone_volume;
+  struct cone_storage this_cone_storage;
 %}
 
 INITIALIZE
 %{
-// Initializes the focusing system for this volume including input sanitation.
-focus_initialize(&this_cone_volume.geometry, POS_A_COMP_INDEX(INDEX_CURRENT_COMP+target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index, target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
+  // Initializes the focusing system for this volume including input sanitation.
+  focus_initialize (&this_cone_volume.geometry, POS_A_COMP_INDEX (INDEX_CURRENT_COMP + target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index,
+                    target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
 
-// Input sanitation for this geometry
-/* Disabled because radius might be 0 on cone
-if (radius <= 0) {
-  printf("\nERROR in Union_cylinder named %s, the radius is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
-*/
+  // Input sanitation for this geometry
+  /* Disabled because radius might be 0 on cone
+  if (radius <= 0) {
+    printf("\nERROR in Union_cylinder named %s, the radius is <= 0. \n",NAME_CURRENT_COMP);
+    exit(1);
+  }
+  */
 
-if (radius > 0){
-	radius_top = radius;
-	radius_bottom = radius;
-}
+  if (radius > 0) {
+    radius_top = radius;
+    radius_bottom = radius;
+  }
 
-if (yheight <= 0) {
-  printf("\nERROR in Union_cone named %s, yheight is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
+  if (yheight <= 0) {
+    printf ("\nERROR in Union_cone named %s, yheight is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
 
-struct pointer_to_global_material_list *global_material_list = &g_material_list;
-// Use sanitation
-#ifdef MATERIAL_DETECTOR
-if (global_material_list->num_elements == 0) {
-  // Here if the user have defined a material, but only after this material
-  printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
-  printf("       %s was defined before first use of Union_make_material.\n",NAME_CURRENT_COMP);
-  exit(1);
-}
-#endif
-#ifndef MATERIAL_DETECTOR
-  printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
-  exit(1);
-#endif
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
+  // Use sanitation
+  #ifdef MATERIAL_DETECTOR
+  if (global_material_list->num_elements == 0) {
+    // Here if the user have defined a material, but only after this material
+    printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
+    printf ("       %s was defined before first use of Union_make_material.\n", NAME_CURRENT_COMP);
+    exit (1);
+  }
+  #endif
+  #ifndef MATERIAL_DETECTOR
+  printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
+  exit (1);
+  #endif
 
+  this_cone_volume.geometry.is_masked_volume = 0;
+  this_cone_volume.geometry.is_exit_volume = 0;
+  this_cone_volume.geometry.is_mask_volume = 0;
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
 
-this_cone_volume.geometry.is_masked_volume = 0;
-this_cone_volume.geometry.is_exit_volume = 0;
-this_cone_volume.geometry.is_mask_volume = 0;
-struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
-
-// Read the material input, or if it lacks, use automatic linking.
-if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {
+  // Read the material input, or if it lacks, use automatic linking.
+  if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.
     // In order for a ray to enter a masked volume, it needs to be both in the region covered by that volume AND the mask volume.
     // When more than
     this_cone_volume.geometry.mask_mode = 1; // Default mask mode is ALL
-    if (mask_setting && strlen(mask_setting) && strcmp(mask_setting, "NULL") && strcmp(mask_setting, "0")) {
-        if (strcmp(mask_setting,"ALL") == 0 || strcmp(mask_setting,"All") == 0) this_cone_volume.geometry.mask_mode = 1;
-        else if (strcmp(mask_setting,"ANY") == 0 || strcmp(mask_setting,"Any") == 0) this_cone_volume.geometry.mask_mode = 2;
-        else {
-            printf("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n",NAME_CURRENT_COMP,mask_setting);
-            exit(1);
-        }
+    if (mask_setting && strlen (mask_setting) && strcmp (mask_setting, "NULL") && strcmp (mask_setting, "0")) {
+      if (strcmp (mask_setting, "ALL") == 0 || strcmp (mask_setting, "All") == 0)
+        this_cone_volume.geometry.mask_mode = 1;
+      else if (strcmp (mask_setting, "ANY") == 0 || strcmp (mask_setting, "Any") == 0)
+        this_cone_volume.geometry.mask_mode = 2;
+      else {
+        printf ("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n", NAME_CURRENT_COMP, mask_setting);
+        exit (1);
+      }
     }
 
     int found_geometries = 0;
-    for (loop_index=0;loop_index<global_geometry_list->num_elements;loop_index++) {
-        // Add mask list
-        if (1 == manual_linking_function(global_geometry_list->elements[loop_index].name,mask_string)) {
-            add_element_to_int_list(&this_cone_volume.geometry.mask_list,global_geometry_list->elements[loop_index].component_index);
-            add_element_to_int_list(&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list,INDEX_CURRENT_COMP);
-            global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
-            if (this_cone_volume.geometry.mask_mode == 2)
-                global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
-            if (this_cone_volume.geometry.mask_mode == 1) {
-                if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1 && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
-                    // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
-                    global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
-            }
-
-            found_geometries = 1;
+    for (loop_index = 0; loop_index < global_geometry_list->num_elements; loop_index++) {
+      // Add mask list
+      if (1 == manual_linking_function (global_geometry_list->elements[loop_index].name, mask_string)) {
+        add_element_to_int_list (&this_cone_volume.geometry.mask_list, global_geometry_list->elements[loop_index].component_index);
+        add_element_to_int_list (&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list, INDEX_CURRENT_COMP);
+        global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
+        if (this_cone_volume.geometry.mask_mode == 2)
+          global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
+        if (this_cone_volume.geometry.mask_mode == 1) {
+          if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1
+              && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
+            // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
+            global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
         }
+
+        found_geometries = 1;
+      }
     }
     if (found_geometries == 0) {
-        printf("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n",NAME_CURRENT_COMP,mask_string);
-        exit(1);
+      printf ("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n", NAME_CURRENT_COMP, mask_string);
+      exit (1);
     }
-    this_cone_volume.p_physics = malloc(sizeof(struct physics_struct));
-    this_cone_volume.p_physics->is_vacuum = 0; // Makes this volume a vacuum
-    this_cone_volume.p_physics->number_of_processes = (int) 0; // Should not be used.
-    this_cone_volume.p_physics->my_a = 0; // Should not be used.
-    sprintf(this_cone_volume.p_physics->name,"Mask");
+    this_cone_volume.p_physics = malloc (sizeof (struct physics_struct));
+    this_cone_volume.p_physics->is_vacuum = 0;                // Makes this volume a vacuum
+    this_cone_volume.p_physics->number_of_processes = (int)0; // Should not be used.
+    this_cone_volume.p_physics->my_a = 0;                     // Should not be used.
+    sprintf (this_cone_volume.p_physics->name, "Mask");
     this_cone_volume.geometry.is_mask_volume = 1;
 
-
-// Read the material input, or if it lacks, use automatic linking.
-} else if (material_string && strlen(material_string) && strcmp(material_string, "NULL") && strcmp(material_string, "0")) {
+    // Read the material input, or if it lacks, use automatic linking.
+  } else if (material_string && strlen (material_string) && strcmp (material_string, "NULL") && strcmp (material_string, "0")) {
     // A geometry string was given, use it to determine which material
-    if (0 == strcmp(material_string,"vacuum") || 0 == strcmp(material_string,"Vacuum")) {
-        // One could have a global physics struct for vacuum instead of creating one for each
-        this_cone_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_cone_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_cone_volume.p_physics->number_of_processes = (int) 0;
-        this_cone_volume.p_physics->my_a = 0; // Should not be used.
-        sprintf(this_cone_volume.p_physics->name,"Vacuum");
-    } else if (0 == strcmp(material_string,"exit") || 0 == strcmp(material_string,"Exit")) {
-        // One could have a global physics struct for exit instead of creating one for each
-        this_cone_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_cone_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_cone_volume.p_physics->number_of_processes = (int) 0;
-        this_cone_volume.p_physics->my_a = 0; // Should not be used.
-        this_cone_volume.geometry.is_exit_volume = 1;
-        sprintf(this_cone_volume.p_physics->name,"Exit");
+    if (0 == strcmp (material_string, "vacuum") || 0 == strcmp (material_string, "Vacuum")) {
+      // One could have a global physics struct for vacuum instead of creating one for each
+      this_cone_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_cone_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_cone_volume.p_physics->number_of_processes = (int)0;
+      this_cone_volume.p_physics->my_a = 0; // Should not be used.
+      sprintf (this_cone_volume.p_physics->name, "Vacuum");
+    } else if (0 == strcmp (material_string, "exit") || 0 == strcmp (material_string, "Exit")) {
+      // One could have a global physics struct for exit instead of creating one for each
+      this_cone_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_cone_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_cone_volume.p_physics->number_of_processes = (int)0;
+      this_cone_volume.p_physics->my_a = 0; // Should not be used.
+      this_cone_volume.geometry.is_exit_volume = 1;
+      sprintf (this_cone_volume.p_physics->name, "Exit");
     } else {
-        for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++) {
-          if (0 == strcmp(material_string,global_material_list->elements[loop_index].name)) {
-            this_cone_volume.p_physics = global_material_list->elements[loop_index].physics;
-            break;
-          }
-          if (loop_index == global_material_list->num_elements-1) {
-            printf("\n");
-            printf("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n",material_string,NAME_CURRENT_COMP);
-            printf("       The materials available at this point (need to be defined before the geometry): \n");
-            for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++)
-              printf("         %s\n",global_material_list->elements[loop_index].name);
-            printf("\n");
-            printf("       It is also possible to use one of the defualt materials avaiable: \n");
-            printf("           Vacuum (for a Volume without scattering or absorption)\n");
-            printf("           Exit (for a Volume where the ray exits the component if it enters)\n");
-            printf("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
-            exit(1);
-          }
+      for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++) {
+        if (0 == strcmp (material_string, global_material_list->elements[loop_index].name)) {
+          this_cone_volume.p_physics = global_material_list->elements[loop_index].physics;
+          break;
         }
+        if (loop_index == global_material_list->num_elements - 1) {
+          printf ("\n");
+          printf ("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n", material_string, NAME_CURRENT_COMP);
+          printf ("       The materials available at this point (need to be defined before the geometry): \n");
+          for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++)
+            printf ("         %s\n", global_material_list->elements[loop_index].name);
+          printf ("\n");
+          printf ("       It is also possible to use one of the defualt materials avaiable: \n");
+          printf ("           Vacuum (for a Volume without scattering or absorption)\n");
+          printf ("           Exit (for a Volume where the ray exits the component if it enters)\n");
+          printf ("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
+          exit (1);
+        }
+      }
     }
-} else {
+  } else {
     // Automatic linking, simply using the last defined material.
     #ifndef MATERIAL_DETECTOR
-        printf("Need to define a material before the geometry to use automatic linking %s.\n",NAME_CURRENT_COMP);
-        exit(1);
+    printf ("Need to define a material before the geometry to use automatic linking %s.\n", NAME_CURRENT_COMP);
+    exit (1);
     #endif
-    this_cone_volume.p_physics = global_material_list->elements[global_material_list->num_elements-1].physics;
-}
+    this_cone_volume.p_physics = global_material_list->elements[global_material_list->num_elements - 1].physics;
+  }
 
-// check if this is a cylinder and add coordinates of tip if it is a cone
+  // check if this is a cylinder and add coordinates of tip if it is a cone
 
-/*
-Coords center = POS_A_CURRENT_COMP;
-Coords cone_direction = ROT_A_CURRENT_COMP;
-Coords cone_top_point = coords_add(center,coords_scalar_mult(cone_direction,0.5*yheight));
-Coords cone_bottom_point = coords_add(center,coords_scalar_mult(cone_direction,-0.5*yheight));
-*/
-//double cone_gradient = (radius_bottom-radius_top)/yheight;
+  /*
+  Coords center = POS_A_CURRENT_COMP;
+  Coords cone_direction = ROT_A_CURRENT_COMP;
+  Coords cone_top_point = coords_add(center,coords_scalar_mult(cone_direction,0.5*yheight));
+  Coords cone_bottom_point = coords_add(center,coords_scalar_mult(cone_direction,-0.5*yheight));
+  */
+  // double cone_gradient = (radius_bottom-radius_top)/yheight;
 
-int is_cylinder = 0;
-if (radius_top==radius_bottom){
+  int is_cylinder = 0;
+  if (radius_top == radius_bottom) {
     is_cylinder = 1;
-}
-/*
-double cone_tip_yheight = 0;
-double theta = 0;
-if (is_cylinder == 0){
-    cone_tip_yheight = 0.5*yheight+1/cone_gradient*radius_top;
-    theta = asin(cone_gradient)*(180/3.14159265359)/2;
-    printf("\nTheta = %2.2f \n",theta);
-}
-*/
+  }
+  /*
+  double cone_tip_yheight = 0;
+  double theta = 0;
+  if (is_cylinder == 0){
+      cone_tip_yheight = 0.5*yheight+1/cone_gradient*radius_top;
+      theta = asin(cone_gradient)*(180/3.14159265359)/2;
+      printf("\nTheta = %2.2f \n",theta);
+  }
+  */
 
-this_cone_storage.cone_radius_top = radius_top;
-this_cone_storage.cone_radius_bottom = radius_bottom;
-//this_cone_storage.is_cylinder = is_cylinder;
-//this_cone_storage.cone_tip_yheight = cone_tip_yheight;
-this_cone_storage.height = yheight;
-//this_cone_storage.theta = theta;
+  this_cone_storage.cone_radius_top = radius_top;
+  this_cone_storage.cone_radius_bottom = radius_bottom;
+  // this_cone_storage.is_cylinder = is_cylinder;
+  // this_cone_storage.cone_tip_yheight = cone_tip_yheight;
+  this_cone_storage.height = yheight;
+  // this_cone_storage.theta = theta;
 
+  sprintf (this_cone_volume.name, NAME_CURRENT_COMP);
+  sprintf (this_cone_volume.geometry.shape, "cone");
+  this_cone_volume.geometry.eShape = cone;
+  this_cone_volume.geometry.priority_value = priority;
+  // Currently the coordinates will be in absolute space.
+  this_cone_volume.geometry.center = POS_A_CURRENT_COMP;
 
-sprintf(this_cone_volume.name,NAME_CURRENT_COMP);
-sprintf(this_cone_volume.geometry.shape,"cone");
-this_cone_volume.geometry.eShape = cone;
-this_cone_volume.geometry.priority_value = priority;
-// Currently the coordinates will be in absolute space.
-this_cone_volume.geometry.center = POS_A_CURRENT_COMP;
+  this_cone_volume.geometry.geometry_p_interact = p_interact;
 
-this_cone_volume.geometry.geometry_p_interact = p_interact;
+  this_cone_volume.geometry.visualization_on = visualize;
+  this_cone_volume.geometry.geometry_parameters.p_cone_storage = &this_cone_storage;
+  this_cone_volume.geometry.within_function = &r_within_cone;
+  this_cone_volume.geometry.intersect_function = &sample_cone_intersect;
+  this_cone_volume.geometry.mcdisplay_function = &mcdisplay_cone_function;
+  this_cone_volume.geometry.shell_points = &shell_points;
+  this_cone_volume.geometry.initialize_from_main_function = &initialize_cone_geometry_from_main_component;
+  this_cone_volume.geometry.process_rot_allocated = 0;
+  this_cone_volume.geometry.copy_geometry_parameters = &allocate_cone_storage_copy;
+  rot_copy (this_cone_volume.geometry.rotation_matrix, ROT_A_CURRENT_COMP);
+  rot_transpose (ROT_A_CURRENT_COMP, this_cone_volume.geometry.transpose_rotation_matrix);
 
-this_cone_volume.geometry.visualization_on = visualize;
-this_cone_volume.geometry.geometry_parameters.p_cone_storage = &this_cone_storage;
-this_cone_volume.geometry.within_function = &r_within_cone;
-this_cone_volume.geometry.intersect_function = &sample_cone_intersect;
-this_cone_volume.geometry.mcdisplay_function = &mcdisplay_cone_function;
-this_cone_volume.geometry.shell_points = &shell_points;
-this_cone_volume.geometry.initialize_from_main_function = &initialize_cone_geometry_from_main_component;
-this_cone_volume.geometry.process_rot_allocated = 0;
-this_cone_volume.geometry.copy_geometry_parameters = &allocate_cone_storage_copy;
-rot_copy(this_cone_volume.geometry.rotation_matrix,ROT_A_CURRENT_COMP);
-rot_transpose(ROT_A_CURRENT_COMP,this_cone_volume.geometry.transpose_rotation_matrix);
+  // Initialize loggers
+  this_cone_volume.loggers.num_elements = 0;
+  this_cone_volume.abs_loggers.num_elements = 0;
 
-// Initialize loggers
-this_cone_volume.loggers.num_elements = 0;
-this_cone_volume.abs_loggers.num_elements = 0;
-
-// packing the information into the global_geometry_element, which is then included in the global_geometry_list.
-sprintf(global_geometry_element.name,NAME_CURRENT_COMP);
-global_geometry_element.activation_counter = number_of_activations;
-global_geometry_element.component_index = INDEX_CURRENT_COMP;
-global_geometry_element.Volume = &this_cone_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
-add_element_to_geometry_list(global_geometry_list,global_geometry_element);
+  // packing the information into the global_geometry_element, which is then included in the global_geometry_list.
+  sprintf (global_geometry_element.name, NAME_CURRENT_COMP);
+  global_geometry_element.activation_counter = number_of_activations;
+  global_geometry_element.component_index = INDEX_CURRENT_COMP;
+  global_geometry_element.Volume = &this_cone_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
+  add_element_to_geometry_list (global_geometry_list, global_geometry_element);
 %}
 
 TRACE

--- a/mcxtrace-comps/union/Union_cone.comp
+++ b/mcxtrace-comps/union/Union_cone.comp
@@ -72,7 +72,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_cone requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Union_cylinder.comp
+++ b/mcxtrace-comps/union/Union_cylinder.comp
@@ -74,8 +74,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 
@@ -194,13 +192,7 @@ if (yheight <= 0) {
   exit(1);
 }
 
-if (_getcomp_index(init) < 0) {
-fprintf(stderr,"Union_cylinder:%s: Error identifying Union_init component, %s is not a known component name.\n",
-NAME_CURRENT_COMP, init);
-exit(-1);
-}
-
-struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
+struct pointer_to_global_material_list *global_material_list = &g_material_list;
 // Use sanitation
 #ifdef MATERIAL_DETECTOR
 if (global_material_list->num_elements == 0) {
@@ -219,7 +211,7 @@ if (global_material_list->num_elements == 0) {
 this_cylinder_volume.geometry.is_masked_volume = 0;
 this_cylinder_volume.geometry.is_exit_volume = 0;
 this_cylinder_volume.geometry.is_mask_volume = 0;
-struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
+struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
 
 // Read the material input, or if it lacks, use automatic linking.
 if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {

--- a/mcxtrace-comps/union/Union_cylinder.comp
+++ b/mcxtrace-comps/union/Union_cylinder.comp
@@ -52,7 +52,6 @@
 * focus_xw:   [m]   horiz. dimension of a rectangular area
 * focus_xh:   [m]   vert. dimension of a rectangular area
 * focus_r:   [m]   focusing on circle with this radius
-* init:                  [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *
@@ -63,20 +62,20 @@
 
 DEFINE COMPONENT Union_cylinder
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(string material_string=0, priority, radius, yheight, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1, string init="init")
+SETTING PARAMETERS(string material_string=0, priority, radius, yheight, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1)
 OUTPUT PARAMETERS ()
 
 /* X-ray parameters: (x,y,z,kx,ky,kz ,phi, t, Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-
-void mcdisplay_cylinder_function(struct lines_to_draw *lines_to_draw_output,int index, struct geometry_struct **Geometries,int number_of_volumes) {
+  void
+  mcdisplay_cylinder_function (struct lines_to_draw* lines_to_draw_output, int index, struct geometry_struct** Geometries, int number_of_volumes) {
     // Function to call in mcdisplay section of the sample component for this volume
     // One can assume that Geometries[index] refers to a geometry as described in this file
     // The 4 lines describin the cylinders side are aligned to the local frame of the cylinder,
@@ -89,30 +88,31 @@ void mcdisplay_cylinder_function(struct lines_to_draw *lines_to_draw_output,int 
     Coords direction = Geometries[index]->geometry_parameters.p_cylinder_storage->direction_vector;
     Coords center = Geometries[index]->center;
 
-    Coords bottom_point = coords_add(center,coords_scalar_mult(direction,0.5*height));
-    Coords top_point = coords_add(center,coords_scalar_mult(direction,-0.5*height));
+    Coords bottom_point = coords_add (center, coords_scalar_mult (direction, 0.5 * height));
+    Coords top_point = coords_add (center, coords_scalar_mult (direction, -0.5 * height));
 
     struct lines_to_draw lines_to_draw_temp;
     lines_to_draw_temp.number_of_lines = 0;
 
-    lines_to_draw_temp = draw_circle_with_highest_priority(top_point,direction,radius,index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_circle_with_highest_priority (top_point, direction, radius, index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    lines_to_draw_temp = draw_circle_with_highest_priority(bottom_point,direction,radius,index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_circle_with_highest_priority (bottom_point, direction, radius, index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    Coords point1,point2;
-    int iterate,number_of_points=4;
+    Coords point1, point2;
+    int iterate, number_of_points = 4;
 
-    for (iterate=0;iterate<number_of_points;iterate++) {
-        point1 = point_on_circle(top_point,direction,radius,iterate,number_of_points);
-        point2 = point_on_circle(bottom_point,direction,radius,iterate,number_of_points);
-        lines_to_draw_temp = draw_line_with_highest_priority(point1,point2,index,Geometries,number_of_volumes,2);
-        merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    for (iterate = 0; iterate < number_of_points; iterate++) {
+      point1 = point_on_circle (top_point, direction, radius, iterate, number_of_points);
+      point2 = point_on_circle (bottom_point, direction, radius, iterate, number_of_points);
+      lines_to_draw_temp = draw_line_with_highest_priority (point1, point2, index, Geometries, number_of_volumes, 2);
+      merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
     }
-};
+  };
 
-void initialize_cylinder_geometry_from_main_component(struct geometry_struct *cylinder) {
+  void
+  initialize_cylinder_geometry_from_main_component (struct geometry_struct* cylinder) {
     // Function to be called in initialize of the main component
     // This is done as the rotation matrix needs to be relative to the main component instead of global
     // Everything done in initialize in this component file has the rotation matrix relative to global
@@ -121,223 +121,226 @@ void initialize_cylinder_geometry_from_main_component(struct geometry_struct *cy
     Coords cyl_vector;
 
     // Start with vector that points along the cylinder in the local frame
-    simple_vector = coords_set(0,1,0);
+    simple_vector = coords_set (0, 1, 0);
 
     // Rotate the direction vector of the cylinder to the master component frame of reference
-    cyl_vector = rot_apply(cylinder->rotation_matrix,simple_vector);
-    NORM(cyl_vector.x,cyl_vector.y,cyl_vector.z);
+    cyl_vector = rot_apply (cylinder->rotation_matrix, simple_vector);
+    NORM (cyl_vector.x, cyl_vector.y, cyl_vector.z);
     cylinder->geometry_parameters.p_cylinder_storage->direction_vector.x = cyl_vector.x;
     cylinder->geometry_parameters.p_cylinder_storage->direction_vector.y = cyl_vector.y;
     cylinder->geometry_parameters.p_cylinder_storage->direction_vector.z = cyl_vector.z;
     // if (verbal == 1) printf("Cords vector1 = (%f,%f,%f)\n",cyl_vector.x,cyl_vector.y,
-}
+  }
 
-struct pointer_to_1d_coords_list cylinder_shell_points(struct geometry_struct *geometry,int max_number_of_points) {
-  // Function that returns a number (less than max) of points on the geometry surface
-  // If used, remember to free the space allocated.
-  int points_per_circle = floor(max_number_of_points/2.0);
+  struct pointer_to_1d_coords_list
+  cylinder_shell_points (struct geometry_struct* geometry, int max_number_of_points) {
+    // Function that returns a number (less than max) of points on the geometry surface
+    // If used, remember to free the space allocated.
+    int points_per_circle = floor (max_number_of_points / 2.0);
 
-  struct pointer_to_1d_coords_list cylinder_shell_array;
-  cylinder_shell_array.elements = malloc(2*points_per_circle*sizeof(Coords));
-  cylinder_shell_array.num_elements = 2*points_per_circle;
+    struct pointer_to_1d_coords_list cylinder_shell_array;
+    cylinder_shell_array.elements = malloc (2 * points_per_circle * sizeof (Coords));
+    cylinder_shell_array.num_elements = 2 * points_per_circle;
 
-  Coords cyl_direction = geometry->geometry_parameters.p_cylinder_storage->direction_vector;
-  Coords center = geometry->center;
-  double radius = geometry->geometry_parameters.p_cylinder_storage->cyl_radius;
-  double height = geometry->geometry_parameters.p_cylinder_storage->height;
+    Coords cyl_direction = geometry->geometry_parameters.p_cylinder_storage->direction_vector;
+    Coords center = geometry->center;
+    double radius = geometry->geometry_parameters.p_cylinder_storage->cyl_radius;
+    double height = geometry->geometry_parameters.p_cylinder_storage->height;
 
-  Coords cyl_top_point = coords_add(center,coords_scalar_mult(cyl_direction,0.5*height));
-  Coords cyl_bottom_point = coords_add(center,coords_scalar_mult(cyl_direction,-0.5*height));
+    Coords cyl_top_point = coords_add (center, coords_scalar_mult (cyl_direction, 0.5 * height));
+    Coords cyl_bottom_point = coords_add (center, coords_scalar_mult (cyl_direction, -0.5 * height));
 
-  points_on_circle(cylinder_shell_array.elements,cyl_top_point,cyl_direction,radius,points_per_circle);
-  // Need to verify this pointer arithimatic works as intended
-  points_on_circle(cylinder_shell_array.elements+points_per_circle,cyl_bottom_point,cyl_direction,radius,points_per_circle);
+    points_on_circle (cylinder_shell_array.elements, cyl_top_point, cyl_direction, radius, points_per_circle);
+    // Need to verify this pointer arithimatic works as intended
+    points_on_circle (cylinder_shell_array.elements + points_per_circle, cyl_bottom_point, cyl_direction, radius, points_per_circle);
 
-  return cylinder_shell_array;
-}
+    return cylinder_shell_array;
+  }
 
-#ifndef ANY_GEOMETRY_DETECTOR_DECLARE
-    #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
-    //struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
-#endif
+  #ifndef ANY_GEOMETRY_DETECTOR_DECLARE
+  #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
+  // struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_geometry_element_struct global_geometry_element;
+  // Needed for transport to the main component
+  struct global_geometry_element_struct global_geometry_element;
 
-int loop_index;
-int loop_2_index;
-int material_index;
+  int loop_index;
+  int loop_2_index;
+  int material_index;
 
-struct Volume_struct this_cylinder_volume;
-struct cylinder_storage this_cylinder_storage;
+  struct Volume_struct this_cylinder_volume;
+  struct cylinder_storage this_cylinder_storage;
 %}
 
 INITIALIZE
 %{
-// Initializes the focusing system for this volume including input sanitation.
-focus_initialize(&this_cylinder_volume.geometry, POS_A_COMP_INDEX(INDEX_CURRENT_COMP+target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index, target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
+  // Initializes the focusing system for this volume including input sanitation.
+  focus_initialize (&this_cylinder_volume.geometry, POS_A_COMP_INDEX (INDEX_CURRENT_COMP + target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index,
+                    target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
 
-// Input sanitation for this geometry
-if (radius <= 0) {
-  printf("\nERROR in Union_cylinder named %s, the radius is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
+  // Input sanitation for this geometry
+  if (radius <= 0) {
+    printf ("\nERROR in Union_cylinder named %s, the radius is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
 
-if (yheight <= 0) {
-  printf("\nERROR in Union_cylinder named %s, yheight is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
+  if (yheight <= 0) {
+    printf ("\nERROR in Union_cylinder named %s, yheight is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
 
-struct pointer_to_global_material_list *global_material_list = &g_material_list;
-// Use sanitation
-#ifdef MATERIAL_DETECTOR
-if (global_material_list->num_elements == 0) {
-  // Here if the user have defined a material, but only after this material
-  printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
-  printf("       %s was defined before first use of Union_make_material.\n",NAME_CURRENT_COMP);
-  exit(1);
-}
-#endif
-#ifndef MATERIAL_DETECTOR
-  printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
-  exit(1);
-#endif
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
+  // Use sanitation
+  #ifdef MATERIAL_DETECTOR
+  if (global_material_list->num_elements == 0) {
+    // Here if the user have defined a material, but only after this material
+    printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
+    printf ("       %s was defined before first use of Union_make_material.\n", NAME_CURRENT_COMP);
+    exit (1);
+  }
+  #endif
+  #ifndef MATERIAL_DETECTOR
+  printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
+  exit (1);
+  #endif
 
+  this_cylinder_volume.geometry.is_masked_volume = 0;
+  this_cylinder_volume.geometry.is_exit_volume = 0;
+  this_cylinder_volume.geometry.is_mask_volume = 0;
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
 
-this_cylinder_volume.geometry.is_masked_volume = 0;
-this_cylinder_volume.geometry.is_exit_volume = 0;
-this_cylinder_volume.geometry.is_mask_volume = 0;
-struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
-
-// Read the material input, or if it lacks, use automatic linking.
-if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {
+  // Read the material input, or if it lacks, use automatic linking.
+  if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.
     // In order for a ray to enter a masked volume, it needs to be both in the region covered by that volume AND the mask volume.
     // When more than
     this_cylinder_volume.geometry.mask_mode = 1; // Default is mask mode is ALL
-    if (mask_setting && strlen(mask_setting) && strcmp(mask_setting, "NULL") && strcmp(mask_setting, "0")) {
-        if (strcmp(mask_setting,"ALL") == 0 || strcmp(mask_setting,"All") == 0) this_cylinder_volume.geometry.mask_mode = 1;
-        else if (strcmp(mask_setting,"ANY") == 0 || strcmp(mask_setting,"Any") == 0) this_cylinder_volume.geometry.mask_mode = 2;
-        else {
-            printf("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n",NAME_CURRENT_COMP,mask_setting);
-            exit(1);
-        }
+    if (mask_setting && strlen (mask_setting) && strcmp (mask_setting, "NULL") && strcmp (mask_setting, "0")) {
+      if (strcmp (mask_setting, "ALL") == 0 || strcmp (mask_setting, "All") == 0)
+        this_cylinder_volume.geometry.mask_mode = 1;
+      else if (strcmp (mask_setting, "ANY") == 0 || strcmp (mask_setting, "Any") == 0)
+        this_cylinder_volume.geometry.mask_mode = 2;
+      else {
+        printf ("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n", NAME_CURRENT_COMP, mask_setting);
+        exit (1);
+      }
     }
 
     int found_geometries = 0;
-    for (loop_index=0;loop_index<global_geometry_list->num_elements;loop_index++) {
-        // Add mask list
-        if (1 == manual_linking_function(global_geometry_list->elements[loop_index].name,mask_string)) {
-            add_element_to_int_list(&this_cylinder_volume.geometry.mask_list,global_geometry_list->elements[loop_index].component_index);
-            add_element_to_int_list(&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list,INDEX_CURRENT_COMP);
-            global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
-            if (this_cylinder_volume.geometry.mask_mode == 2)
-                global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
-            if (this_cylinder_volume.geometry.mask_mode == 1) {
-                if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1 && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
-                    // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
-                    global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
-            }
-
-            found_geometries = 1;
+    for (loop_index = 0; loop_index < global_geometry_list->num_elements; loop_index++) {
+      // Add mask list
+      if (1 == manual_linking_function (global_geometry_list->elements[loop_index].name, mask_string)) {
+        add_element_to_int_list (&this_cylinder_volume.geometry.mask_list, global_geometry_list->elements[loop_index].component_index);
+        add_element_to_int_list (&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list, INDEX_CURRENT_COMP);
+        global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
+        if (this_cylinder_volume.geometry.mask_mode == 2)
+          global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
+        if (this_cylinder_volume.geometry.mask_mode == 1) {
+          if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1
+              && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
+            // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
+            global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
         }
+
+        found_geometries = 1;
+      }
     }
     if (found_geometries == 0) {
-        printf("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n",NAME_CURRENT_COMP,mask_string);
-        exit(1);
+      printf ("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n", NAME_CURRENT_COMP, mask_string);
+      exit (1);
     }
-    this_cylinder_volume.p_physics = malloc(sizeof(struct physics_struct));
-    this_cylinder_volume.p_physics->is_vacuum = 0; // Makes this volume a vacuum
-    this_cylinder_volume.p_physics->number_of_processes = (int) 0; // Should not be used.
-    this_cylinder_volume.p_physics->my_a = 0; // Should not be used.
-    sprintf(this_cylinder_volume.p_physics->name,"Mask");
+    this_cylinder_volume.p_physics = malloc (sizeof (struct physics_struct));
+    this_cylinder_volume.p_physics->is_vacuum = 0;                // Makes this volume a vacuum
+    this_cylinder_volume.p_physics->number_of_processes = (int)0; // Should not be used.
+    this_cylinder_volume.p_physics->my_a = 0;                     // Should not be used.
+    sprintf (this_cylinder_volume.p_physics->name, "Mask");
     this_cylinder_volume.geometry.is_mask_volume = 1;
 
-
-// Read the material input, or if it lacks, use automatic linking.
-} else if (material_string && strlen(material_string) && strcmp(material_string, "NULL") && strcmp(material_string, "0")) {
+    // Read the material input, or if it lacks, use automatic linking.
+  } else if (material_string && strlen (material_string) && strcmp (material_string, "NULL") && strcmp (material_string, "0")) {
     // A geometry string was given, use it to determine which material
-    if (0 == strcmp(material_string,"vacuum") || 0 == strcmp(material_string,"Vacuum")) {
-        // One could have a global physics struct for vacuum instead of creating one for each
-        this_cylinder_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_cylinder_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_cylinder_volume.p_physics->number_of_processes = (int) 0;
-        this_cylinder_volume.p_physics->my_a = 0; // Should not be used.
-        sprintf(this_cylinder_volume.p_physics->name,"Vacuum");
-    } else if (0 == strcmp(material_string,"exit") || 0 == strcmp(material_string,"Exit")) {
-        // One could have a global physics struct for exit instead of creating one for each
-        this_cylinder_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_cylinder_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_cylinder_volume.p_physics->number_of_processes = (int) 0;
-        this_cylinder_volume.p_physics->my_a = 0; // Should not be used.
-        this_cylinder_volume.geometry.is_exit_volume = 1;
-        sprintf(this_cylinder_volume.p_physics->name,"Exit");
+    if (0 == strcmp (material_string, "vacuum") || 0 == strcmp (material_string, "Vacuum")) {
+      // One could have a global physics struct for vacuum instead of creating one for each
+      this_cylinder_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_cylinder_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_cylinder_volume.p_physics->number_of_processes = (int)0;
+      this_cylinder_volume.p_physics->my_a = 0; // Should not be used.
+      sprintf (this_cylinder_volume.p_physics->name, "Vacuum");
+    } else if (0 == strcmp (material_string, "exit") || 0 == strcmp (material_string, "Exit")) {
+      // One could have a global physics struct for exit instead of creating one for each
+      this_cylinder_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_cylinder_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_cylinder_volume.p_physics->number_of_processes = (int)0;
+      this_cylinder_volume.p_physics->my_a = 0; // Should not be used.
+      this_cylinder_volume.geometry.is_exit_volume = 1;
+      sprintf (this_cylinder_volume.p_physics->name, "Exit");
     } else {
-        for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++) {
-          if (0 == strcmp(material_string,global_material_list->elements[loop_index].name)) {
-            this_cylinder_volume.p_physics = global_material_list->elements[loop_index].physics;
-            break;
-          }
-          if (loop_index == global_material_list->num_elements-1) {
-            printf("\n");
-            printf("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n",material_string,NAME_CURRENT_COMP);
-            printf("       The materials available at this point (need to be defined before the geometry): \n");
-            for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++)
-              printf("         %s\n",global_material_list->elements[loop_index].name);
-            printf("\n");
-            printf("       It is also possible to use one of the defualt materials avaiable: \n");
-            printf("           Vacuum (for a Volume without scattering or absorption)\n");
-            printf("           Exit (for a Volume where the ray exits the component if it enters)\n");
-            printf("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
-            exit(1);
-          }
+      for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++) {
+        if (0 == strcmp (material_string, global_material_list->elements[loop_index].name)) {
+          this_cylinder_volume.p_physics = global_material_list->elements[loop_index].physics;
+          break;
         }
+        if (loop_index == global_material_list->num_elements - 1) {
+          printf ("\n");
+          printf ("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n", material_string, NAME_CURRENT_COMP);
+          printf ("       The materials available at this point (need to be defined before the geometry): \n");
+          for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++)
+            printf ("         %s\n", global_material_list->elements[loop_index].name);
+          printf ("\n");
+          printf ("       It is also possible to use one of the defualt materials avaiable: \n");
+          printf ("           Vacuum (for a Volume without scattering or absorption)\n");
+          printf ("           Exit (for a Volume where the ray exits the component if it enters)\n");
+          printf ("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
+          exit (1);
+        }
+      }
     }
-} else {
+  } else {
     // Automatic linking, simply using the last defined material.
     #ifndef MATERIAL_DETECTOR
-        printf("Need to define a material before the geometry to use automatic linking %s.\n",NAME_CURRENT_COMP);
-        exit(1);
+    printf ("Need to define a material before the geometry to use automatic linking %s.\n", NAME_CURRENT_COMP);
+    exit (1);
     #endif
-    this_cylinder_volume.p_physics = global_material_list->elements[global_material_list->num_elements-1].physics;
-}
+    this_cylinder_volume.p_physics = global_material_list->elements[global_material_list->num_elements - 1].physics;
+  }
 
-sprintf(this_cylinder_volume.name,NAME_CURRENT_COMP);
-sprintf(this_cylinder_volume.geometry.shape,"cylinder");
-this_cylinder_volume.geometry.eShape = cylinder;
-this_cylinder_volume.geometry.priority_value = priority;
-// Currently the coordinates will be in absolute space.
-this_cylinder_volume.geometry.center = POS_A_CURRENT_COMP;
+  sprintf (this_cylinder_volume.name, NAME_CURRENT_COMP);
+  sprintf (this_cylinder_volume.geometry.shape, "cylinder");
+  this_cylinder_volume.geometry.eShape = cylinder;
+  this_cylinder_volume.geometry.priority_value = priority;
+  // Currently the coordinates will be in absolute space.
+  this_cylinder_volume.geometry.center = POS_A_CURRENT_COMP;
 
-this_cylinder_volume.geometry.geometry_p_interact = p_interact;
-this_cylinder_storage.cyl_radius = radius;
-this_cylinder_storage.height = yheight;
-this_cylinder_volume.geometry.visualization_on = visualize;
-this_cylinder_volume.geometry.geometry_parameters.p_cylinder_storage = &this_cylinder_storage;
-this_cylinder_volume.geometry.within_function = &r_within_cylinder;
-this_cylinder_volume.geometry.intersect_function = &sample_cylinder_intersect;
-this_cylinder_volume.geometry.mcdisplay_function = &mcdisplay_cylinder_function;
-this_cylinder_volume.geometry.shell_points = &cylinder_shell_points;
-this_cylinder_volume.geometry.initialize_from_main_function = &initialize_cylinder_geometry_from_main_component;
-this_cylinder_volume.geometry.process_rot_allocated = 0;
-this_cylinder_volume.geometry.copy_geometry_parameters = &allocate_cylinder_storage_copy;
+  this_cylinder_volume.geometry.geometry_p_interact = p_interact;
+  this_cylinder_storage.cyl_radius = radius;
+  this_cylinder_storage.height = yheight;
+  this_cylinder_volume.geometry.visualization_on = visualize;
+  this_cylinder_volume.geometry.geometry_parameters.p_cylinder_storage = &this_cylinder_storage;
+  this_cylinder_volume.geometry.within_function = &r_within_cylinder;
+  this_cylinder_volume.geometry.intersect_function = &sample_cylinder_intersect;
+  this_cylinder_volume.geometry.mcdisplay_function = &mcdisplay_cylinder_function;
+  this_cylinder_volume.geometry.shell_points = &cylinder_shell_points;
+  this_cylinder_volume.geometry.initialize_from_main_function = &initialize_cylinder_geometry_from_main_component;
+  this_cylinder_volume.geometry.process_rot_allocated = 0;
+  this_cylinder_volume.geometry.copy_geometry_parameters = &allocate_cylinder_storage_copy;
 
-rot_copy(this_cylinder_volume.geometry.rotation_matrix,ROT_A_CURRENT_COMP);
-rot_transpose(ROT_A_CURRENT_COMP,this_cylinder_volume.geometry.transpose_rotation_matrix);
+  rot_copy (this_cylinder_volume.geometry.rotation_matrix, ROT_A_CURRENT_COMP);
+  rot_transpose (ROT_A_CURRENT_COMP, this_cylinder_volume.geometry.transpose_rotation_matrix);
 
-// Initialize loggers
-this_cylinder_volume.loggers.num_elements = 0;
-this_cylinder_volume.abs_loggers.num_elements = 0;
+  // Initialize loggers
+  this_cylinder_volume.loggers.num_elements = 0;
+  this_cylinder_volume.abs_loggers.num_elements = 0;
 
-// packing the information into the global_geometry_element, which is then included in the global_geometry_list.
-sprintf(global_geometry_element.name,NAME_CURRENT_COMP);
-global_geometry_element.activation_counter = number_of_activations;
-global_geometry_element.component_index = INDEX_CURRENT_COMP;
-global_geometry_element.Volume = &this_cylinder_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
-add_element_to_geometry_list(global_geometry_list,global_geometry_element);
+  // packing the information into the global_geometry_element, which is then included in the global_geometry_list.
+  sprintf (global_geometry_element.name, NAME_CURRENT_COMP);
+  global_geometry_element.activation_counter = number_of_activations;
+  global_geometry_element.component_index = INDEX_CURRENT_COMP;
+  global_geometry_element.Volume = &this_cylinder_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
+  add_element_to_geometry_list (global_geometry_list, global_geometry_element);
 %}
 
 TRACE

--- a/mcxtrace-comps/union/Union_cylinder.comp
+++ b/mcxtrace-comps/union/Union_cylinder.comp
@@ -70,7 +70,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_cylinder requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Union_cylinder.comp
+++ b/mcxtrace-comps/union/Union_cylinder.comp
@@ -71,8 +71,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Union_init.comp
+++ b/mcxtrace-comps/union/Union_init.comp
@@ -9,38 +9,33 @@
 * Version: $Revision: 0.1 $
 * Origin: ESS DMSC
 *
-* Initialize component that needs to be place before any Union component
+* Deprecated no-op placeholder, kept for backward compatibility.
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
-*  sperates geometry and physics within McStas.
-* The use of this component requires other components to be used.
+*  sperates geometry and physics within McXtrace.
 *
-* 1) One specifies a number of processes using process components
-* 2) These are gathered into material definitions using this component
-* 3) Geometries are placed using Union_box/cylinder/sphere, assigned a material
-* 4) A Union_master component placed after all of the above
+* This component used to be required as the FIRST Union component. It defined
+*  the shared header (union-lib.c) and owned the shared global lists, which the
+*  other Union components reached via COMP_GETPAR3.
 *
-* Only in step 4 will any simulation happen, and per default all geometries
-*  defined before the master, but after the previous will be simulated here.
+* That is no longer needed: the code generator now detects that the instrument
+*  uses Union (by the presence of a Union_master) and auto-injects the shared
+*  header, the global state and the dispatch switch in the right places. The
+*  Union_init and Union_stop components are therefore optional.
 *
-* There is a dedicated manual available for the Union_components
-*
-* Algorithm:
-* Described elsewhere
+* This definition is kept only so that existing instruments that still place a
+*  Union_init component continue to compile. It has no effect.
 *
 * %P
 * INPUT PARAMETERS:
 *
 * OUTPUT PARAMETERS:
 *
-* GLOBAL PARAMETERS:
-* global_material_list:     List of all defined materials, available in the global scope
-*
 * %L
 *
 * %E
-******************************************************************************/
+ ******************************************************************************/
 
 DEFINE COMPONENT Union_init
 DEFINITION PARAMETERS ()
@@ -48,105 +43,18 @@ SETTING PARAMETERS()
 OUTPUT PARAMETERS ()
 
 
-/* Neutron parameters: (x,y,z,vx,vy,vz,t,sx,sy,sz,p) */
+/* X-ray parameters: (x,y,z,kx,ky,kz ,phi, t, Ex,Ey,Ez,p) */
 
 SHARE
 %{
-
-%include "read_table-lib"
-
-#ifdef Union
-printf("ERROR: The Union_init component needs to be the first Union component!\n");
-exit(1);
-#endif
-
-#ifndef Union
-#define Union $Revision: 0.8 $
-
-%include "union-lib.c"
-
-#endif
-
 %}
 
 DECLARE
 %{
-// Initialize global positions / rotations to transform lists
-  // These are lists of pointers to positons / rotations, that will be updated from global frame
-  //  to the frame of the master component that uses them in that masters initialize section.
-  struct global_positions_to_transform_list_struct global_positions_to_transform_list;
-  struct global_rotations_to_transform_list_struct global_rotations_to_transform_list;
-
-// Initialize global_process_list
-  // Used to facilitate communication between processes and the other types of Union components
-  struct pointer_to_global_process_list global_process_list;
-
-// Initialize global_material_list
-  // Used to facilitate communication between materials and the other types of Union components
-  struct pointer_to_global_material_list global_material_list;
-
-// Initialize global_geometry_list
-  // Used to facilitate communication between geometries and the other types of Union components
-  struct pointer_to_global_geometry_list global_geometry_list;
-
-// Initialize global_logger_lists
-  // Used to facilitate communication between loggers and the other types of Union components
-  struct pointer_to_global_logger_list global_all_volume_logger_list;
-  struct pointer_to_global_logger_list global_specific_volumes_logger_list;
-
-// Initialize global_abs_logger_lists
-  struct pointer_to_global_abs_logger_list global_all_volume_abs_logger_list;
-  struct pointer_to_global_abs_logger_list global_specific_volumes_abs_logger_list;
-
-// Initialize global_tagging_conditional_list
-  // Used to facilitate communication between conditionals and the other types of Union components
-  struct global_tagging_conditional_list_struct global_tagging_conditional_list;
-
-// Initialize global_master_list
-  // Used to facilitate communication between Master components (mainly for deallocation)
-  struct pointer_to_global_master_list global_master_list;
-
-// Initialize global_mantid_min_pixel_id
-  // Used for ensuring pixel id's on Mantid monitors do not overlap
-  int global_mantid_min_pixel_id;
 %}
 
 INITIALIZE
 %{
-global_positions_to_transform_list.num_elements = 0;
-global_positions_to_transform_list.positions = NULL;
-
-global_rotations_to_transform_list.num_elements = 0;
-global_rotations_to_transform_list.rotations = NULL;
-
-global_process_list.num_elements = 0;
-global_process_list.elements = NULL;
-
-global_material_list.num_elements = 0;
-global_material_list.elements = NULL;
-
-global_geometry_list.num_elements = 0;
-global_geometry_list.elements = NULL;
-
-global_all_volume_logger_list.num_elements = 0;
-global_all_volume_logger_list.elements = NULL;
-
-global_specific_volumes_logger_list.num_elements = 0;
-global_specific_volumes_logger_list.elements = NULL;
-
-global_all_volume_abs_logger_list.num_elements = 0;
-global_all_volume_abs_logger_list.elements = NULL;
-
-global_specific_volumes_abs_logger_list.num_elements = 0;
-global_specific_volumes_abs_logger_list.elements = NULL;
-
-global_tagging_conditional_list.num_elements = 0;
-global_tagging_conditional_list.elements = NULL;
-
-global_master_list.num_elements = 0;
-global_master_list.elements = NULL;
-
-global_mantid_min_pixel_id = 0;
 %}
 
 TRACE

--- a/mcxtrace-comps/union/Union_init.comp
+++ b/mcxtrace-comps/union/Union_init.comp
@@ -47,6 +47,13 @@ OUTPUT PARAMETERS ()
 
 SHARE
 %{
+#ifndef UNION_LIB_C
+/* Compatibility path for code generators without Union auto-injection. */
+#define Union $Revision: 0.8 $
+%include "read_table-lib.h"
+%include "union-lib.c"
+%include "union-init.c"
+#endif
 %}
 
 DECLARE

--- a/mcxtrace-comps/union/Union_init.comp
+++ b/mcxtrace-comps/union/Union_init.comp
@@ -25,8 +25,8 @@
 *  Union_init and Union_stop components are therefore optional.
 *
 * This definition is kept only so that existing instruments that still place a
- *  Union_init component continue to compile. It emits a deprecation warning
- *  and has no effect.
+*  Union_init component continue to compile. It emits a deprecation warning
+*  and has no effect.
 *
 * %P
 * INPUT PARAMETERS:

--- a/mcxtrace-comps/union/Union_init.comp
+++ b/mcxtrace-comps/union/Union_init.comp
@@ -25,7 +25,8 @@
 *  Union_init and Union_stop components are therefore optional.
 *
 * This definition is kept only so that existing instruments that still place a
-*  Union_init component continue to compile. It has no effect.
+ *  Union_init component continue to compile. It emits a deprecation warning
+ *  and has no effect.
 *
 * %P
 * INPUT PARAMETERS:
@@ -45,31 +46,9 @@ OUTPUT PARAMETERS ()
 
 /* X-ray parameters: (x,y,z,kx,ky,kz ,phi, t, Ex,Ey,Ez,p) */
 
-SHARE
-%{
-#ifndef UNION_LIB_C
-/* Compatibility path for code generators without Union auto-injection. */
-#define Union $Revision: 0.8 $
-%include "read_table-lib.h"
-%include "union-lib.c"
-%include "union-init.c"
-#endif
-%}
-
-DECLARE
-%{
-%}
-
 INITIALIZE
 %{
-%}
-
-TRACE
-%{
-%}
-
-FINALLY
-%{
+  MPI_MASTER (printf ("WARNING: Union_init is deprecated; Union components initialize automatically.\n"););
 %}
 
 END

--- a/mcxtrace-comps/union/Union_make_material.comp
+++ b/mcxtrace-comps/union/Union_make_material.comp
@@ -62,8 +62,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 // This function checks if global_process_element should be included in this material when using automatic linking, returns 1 if yes, 0 if no.
@@ -191,14 +189,8 @@ INITIALIZE
       exit(1);
     }
 
-  if (_getcomp_index(init) < 0) {
-  fprintf(stderr,"Union_make_material:%s: Error identifying Union_init component, %s is not a known component name.\n",
-    NAME_CURRENT_COMP, init);
-  exit(-1);
-  }
-
-struct pointer_to_global_process_list *global_process_list = COMP_GETPAR3(Union_init, init, global_process_list);
-  struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
+struct pointer_to_global_process_list *global_process_list = &g_process_list;
+  struct pointer_to_global_material_list *global_material_list = &g_material_list;
 
   if (absorber == 0) {
     if (process_string && strlen(process_string) && strcmp(process_string,"NULL") && strcmp(process_string, "0")) {
@@ -249,8 +241,8 @@ FINALLY
 if (this_material.number_of_processes > 0) free(this_material.p_scattering_array);
 if (accepted_processes.num_elements > 0) free(accepted_processes.elements);
 
-struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
-struct pointer_to_global_master_list *global_master_list = COMP_GETPAR3(Union_init, init, global_master_list);
+struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
+struct pointer_to_global_master_list *global_master_list = &g_master_list;
 
 // Checking if any Union volumes are defined after the master component
 #ifdef MASTER_DETECTOR

--- a/mcxtrace-comps/union/Union_make_material.comp
+++ b/mcxtrace-comps/union/Union_make_material.comp
@@ -58,7 +58,7 @@ SHARE
   %include "read_table-lib"
 
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_make_material requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Union_make_material.comp
+++ b/mcxtrace-comps/union/Union_make_material.comp
@@ -59,8 +59,7 @@ SHARE
 %include "read_table-lib"
 
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Union_make_material.comp
+++ b/mcxtrace-comps/union/Union_make_material.comp
@@ -35,7 +35,6 @@
 * my_absorption:  [1/m]    Inverse penetration depth from absorption at standard energy
 * absorber:       [0/1]    Control parameter, if set to 1 the material will have no scattering processes
 * material_string: [string] List of elements present in the material. Triggers a search for materials constants files.
-* init:           [string] Name of Union_init component (typically "init", default)
 *
 * CALCULATED PARAMETERS:
 * this_material:            Structure that contains information on this material
@@ -51,121 +50,130 @@
 
 DEFINE COMPONENT Union_make_material
 
-SETTING PARAMETERS(string process_string="NULL",my_absorption,absorber=0, string material_string="NULL", string init="init")
+SETTING PARAMETERS(string process_string="NULL",my_absorption,absorber=0, string material_string="NULL")
 OUTPUT PARAMETERS ()
 
 SHARE
 %{
-%include "read_table-lib"
+  %include "read_table-lib"
 
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-// This function checks if global_process_element should be included in this material when using automatic linking, returns 1 if yes, 0 if no.
-int automatic_linking_materials_function(struct global_process_element_struct global_process_element, struct pointer_to_global_material_list global_material_list,int current_index) {
+  // This function checks if global_process_element should be included in this material when using automatic linking, returns 1 if yes, 0 if no.
+  int
+  automatic_linking_materials_function (struct global_process_element_struct global_process_element, struct pointer_to_global_material_list global_material_list,
+                                        int current_index) {
     // Remember this function is used before the current material is added to global_material_list
     // debug info
-    //MPI_MASTER(
-    //printf("Checking if process with index %d should be automatically linked to material with index %d\n",global_process_element.component_index,current_index);
+    // MPI_MASTER(
+    // printf("Checking if process with index %d should be automatically linked to material with index
+    // %d\n",global_process_element.component_index,current_index);
     //)
 
     // Check if this is the first make_material, which makes the problem simpler.
     if (global_material_list.num_elements == 0) {
-       if (global_process_element.component_index < current_index) return 1;
-       else return 0;
+      if (global_process_element.component_index < current_index)
+        return 1;
+      else
+        return 0;
     }
     // In case there are more than 1 make_material, global_material_list.elements[global_material_list.num_elements-1].component_index makes sense.
-    if (global_process_element.component_index < current_index && global_process_element.component_index > global_material_list.elements[global_material_list.num_elements-1].component_index) return 1;
-    else return 0;
-}
+    if (global_process_element.component_index < current_index
+        && global_process_element.component_index > global_material_list.elements[global_material_list.num_elements - 1].component_index)
+      return 1;
+    else
+      return 0;
+  }
 
-void manual_linking_function_material(char *input_string, struct pointer_to_global_process_list *global_process_list, struct pointer_to_1d_int_list *accepted_processes, char *component_name) {
+  void
+  manual_linking_function_material (char* input_string, struct pointer_to_global_process_list* global_process_list,
+                                    struct pointer_to_1d_int_list* accepted_processes, char* component_name) {
     // Need to check a input_string of text for an occurance of name. If it is in the inputstring, yes return 1, otherwise 0.
-   char *token;
-   int loop_index;
-   char local_string[256];
+    char* token;
+    int loop_index;
+    char local_string[256];
 
-   strcpy(local_string,input_string);
-   // get the first token
-   token = strtok(local_string,",");
+    strcpy (local_string, input_string);
+    // get the first token
+    token = strtok (local_string, ",");
 
-   // walk through other tokens
-   while( token != NULL )
-   {
-      //printf( " %s\n", token );
-      for (loop_index=0;loop_index<global_process_list->num_elements;loop_index++) {
-        if (strcmp(token,global_process_list->elements[loop_index].name) == 0) {
-          add_element_to_int_list(accepted_processes,loop_index);
+    // walk through other tokens
+    while (token != NULL) {
+      // printf( " %s\n", token );
+      for (loop_index = 0; loop_index < global_process_list->num_elements; loop_index++) {
+        if (strcmp (token, global_process_list->elements[loop_index].name) == 0) {
+          add_element_to_int_list (accepted_processes, loop_index);
           break;
         }
 
         if (loop_index == global_process_list->num_elements - 1) {
           // All possible process names have been looked through, and the break was not executed.
           // Alert the user to this problem by showing the process name that was not found and the currently available processes
-            printf("\n");
-            printf("ERROR: The process string \"%s\" in Union material \"%s\" had an entry that did not match a specified process. \n", input_string, component_name);
-            printf("       The unrecognized process name was: \"%s\" \n",token);
-            printf("       The processes available at this point (need to be defined before the material): \n");
-            for (loop_index=0;loop_index<global_process_list->num_elements;loop_index++)
-              printf("         %s\n",global_process_list->elements[loop_index].name);
-            exit(1);
+          printf ("\n");
+          printf ("ERROR: The process string \"%s\" in Union material \"%s\" had an entry that did not match a specified process. \n", input_string,
+                  component_name);
+          printf ("       The unrecognized process name was: \"%s\" \n", token);
+          printf ("       The processes available at this point (need to be defined before the material): \n");
+          for (loop_index = 0; loop_index < global_process_list->num_elements; loop_index++)
+            printf ("         %s\n", global_process_list->elements[loop_index].name);
+          exit (1);
         }
       }
 
       // Updates the token
-      token = strtok(NULL,",");
-   }
-}
+      token = strtok (NULL, ",");
+    }
+  }
 
-// This function is needed in initialize of all geometry components
-// Possible to insert these functions in make material, as they are only compiled once instead of many times
-int manual_linking_function(char *name, char *input_string) {
+  // This function is needed in initialize of all geometry components
+  // Possible to insert these functions in make material, as they are only compiled once instead of many times
+  int
+  manual_linking_function (char* name, char* input_string) {
     // Need to check a input_string of text for an occurance of name. If it is in the inputstring, yes return 1, otherwise 0.
-   char *token;
-   int return_integer=0;
-   char local_string[124];
+    char* token;
+    int return_integer = 0;
+    char local_string[124];
 
-   strcpy(local_string,input_string);
-   /* get the first token */
-   token = strtok(local_string,",");
+    strcpy (local_string, input_string);
+    /* get the first token */
+    token = strtok (local_string, ",");
 
-   /* walk through other tokens */
-   while( token != NULL )
-   {
-      if (strcmp(token,name) == 0) return_integer=1;
+    /* walk through other tokens */
+    while (token != NULL) {
+      if (strcmp (token, name) == 0)
+        return_integer = 1;
 
-      token = strtok(NULL,",");
-   }
+      token = strtok (NULL, ",");
+    }
 
-   return return_integer;
-}
+    return return_integer;
+  }
 
-#ifndef MATERIAL_DETECTOR
-    #define MATERIAL_DETECTOR dummy
-#endif
-
+  #ifndef MATERIAL_DETECTOR
+  #define MATERIAL_DETECTOR dummy
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_material_element_struct global_material_element;
-struct physics_struct this_material;
+  // Needed for transport to the main component
+  struct global_material_element_struct global_material_element;
+  struct physics_struct this_material;
 
-int loop_index;
-int found_process;
-int specified_processes;
-char local_string[256];
+  int loop_index;
+  int found_process;
+  int specified_processes;
+  char local_string[256];
 
-struct pointer_to_1d_int_list accepted_processes;
+  struct pointer_to_1d_int_list accepted_processes;
 
-// Add setup for loggers since make_material is called before any volume / master
-#ifndef UNION_LOGGER_DECLARE
-	#define UNION_LOGGER_DECLARE dummy
-#endif
-
+  // Add setup for loggers since make_material is called before any volume / master
+  #ifndef UNION_LOGGER_DECLARE
+  #define UNION_LOGGER_DECLARE dummy
+  #endif
 %}
 
 INITIALIZE
@@ -173,61 +181,62 @@ INITIALIZE
 
   accepted_processes.num_elements = 0;
   accepted_processes.elements = NULL;
-  
 
-  if (0 == strcmp(NAME_CURRENT_COMP,"vacuum") || 0 == strcmp(NAME_CURRENT_COMP,"Vacuum")) {
-    printf("ERROR, a Union material may not be called Vacuum. A vacuum volume may be created by material=\"Vacuum\" in a geometry component.\n");
-    exit(1);
+  if (0 == strcmp (NAME_CURRENT_COMP, "vacuum") || 0 == strcmp (NAME_CURRENT_COMP, "Vacuum")) {
+    printf ("ERROR, a Union material may not be called Vacuum. A vacuum volume may be created by material=\"Vacuum\" in a geometry component.\n");
+    exit (1);
   }
-  if (0 == strcmp(NAME_CURRENT_COMP,"exit") || 0 == strcmp(NAME_CURRENT_COMP,"Exit")) {
-    printf("ERROR, a Union material may not be called Exit. A exit volume may be created by material=\"Exit\" in a geometry component.\n");
-    exit(1);
+  if (0 == strcmp (NAME_CURRENT_COMP, "exit") || 0 == strcmp (NAME_CURRENT_COMP, "Exit")) {
+    printf ("ERROR, a Union material may not be called Exit. A exit volume may be created by material=\"Exit\" in a geometry component.\n");
+    exit (1);
   }
-    if (my_absorption < 0) {
-      printf("ERROR, Union make material named %s has a negative absorption cross section!.\n",NAME_CURRENT_COMP);
-      exit(1);
-    }
+  if (my_absorption < 0) {
+    printf ("ERROR, Union make material named %s has a negative absorption cross section!.\n", NAME_CURRENT_COMP);
+    exit (1);
+  }
 
-struct pointer_to_global_process_list *global_process_list = &g_process_list;
-  struct pointer_to_global_material_list *global_material_list = &g_material_list;
+  struct pointer_to_global_process_list* global_process_list = &g_process_list;
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
 
   if (absorber == 0) {
-    if (process_string && strlen(process_string) && strcmp(process_string,"NULL") && strcmp(process_string, "0")) {
-        manual_linking_function_material(process_string, global_process_list, &accepted_processes, NAME_CURRENT_COMP);
+    if (process_string && strlen (process_string) && strcmp (process_string, "NULL") && strcmp (process_string, "0")) {
+      manual_linking_function_material (process_string, global_process_list, &accepted_processes, NAME_CURRENT_COMP);
     } else {
-      for (loop_index=0;loop_index<global_process_list->num_elements;loop_index++) {
+      for (loop_index = 0; loop_index < global_process_list->num_elements; loop_index++) {
         // printf("Automatic linking chosen [loop index = %d] with process_string = %s  \n",loop_index,process_string);
         // automatic linking
         // accept a process if index is between current and former index of make_material components
-          if (1 == automatic_linking_materials_function(global_process_list->elements[loop_index], *global_material_list, INDEX_CURRENT_COMP))
-              add_element_to_int_list(&accepted_processes,loop_index);
+        if (1 == automatic_linking_materials_function (global_process_list->elements[loop_index], *global_material_list, INDEX_CURRENT_COMP))
+          add_element_to_int_list (&accepted_processes, loop_index);
       }
     }
   }
 
   this_material.number_of_processes = accepted_processes.num_elements; // Add number of processes
-  this_material.is_vacuum = 0; // This material is not vacuum
+  this_material.is_vacuum = 0;                                         // This material is not vacuum
 
-  if (this_material.number_of_processes == 0 && this_material.number_of_elements==0 && my_absorption == 0) {
-    printf("ERROR, the material named %s has no processes assigned, no material_data_tables assigned nor no absorption cross section, making it eqvialent to vacuum. Vacuums are assigned by setting material=\"Vacuum\" in a geometry component.\n",NAME_CURRENT_COMP);
-    exit(1);
+  if (this_material.number_of_processes == 0 && this_material.number_of_elements == 0 && my_absorption == 0) {
+    printf ("ERROR, the material named %s has no processes assigned, no material_data_tables assigned nor no absorption cross section, making it eqvialent to "
+            "vacuum. Vacuums are assigned by setting material=\"Vacuum\" in a geometry component.\n",
+            NAME_CURRENT_COMP);
+    exit (1);
   }
 
   // add process element to this_material, building an array of processes called p_scattering_array
-  if (this_material.number_of_processes > 0) this_material.p_scattering_array = malloc(this_material.number_of_processes * sizeof(struct scattering_process_struct));
-  for (loop_index=0;loop_index<accepted_processes.num_elements;loop_index++) {
-        this_material.p_scattering_array[loop_index]=*global_process_list->elements[accepted_processes.elements[loop_index]].p_scattering_process;
+  if (this_material.number_of_processes > 0)
+    this_material.p_scattering_array = malloc (this_material.number_of_processes * sizeof (struct scattering_process_struct));
+  for (loop_index = 0; loop_index < accepted_processes.num_elements; loop_index++) {
+    this_material.p_scattering_array[loop_index] = *global_process_list->elements[accepted_processes.elements[loop_index]].p_scattering_process;
   }
 
-  this_material.my_a = my_absorption;  // add the absorption to this material
-  sprintf(this_material.name,"%s",NAME_CURRENT_COMP);
+  this_material.my_a = my_absorption; // add the absorption to this material
+  sprintf (this_material.name, "%s", NAME_CURRENT_COMP);
 
   // packing the information into the global_material_element, which is then included in the global_material_list.
-  sprintf(global_material_element.name,"%s",NAME_CURRENT_COMP);
+  sprintf (global_material_element.name, "%s", NAME_CURRENT_COMP);
   global_material_element.component_index = INDEX_CURRENT_COMP;
   global_material_element.physics = &this_material; // Would be nicer if this material was a pointer, now we have the (small) data two places
-  add_element_to_material_list(global_material_list, global_material_element);
-
+  add_element_to_material_list (global_material_list, global_material_element);
  %}
 
 TRACE
@@ -236,47 +245,47 @@ TRACE
 
 FINALLY
 %{
-// The elements of the scattering array used static allocation and is thus deallocated automatically
-if (this_material.number_of_processes > 0) free(this_material.p_scattering_array);
-if (accepted_processes.num_elements > 0) free(accepted_processes.elements);
+  // The elements of the scattering array used static allocation and is thus deallocated automatically
+  if (this_material.number_of_processes > 0)
+    free (this_material.p_scattering_array);
+  if (accepted_processes.num_elements > 0)
+    free (accepted_processes.elements);
 
-struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
-struct pointer_to_global_master_list *global_master_list = &g_master_list;
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  struct pointer_to_global_master_list* global_master_list = &g_master_list;
 
-// Checking if any Union volumes are defined after the master component
-#ifdef MASTER_DETECTOR
+  // Checking if any Union volumes are defined after the master component
+  #ifdef MASTER_DETECTOR
   #ifdef ANY_GEOMETRY_DETECTOR_DECLARE
-    #ifndef MASTER_DETECTOR_WARNING
-    
-      for (loop_index=0;loop_index<global_geometry_list->num_elements;loop_index++) {
-        if (global_geometry_list->elements[loop_index].component_index > global_master_list->elements[global_master_list->num_elements-1].component_index) {
-          printf("WARNING: No Union_master component defined after Union volume named %s, this components did not affect the simulation in any way.\n",global_geometry_list->elements[loop_index].name);
-        }
-      }
-      // Decided to have this as a warning without exiting the simulation
-      // In order to only show this warning once, the MASTER_DETECTOR_WARNING is defined
-      #define MASTER_DETECTOR_WARNING dummy
-    #endif
-  #endif
-#endif
+  #ifndef MASTER_DETECTOR_WARNING
 
-// Checking if the user remembered to put in a Union_master
-#ifndef MASTER_DETECTOR
+  for (loop_index = 0; loop_index < global_geometry_list->num_elements; loop_index++) {
+    if (global_geometry_list->elements[loop_index].component_index > global_master_list->elements[global_master_list->num_elements - 1].component_index) {
+      printf ("WARNING: No Union_master component defined after Union volume named %s, this components did not affect the simulation in any way.\n",
+              global_geometry_list->elements[loop_index].name);
+    }
+  }
+  // Decided to have this as a warning without exiting the simulation
+  // In order to only show this warning once, the MASTER_DETECTOR_WARNING is defined
+  #define MASTER_DETECTOR_WARNING dummy
+  #endif
+  #endif
+  #endif
+
+  // Checking if the user remembered to put in a Union_master
+  #ifndef MASTER_DETECTOR
   #ifdef ANY_GEOMETRY_DETECTOR_DECLARE
-    #ifndef MASTER_DETECTOR_WARNING
-      printf("\nWARNING: No Union_master component used, these components did not affect the simulation in any way:\n");
-      for (loop_index=0;loop_index<global_geometry_list->num_elements;loop_index++)
-        printf("  %s\n",global_geometry_list->elements[loop_index].name);
-      printf("\n");
-      // Decided to have this as a warning without exiting the simulation
-      // In order to only show this warning once, the MASTER_DETECTOR_WARNING is defined
-      #define MASTER_DETECTOR_WARNING dummy
-    #endif
+  #ifndef MASTER_DETECTOR_WARNING
+  printf ("\nWARNING: No Union_master component used, these components did not affect the simulation in any way:\n");
+  for (loop_index = 0; loop_index < global_geometry_list->num_elements; loop_index++)
+    printf ("  %s\n", global_geometry_list->elements[loop_index].name);
+  printf ("\n");
+  // Decided to have this as a warning without exiting the simulation
+  // In order to only show this warning once, the MASTER_DETECTOR_WARNING is defined
+  #define MASTER_DETECTOR_WARNING dummy
   #endif
-#endif
-
-
+  #endif
+  #endif
 %}
 
 END
-

--- a/mcxtrace-comps/union/Union_master.comp
+++ b/mcxtrace-comps/union/Union_master.comp
@@ -73,8 +73,6 @@ SHARE
 #define Union $Revision: 0.9 $
 
 
-%include "union-init.c"
-
 #endif
 
 // TEST
@@ -310,23 +308,18 @@ DECLARE
 
 INITIALIZE
 %{
-if (_getcomp_index(init) < 0) {
-fprintf(stderr,"Union_master:%s: Error identifying Union_init component, %s is not a known component name.\n",
-NAME_CURRENT_COMP, init);
-exit(-1);
-}
   // Unpack global lists
-  global_positions_to_transform_list_master = COMP_GETPAR3(Union_init, init, global_positions_to_transform_list);
-  global_rotations_to_transform_list_master = COMP_GETPAR3(Union_init, init, global_rotations_to_transform_list);
-  global_process_list_master = COMP_GETPAR3(Union_init, init, global_process_list);
-  global_material_list_master = COMP_GETPAR3(Union_init, init, global_material_list);
-  global_geometry_list_master = COMP_GETPAR3(Union_init, init, global_geometry_list);
-  global_all_volume_logger_list_master = COMP_GETPAR3(Union_init, init, global_all_volume_logger_list);
-  global_specific_volumes_logger_list_master = COMP_GETPAR3(Union_init, init, global_specific_volumes_logger_list);
-  global_all_volume_abs_logger_list_master = COMP_GETPAR3(Union_init, init, global_all_volume_abs_logger_list);
-  global_specific_volumes_abs_logger_list_master = COMP_GETPAR3(Union_init, init, global_specific_volumes_abs_logger_list);
-  global_tagging_conditional_list_master = COMP_GETPAR3(Union_init, init, global_tagging_conditional_list);
-  global_master_list_master = COMP_GETPAR3(Union_init, init, global_master_list);
+  global_positions_to_transform_list_master = &g_positions_to_transform_list;
+  global_rotations_to_transform_list_master = &g_rotations_to_transform_list;
+  global_process_list_master = &g_process_list;
+  global_material_list_master = &g_material_list;
+  global_geometry_list_master = &g_geometry_list;
+  global_all_volume_logger_list_master = &g_all_volume_logger_list;
+  global_specific_volumes_logger_list_master = &g_specific_volumes_logger_list;
+  global_all_volume_abs_logger_list_master = &g_all_volume_abs_logger_list;
+  global_specific_volumes_abs_logger_list_master = &g_specific_volumes_abs_logger_list;
+  global_tagging_conditional_list_master = &g_tagging_conditional_list;
+  global_master_list_master = &g_master_list;
 
   // It is possible to surpress warnings on starting volume by setting this to 1
   starting_volume_warning = 0;

--- a/mcxtrace-comps/union/Union_master.comp
+++ b/mcxtrace-comps/union/Union_master.comp
@@ -70,8 +70,7 @@ SHARE
 %include "read_table-lib"
 
 #ifndef Union
-#define Union $Revision: 0.9 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 
@@ -182,7 +181,6 @@ DECLARE
   double time_to_scattering;
   double length_to_scattering;
   double length_to_boundery;
-  double length_to_boundery_fp
   double time_to_boundery;
   int selected_process;
   int scattering_event;

--- a/mcxtrace-comps/union/Union_master.comp
+++ b/mcxtrace-comps/union/Union_master.comp
@@ -39,7 +39,6 @@
 *   history_limit:               [1]Limit the number of unique histories that are saved
 *   enable_conditionals:  [0/1] Use conditionals with this master
 *   inherit_number_of_scattering_events: [0/1] Inherit the number of scattering events from last master
-* init:                             [string] Name of Union_init component (typically "init", default)
 *
 * OUTPUT PARAMETERS:
 *
@@ -57,8 +56,8 @@ SETTING PARAMETERS(verbal = 1,
                    enable_tagging = 0,
                    history_limit=300000,
                    enable_conditionals=1,
-                   inherit_number_of_scattering_events=0,
-                   string init="init")
+                    inherit_number_of_scattering_events=0
+                   )
 OUTPUT PARAMETERS ()
 NOACC
 
@@ -67,55 +66,56 @@ NOACC
 SHARE
 %{
 
-%include "read_table-lib"
+  %include "read_table-lib"
 
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-// TEST
-struct logger_with_data_struct loggers_with_data_array;
-struct abs_logger_with_data_struct abs_loggers_with_data_array;
+  // TEST
+  struct logger_with_data_struct loggers_with_data_array;
+  struct abs_logger_with_data_struct abs_loggers_with_data_array;
 
-#ifndef MASTER_DETECTOR
-    #define MASTER_DETECTOR dummy
-#endif
-double get_my_abs(struct physics_struct *this_material, double k){
-  const int my_column=3;
-  double my_a=0;
-  if (this_material->my_a==0){
-    int i;
-    for (i=0;i<this_material->number_of_elements;i++){
-      /*the factor 100 is because tabulated values from the database are in cm2/g*/
-      my_a+=Table_Value(this_material->p_element_array[i].element_table,k*K2E,my_column)*this_material->p_element_array[i].rho*this_material->p_element_array[i].multiplicity*100;
+  #ifndef MASTER_DETECTOR
+  #define MASTER_DETECTOR dummy
+  #endif
+  double
+  get_my_abs (struct physics_struct* this_material, double k) {
+    const int my_column = 3;
+    double my_a = 0;
+    if (this_material->my_a == 0) {
+      int i;
+      for (i = 0; i < this_material->number_of_elements; i++) {
+        /*the factor 100 is because tabulated values from the database are in cm2/g*/
+        my_a += Table_Value (this_material->p_element_array[i].element_table, k * K2E, my_column) * this_material->p_element_array[i].rho
+                * this_material->p_element_array[i].multiplicity * 100;
+      }
+    } else {
+      my_a = this_material->my_a;
     }
-  }else{
-    my_a=this_material->my_a;
+    return my_a;
   }
-  return my_a;
-}
-
 %}
 
 DECLARE
 %{
   // Declare global lists, will be retrieved in INITIALIZE
-  struct global_positions_to_transform_list_struct *global_positions_to_transform_list_master;
-  struct global_rotations_to_transform_list_struct *global_rotations_to_transform_list_master;
-  struct pointer_to_global_process_list *global_process_list_master;
-  struct pointer_to_global_material_list *global_material_list_master;
-  struct pointer_to_global_geometry_list *global_geometry_list_master;
-  struct pointer_to_global_logger_list *global_all_volume_logger_list_master;
-  struct pointer_to_global_logger_list *global_specific_volumes_logger_list_master;
-  struct pointer_to_global_abs_logger_list *global_all_volume_abs_logger_list_master;
-  struct pointer_to_global_abs_logger_list *global_specific_volumes_abs_logger_list_master;
-  struct global_tagging_conditional_list_struct *global_tagging_conditional_list_master;
-  struct pointer_to_global_master_list *global_master_list_master;
+  struct global_positions_to_transform_list_struct* global_positions_to_transform_list_master;
+  struct global_rotations_to_transform_list_struct* global_rotations_to_transform_list_master;
+  struct pointer_to_global_process_list* global_process_list_master;
+  struct pointer_to_global_material_list* global_material_list_master;
+  struct pointer_to_global_geometry_list* global_geometry_list_master;
+  struct pointer_to_global_logger_list* global_all_volume_logger_list_master;
+  struct pointer_to_global_logger_list* global_specific_volumes_logger_list_master;
+  struct pointer_to_global_abs_logger_list* global_all_volume_abs_logger_list_master;
+  struct pointer_to_global_abs_logger_list* global_specific_volumes_abs_logger_list_master;
+  struct global_tagging_conditional_list_struct* global_tagging_conditional_list_master;
+  struct pointer_to_global_master_list* global_master_list_master;
 
   // New precompiler settings for verbal / tagging, remove // to include verbal in trace and/or tagging
-  //#define Union_trace_verbal_setting
-  //#define Union_enable_tagging_setting
+  // #define Union_trace_verbal_setting
+  // #define Union_enable_tagging_setting
 
   int starting_volume_warning;
 
@@ -129,9 +129,9 @@ DECLARE
 
   // The main structures used in this component
   struct intersection_time_table_struct intersection_time_table;
-  struct Volume_struct **Volumes;
-  struct geometry_struct **Geometries;
-  struct Volume_struct **Volume_copies;
+  struct Volume_struct** Volumes;
+  struct geometry_struct** Geometries;
+  struct Volume_struct** Volume_copies;
   struct starting_lists_struct starting_lists;
 
   // garbage collection for volume_copies
@@ -164,11 +164,11 @@ DECLARE
   double intersection_time;
   double min_intersection_time;
 
-  struct scattering_process_struct *process;
-  struct scattering_process_struct *process_start;
-  double *my_trace;
-  double *p_my_trace;
-  double *my_trace_fraction_control;
+  struct scattering_process_struct* process;
+  struct scattering_process_struct* process_start;
+  double* my_trace;
+  double* p_my_trace;
+  double* my_trace_fraction_control;
   double k[3];
   double k_new[3];
   double k_old[3];
@@ -193,18 +193,18 @@ DECLARE
   int done;
   int current_volume;
   int ray_sucseeded;
-  int *number_of_solutions;
+  int* number_of_solutions;
   int number_of_solutions_static;
-  int *check;
-  int *start;
+  int* check;
+  int* start;
   int intersection_with_children;
   int geometry_output;
 
   // For within_which_volume
   int tree_next_volume;
-  int *pre_allocated1;
-  int *pre_allocated2;
-  int *pre_allocated3;
+  int* pre_allocated1;
+  int* pre_allocated2;
+  int* pre_allocated3;
   Coords ray_position;
   Coords ray_wavevector;
   Coords ray_wavevector_rotated;
@@ -213,8 +213,8 @@ DECLARE
   Coords wavevector_rotated;
   int volume_0_found;
 
-  int *scattered_flag;
-  int **scattered_flag_VP;
+  int* scattered_flag;
+  int** scattered_flag_VP;
 
   // For coordinate transformations
   Rotation master_transposed_rotation_matrix;
@@ -226,7 +226,7 @@ DECLARE
 
   // For tagging
   struct list_of_tagging_tree_node_pointers master_tagging_node_list;
-  struct tagging_tree_node_struct *current_tagging_node;
+  struct tagging_tree_node_struct* current_tagging_node;
 
   int tagging_leaf_counter;
   int stop_tagging_ray;
@@ -253,24 +253,24 @@ DECLARE
   struct pointer_to_1d_int_list current_mask_intersect_list_status;
   int mask_index_main;
   int mask_iterator;
-  int *mask_start;
-  int *mask_check;
+  int* mask_start;
+  int* mask_check;
   int need_to_run_within_which_volume;
 
   // Loggers
-  //struct logger_with_data_struct loggers_with_data_array;
-  int *number_of_processes_array;
+  // struct logger_with_data_struct loggers_with_data_array;
+  int* number_of_processes_array;
   double p_old;
   int log_index;
   int conditional_status;
-  struct logger_struct *this_logger;
-  struct abs_logger_struct *this_abs_logger;
+  struct logger_struct* this_logger;
+  struct abs_logger_struct* this_abs_logger;
   //  union detector_pointer_union detector_pointer;
 
   // Conditionals
-  struct conditional_list_struct *tagging_conditional_list;
-  int *logger_conditional_extend_array;
-  int *abs_logger_conditional_extend_array;
+  struct conditional_list_struct* tagging_conditional_list;
+  int* logger_conditional_extend_array;
+  int* abs_logger_conditional_extend_array;
   int max_conditional_extend_index;
   int tagging_conditional_extend;
   int free_tagging_conditional_list;
@@ -300,8 +300,6 @@ DECLARE
   double t_abs_propagation;
   double abs_distance;
   double abs_max_length;
-
-
 %}
 
 INITIALIZE
@@ -329,7 +327,7 @@ INITIALIZE
   volume_0_found = 0;
 
   // For tagging
-  tagging_leaf_counter=0;
+  tagging_leaf_counter = 0;
 
   // For masks
   number_of_masks = 0;
@@ -337,127 +335,153 @@ INITIALIZE
 
   // Use sanitation
   #ifndef ANY_GEOMETRY_DETECTOR_DECLARE
-    printf("\nERROR: Need to define at least one Volume using Union_cylinder or Union_box before using the Union_master component. \n");
-    exit(1);
+  printf ("\nERROR: Need to define at least one Volume using Union_cylinder or Union_box before using the Union_master component. \n");
+  exit (1);
   #endif
   #ifdef ANY_GEOMETRY_DETECTOR_DECLARE
-    if (global_geometry_list_master->num_elements == 0) {
-      printf("\nERROR: Need to define at least one Volume using Union_cylinder or Union_box before using the Union_master component. \n");
-      printf("       Union_master component named \"%s\" is before any Volumes in the instrument file. At least one Volume need to be defined before\n",NAME_CURRENT_COMP);
+  if (global_geometry_list_master->num_elements == 0) {
+    printf ("\nERROR: Need to define at least one Volume using Union_cylinder or Union_box before using the Union_master component. \n");
+    printf ("       Union_master component named \"%s\" is before any Volumes in the instrument file. At least one Volume need to be defined before\n",
+            NAME_CURRENT_COMP);
 
-      exit(1);
-    }
+    exit (1);
+  }
   #endif
 
   // Parameters describing the safety distances close to surfaces, as scattering should not occur closer to a surface than the
   //  accuracy of the intersection calculation.
   safty_distance = 1E-11;
-  safty_distance2 = safty_distance*2;
+  safty_distance2 = safty_distance * 2;
 
   // Write information to the global_master_list_master about the current Union_master
-  sprintf(global_master_element.name,"%s",NAME_CURRENT_COMP);
+  sprintf (global_master_element.name, "%s", NAME_CURRENT_COMP);
   global_master_element.component_index = INDEX_CURRENT_COMP;
-  add_element_to_master_list(global_master_list_master, global_master_element);
+  add_element_to_master_list (global_master_list_master, global_master_element);
   if (inherit_number_of_scattering_events == 1 && global_master_list_master->num_elements == 1) {
-     printf("ERROR in Union_master with name %s. Inherit_number_of_scattering_events set to 1 for first Union_master component, but there is no preceeding Union_master component. Aborting.\n",NAME_CURRENT_COMP);
-     exit(1);
+    printf ("ERROR in Union_master with name %s. Inherit_number_of_scattering_events set to 1 for first Union_master component, but there is no preceeding "
+            "Union_master component. Aborting.\n",
+            NAME_CURRENT_COMP);
+    exit (1);
   }
   this_global_master_index = global_master_list_master->num_elements - 1; // Save the index for this master in global master list
 
   // Set the component index of the previous Union_master component if one exists
-  if (global_master_list_master->num_elements == 1) previous_master_index = 0; // no previous index
-  else previous_master_index = global_master_list_master->elements[global_master_list_master->num_elements-2].component_index; // -2 because of zero indexing and needing the previous index.
-  //printf("Assigned previous_master_index = %d \n",previous_master_index);
+  if (global_master_list_master->num_elements == 1)
+    previous_master_index = 0; // no previous index
+  else
+    previous_master_index = global_master_list_master->elements[global_master_list_master->num_elements - 2]
+                                .component_index; // -2 because of zero indexing and needing the previous index.
+  // printf("Assigned previous_master_index = %d \n",previous_master_index);
 
   // All volumes in the global_geometry_list_master is being check for activity using the number_of_activations input made for each geometry (default is 1)
   // In addition it is counted how many volumes, mask volumes and masked volumes are active in this Union_master.
-  number_of_volumes = 1; // Starting with 1 as the surrounding vacuum is considered a volume
-  number_of_masks = 0;   // Starting with 0 mask volumes
+  number_of_volumes = 1;        // Starting with 1 as the surrounding vacuum is considered a volume
+  number_of_masks = 0;          // Starting with 0 mask volumes
   number_of_masked_volumes = 0; // Starting with 0 masked volumes
-  for (iterator=0;iterator<global_geometry_list_master->num_elements;iterator++) {
-    if (global_geometry_list_master->elements[iterator].component_index < INDEX_CURRENT_COMP && global_geometry_list_master->elements[iterator].activation_counter > 0) {
-        global_geometry_list_master->elements[iterator].active = 1;
-        global_geometry_list_master->elements[iterator].activation_counter--;
-        number_of_volumes++;
-        if (global_geometry_list_master->elements[iterator].Volume->geometry.is_mask_volume == 1) number_of_masks++;
-        if (global_geometry_list_master->elements[iterator].Volume->geometry.is_masked_volume == 1) number_of_masked_volumes++;
-    } else global_geometry_list_master->elements[iterator].active = 0;
+  for (iterator = 0; iterator < global_geometry_list_master->num_elements; iterator++) {
+    if (global_geometry_list_master->elements[iterator].component_index < INDEX_CURRENT_COMP
+        && global_geometry_list_master->elements[iterator].activation_counter > 0) {
+      global_geometry_list_master->elements[iterator].active = 1;
+      global_geometry_list_master->elements[iterator].activation_counter--;
+      number_of_volumes++;
+      if (global_geometry_list_master->elements[iterator].Volume->geometry.is_mask_volume == 1)
+        number_of_masks++;
+      if (global_geometry_list_master->elements[iterator].Volume->geometry.is_masked_volume == 1)
+        number_of_masked_volumes++;
+    } else
+      global_geometry_list_master->elements[iterator].active = 0;
   }
 
   // Allocation of global lists
   geometry_component_index_list.num_elements = number_of_volumes;
-  geometry_component_index_list.elements = malloc( geometry_component_index_list.num_elements * sizeof(int));
+  geometry_component_index_list.elements = malloc (geometry_component_index_list.num_elements * sizeof (int));
   mask_volume_index_list.num_elements = number_of_masks;
-  if (number_of_masks >0) mask_volume_index_list.elements = malloc( number_of_masks * sizeof(int));
+  if (number_of_masks > 0)
+    mask_volume_index_list.elements = malloc (number_of_masks * sizeof (int));
   mask_status_list.num_elements = number_of_masks;
-  if (number_of_masks >0) mask_status_list.elements = malloc( number_of_masks * sizeof(int));
+  if (number_of_masks > 0)
+    mask_status_list.elements = malloc (number_of_masks * sizeof (int));
   current_mask_intersect_list_status.num_elements = number_of_masked_volumes;
-  if (number_of_masked_volumes >0) current_mask_intersect_list_status.elements = malloc( number_of_masked_volumes * sizeof(int));
+  if (number_of_masked_volumes > 0)
+    current_mask_intersect_list_status.elements = malloc (number_of_masked_volumes * sizeof (int));
 
   // Make a list of component index from each volume index
   volume_index = 0;
-  for (iterator=0;iterator<global_geometry_list_master->num_elements;iterator++) {
+  for (iterator = 0; iterator < global_geometry_list_master->num_elements; iterator++) {
     if (global_geometry_list_master->elements[iterator].active == 1)
-        geometry_component_index_list.elements[++volume_index] = global_geometry_list_master->elements[iterator].component_index;
-
+      geometry_component_index_list.elements[++volume_index] = global_geometry_list_master->elements[iterator].component_index;
   }
   geometry_component_index_list.elements[0] = 0; // Volume 0 is never set in the above code, but should never be used.
 
   // The input for this component is done through a series of input components
   // All information needed is stored in global lists, some of which is printed here for an overview to the user.
-  MPI_MASTER( // MPI_MASTER ensures just one thread output this information to the user
-  if (verbal == 1) {
-      printf("---------------------------------------------------------------------\n");
-      printf("global_process_list_master->num_elements: %d\n",global_process_list_master->num_elements);
-      for (iterator=0;iterator<global_process_list_master->num_elements;iterator++) {
-      printf("name of process [%d]: %s \n",iterator,global_process_list_master->elements[iterator].name);
-      printf("component index [%d]: %d \n",iterator,global_process_list_master->elements[iterator].component_index);
-      }
-
-      printf("---------------------------------------------------------------------\n");
-      printf("global_material_list_master->num_elements: %d\n",global_material_list_master->num_elements);
-      for (iterator=0;iterator<global_material_list_master->num_elements;iterator++) {
-      printf("name of material    [%d]: %s \n",iterator,global_material_list_master->elements[iterator].name);
-      printf("component index     [%d]: %d \n",iterator,global_material_list_master->elements[iterator].component_index);
-      printf("my_absoprtion       [%d]: %f \n",iterator,global_material_list_master->elements[iterator].physics->my_a);
-      printf("number of processes [%d]: %d \n",iterator,global_material_list_master->elements[iterator].physics->number_of_processes);
-      }
-
-      printf("---------------------------------------------------------------------\n");
-      printf("global_geometry_list_master->num_elements: %d\n",global_material_list_master->num_elements);
-      for (iterator=0;iterator<global_geometry_list_master->num_elements;iterator++) {
-        if (global_geometry_list_master->elements[iterator].active == 1) {
-          printf("\n");
-          printf("name of geometry    [%d]: %s \n",iterator,global_geometry_list_master->elements[iterator].name);
-          printf("component index     [%d]: %d \n",iterator,global_geometry_list_master->elements[iterator].component_index);
-          printf("Volume.name         [%d]: %s \n",iterator,global_geometry_list_master->elements[iterator].Volume->name);
-          if (global_geometry_list_master->elements[iterator].Volume->geometry.is_mask_volume == 0) {
-          printf("Volume.p_physics.is_vacuum           [%d]: %d \n",iterator,global_geometry_list_master->elements[iterator].Volume->p_physics->is_vacuum);
-          printf("Volume.p_physics.my_absorption       [%d]: %f \n",iterator,global_geometry_list_master->elements[iterator].Volume->p_physics->my_a);
-          printf("Volume.p_physics.number of processes [%d]: %d \n",iterator,global_geometry_list_master->elements[iterator].Volume->p_physics->number_of_processes);
-          }
-          printf("Volume.geometry.shape                [%d]: %s \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.shape);
-          printf("Volume.geometry.center.x             [%d]: %f \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.center.x);
-          printf("Volume.geometry.center.y             [%d]: %f \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.center.y);
-          printf("Volume.geometry.center.z             [%d]: %f \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.center.z);
-          printf("Volume.geometry.rotation_matrix[0]           [%d]: [%f %f %f] \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[0][0],global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[0][1],global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[0][2]);
-          printf("Volume.geometry.rotation_matrix[1]           [%d]: [%f %f %f] \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[1][0],global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[1][1],global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[1][2]);
-          printf("Volume.geometry.rotation_matrix[2]           [%d]: [%f %f %f] \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[2][0],global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[2][1],global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[2][2]);
-          if (strcmp(global_geometry_list_master->elements[iterator].Volume->geometry.shape,"cylinder") == 0) {
-          printf("Volume.geometry.geometry_parameters.cyl_radius [%d]: %f \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.geometry_parameters.p_cylinder_storage->cyl_radius);
-          printf("Volume.geometry.geometry_parameters.height [%d]: %f \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.geometry_parameters.p_cylinder_storage->height);
-          }
-          printf("Volume.geometry.focus_data_array.elements[0].Aim             [%d]: [%f %f %f] \n",iterator,global_geometry_list_master->elements[iterator].Volume->geometry.focus_data_array.elements[0].Aim.x,global_geometry_list_master->elements[iterator].Volume->geometry.focus_data_array.elements[0].Aim.y,global_geometry_list_master->elements[iterator].Volume->geometry.focus_data_array.elements[0].Aim.z);
+  MPI_MASTER ( // MPI_MASTER ensures just one thread output this information to the user
+      if (verbal == 1) {
+        printf ("---------------------------------------------------------------------\n");
+        printf ("global_process_list_master->num_elements: %d\n", global_process_list_master->num_elements);
+        for (iterator = 0; iterator < global_process_list_master->num_elements; iterator++) {
+          printf ("name of process [%d]: %s \n", iterator, global_process_list_master->elements[iterator].name);
+          printf ("component index [%d]: %d \n", iterator, global_process_list_master->elements[iterator].component_index);
         }
+
+        printf ("---------------------------------------------------------------------\n");
+        printf ("global_material_list_master->num_elements: %d\n", global_material_list_master->num_elements);
+        for (iterator = 0; iterator < global_material_list_master->num_elements; iterator++) {
+          printf ("name of material    [%d]: %s \n", iterator, global_material_list_master->elements[iterator].name);
+          printf ("component index     [%d]: %d \n", iterator, global_material_list_master->elements[iterator].component_index);
+          printf ("my_absoprtion       [%d]: %f \n", iterator, global_material_list_master->elements[iterator].physics->my_a);
+          printf ("number of processes [%d]: %d \n", iterator, global_material_list_master->elements[iterator].physics->number_of_processes);
+        }
+
+        printf ("---------------------------------------------------------------------\n");
+        printf ("global_geometry_list_master->num_elements: %d\n", global_material_list_master->num_elements);
+        for (iterator = 0; iterator < global_geometry_list_master->num_elements; iterator++) {
+          if (global_geometry_list_master->elements[iterator].active == 1) {
+            printf ("\n");
+            printf ("name of geometry    [%d]: %s \n", iterator, global_geometry_list_master->elements[iterator].name);
+            printf ("component index     [%d]: %d \n", iterator, global_geometry_list_master->elements[iterator].component_index);
+            printf ("Volume.name         [%d]: %s \n", iterator, global_geometry_list_master->elements[iterator].Volume->name);
+            if (global_geometry_list_master->elements[iterator].Volume->geometry.is_mask_volume == 0) {
+              printf ("Volume.p_physics.is_vacuum           [%d]: %d \n", iterator, global_geometry_list_master->elements[iterator].Volume->p_physics->is_vacuum);
+              printf ("Volume.p_physics.my_absorption       [%d]: %f \n", iterator, global_geometry_list_master->elements[iterator].Volume->p_physics->my_a);
+              printf ("Volume.p_physics.number of processes [%d]: %d \n", iterator,
+                      global_geometry_list_master->elements[iterator].Volume->p_physics->number_of_processes);
+            }
+            printf ("Volume.geometry.shape                [%d]: %s \n", iterator, global_geometry_list_master->elements[iterator].Volume->geometry.shape);
+            printf ("Volume.geometry.center.x             [%d]: %f \n", iterator, global_geometry_list_master->elements[iterator].Volume->geometry.center.x);
+            printf ("Volume.geometry.center.y             [%d]: %f \n", iterator, global_geometry_list_master->elements[iterator].Volume->geometry.center.y);
+            printf ("Volume.geometry.center.z             [%d]: %f \n", iterator, global_geometry_list_master->elements[iterator].Volume->geometry.center.z);
+            printf ("Volume.geometry.rotation_matrix[0]           [%d]: [%f %f %f] \n", iterator,
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[0][0],
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[0][1],
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[0][2]);
+            printf ("Volume.geometry.rotation_matrix[1]           [%d]: [%f %f %f] \n", iterator,
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[1][0],
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[1][1],
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[1][2]);
+            printf ("Volume.geometry.rotation_matrix[2]           [%d]: [%f %f %f] \n", iterator,
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[2][0],
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[2][1],
+                    global_geometry_list_master->elements[iterator].Volume->geometry.rotation_matrix[2][2]);
+            if (strcmp (global_geometry_list_master->elements[iterator].Volume->geometry.shape, "cylinder") == 0) {
+              printf ("Volume.geometry.geometry_parameters.cyl_radius [%d]: %f \n", iterator,
+                      global_geometry_list_master->elements[iterator].Volume->geometry.geometry_parameters.p_cylinder_storage->cyl_radius);
+              printf ("Volume.geometry.geometry_parameters.height [%d]: %f \n", iterator,
+                      global_geometry_list_master->elements[iterator].Volume->geometry.geometry_parameters.p_cylinder_storage->height);
+            }
+            printf ("Volume.geometry.focus_data_array.elements[0].Aim             [%d]: [%f %f %f] \n", iterator,
+                    global_geometry_list_master->elements[iterator].Volume->geometry.focus_data_array.elements[0].Aim.x,
+                    global_geometry_list_master->elements[iterator].Volume->geometry.focus_data_array.elements[0].Aim.y,
+                    global_geometry_list_master->elements[iterator].Volume->geometry.focus_data_array.elements[0].Aim.z);
+          }
+        }
+        printf ("---------------------------------------------------------------------\n");
+        printf ("number_of_volumes = %d\n", number_of_volumes);
+        printf ("number_of_masks = %d\n", number_of_masks);
+        printf ("number_of_masked_volumes = %d\n", number_of_masked_volumes);
       }
-      printf("---------------------------------------------------------------------\n");
-      printf("number_of_volumes = %d\n",number_of_volumes);
-      printf("number_of_masks = %d\n",number_of_masks);
-      printf("number_of_masked_volumes = %d\n",number_of_masked_volumes);
-  }
 
   ); // End MPI_MASTER
-
 
   // --- Initialization tasks independent of volume stucture -----------------------
 
@@ -467,7 +491,7 @@ INITIALIZE
     tagging_conditional_list = &global_tagging_conditional_list_master->elements[global_tagging_conditional_list_master->current_index++].conditional_list;
     free_tagging_conditional_list = 0;
   } else {
-    tagging_conditional_list = malloc(sizeof(struct conditional_list_struct));
+    tagging_conditional_list = malloc (sizeof (struct conditional_list_struct));
     tagging_conditional_list->num_elements = 0;
     free_tagging_conditional_list = 1;
   }
@@ -475,14 +499,14 @@ INITIALIZE
   // Find the maximum logger extend index so that the correct memory allocation can be performed later
   // Here the loggers applied to all volumes are searched, later this result is compared to volume specific loggers and updated
   max_conditional_extend_index = -1;
-  for (iterator=0;iterator<global_all_volume_logger_list_master->num_elements;iterator++) {
+  for (iterator = 0; iterator < global_all_volume_logger_list_master->num_elements; iterator++) {
     if (global_all_volume_logger_list_master->elements[iterator].logger->logger_extend_index > max_conditional_extend_index) {
       max_conditional_extend_index = global_all_volume_logger_list_master->elements[iterator].logger->logger_extend_index;
     }
   }
 
   // The absolute rotation of this component is saved for use in initialization
-  rot_transpose(ROT_A_CURRENT_COMP,master_transposed_rotation_matrix);
+  rot_transpose (ROT_A_CURRENT_COMP, master_transposed_rotation_matrix);
 
   // Preceeding componnets can add coordinates and rotations to global_positions_to_transform and global_rotations_to_transform
   //  in order to have these transformed into the coordinate system of the next master compoent in the instrument file.
@@ -490,49 +514,48 @@ INITIALIZE
   //  next master components.
 
   // Position transformation
-  for (iterator=0;iterator<global_positions_to_transform_list_master->num_elements;iterator++) {
-    non_rotated_position = coords_sub(*(global_positions_to_transform_list_master->positions[iterator]),POS_A_CURRENT_COMP);
-    *(global_positions_to_transform_list_master->positions[iterator]) = rot_apply(ROT_A_CURRENT_COMP,non_rotated_position);
+  for (iterator = 0; iterator < global_positions_to_transform_list_master->num_elements; iterator++) {
+    non_rotated_position = coords_sub (*(global_positions_to_transform_list_master->positions[iterator]), POS_A_CURRENT_COMP);
+    *(global_positions_to_transform_list_master->positions[iterator]) = rot_apply (ROT_A_CURRENT_COMP, non_rotated_position);
   }
   if (global_positions_to_transform_list_master->num_elements > 0) {
     global_positions_to_transform_list_master->num_elements = 0;
-    free(global_positions_to_transform_list_master->positions);
+    free (global_positions_to_transform_list_master->positions);
   }
   // Rotation transformation
-  for (iterator=0;iterator<global_rotations_to_transform_list_master->num_elements;iterator++) {
-    //print_rotation(*(global_rotations_to_transform_list_master->rotations[iterator]),"rotation matrix to be updated");
-    rot_mul(master_transposed_rotation_matrix,*(global_rotations_to_transform_list_master->rotations[iterator]),temp_rotation_matrix);
-    rot_copy(*(global_rotations_to_transform_list_master->rotations[iterator]),temp_rotation_matrix);
+  for (iterator = 0; iterator < global_rotations_to_transform_list_master->num_elements; iterator++) {
+    // print_rotation(*(global_rotations_to_transform_list_master->rotations[iterator]),"rotation matrix to be updated");
+    rot_mul (master_transposed_rotation_matrix, *(global_rotations_to_transform_list_master->rotations[iterator]), temp_rotation_matrix);
+    rot_copy (*(global_rotations_to_transform_list_master->rotations[iterator]), temp_rotation_matrix);
   }
   if (global_rotations_to_transform_list_master->num_elements > 0) {
     global_rotations_to_transform_list_master->num_elements = 0;
-    free(global_rotations_to_transform_list_master->rotations);
+    free (global_rotations_to_transform_list_master->rotations);
   }
-
 
   // --- Definition of volumes and loading of appropriate data  -----------------------
 
   // The information stored in global lists is to be stored in one array of structures that is allocated here
-  Volumes = malloc(number_of_volumes * sizeof(struct Volume_struct*));
-  scattered_flag = malloc(number_of_volumes*sizeof(int));
-  scattered_flag_VP = (int**) malloc(number_of_volumes * sizeof(int*));
-  number_of_processes_array = malloc(number_of_volumes*sizeof(int));
+  Volumes = malloc (number_of_volumes * sizeof (struct Volume_struct*));
+  scattered_flag = malloc (number_of_volumes * sizeof (int));
+  scattered_flag_VP = (int**)malloc (number_of_volumes * sizeof (int*));
+  number_of_processes_array = malloc (number_of_volumes * sizeof (int));
 
   // The mcdisplay functions need access to the other geomtries, but can not use the Volumes struct because of order of definition.
   // A separate list of pointers to the geometry structures is thus allocated
-  Geometries = malloc(number_of_volumes * sizeof(struct geometry_struct *));
+  Geometries = malloc (number_of_volumes * sizeof (struct geometry_struct*));
 
   // When activation counter is used to have several copies of one volume, it can become necessary to have soft copies of volumes
   // Not all of these will necessarily be allocated or used.
-  Volume_copies = malloc(number_of_volumes * sizeof(struct Volume_struct *));
+  Volume_copies = malloc (number_of_volumes * sizeof (struct Volume_struct*));
   Volume_copies_allocated.num_elements = 0;
 
   // The central structure is called a "Volume", it describes a region in space with certain scattering processes and absorption cross section
 
   // ---  Volume 0 ------------------------------------------------------------------------------------------------
   // Volume 0 is the vacuum surrounding the experiment (infinite, everywhere) and its properties are hardcoded here
-  Volumes[0] = malloc(sizeof(struct Volume_struct));
-  strcpy(Volumes[0]->name,"Surrounding vacuum");
+  Volumes[0] = malloc (sizeof (struct Volume_struct));
+  strcpy (Volumes[0]->name, "Surrounding vacuum");
   // Assign geometry
 
   // This information is meaningless for volume 0, and is never be acsessed in the logic.
@@ -540,7 +563,7 @@ INITIALIZE
   Volumes[0]->geometry.center.x = 0;
   Volumes[0]->geometry.center.y = 0;
   Volumes[0]->geometry.center.z = 0;
-  strcpy(Volumes[0]->geometry.shape,"vacuum");
+  strcpy (Volumes[0]->geometry.shape, "vacuum");
   Volumes[0]->geometry.eShape = surroundings;
   Volumes[0]->geometry.within_function = &r_within_surroundings; // Always returns 1
   // No physics struct allocated
@@ -548,18 +571,18 @@ INITIALIZE
   number_of_processes_array[volume_index] = 0;
 
   // These are never used for volume 0, but by setting the length to 0 it is automatically skipped in many forloops without the need for an if statement
-  Volumes[0]->geometry.children.num_elements=0;
-  Volumes[0]->geometry.direct_children.num_elements=0;
-  Volumes[0]->geometry.destinations_list.num_elements=0;
-  Volumes[0]->geometry.reduced_destinations_list.num_elements=0;
+  Volumes[0]->geometry.children.num_elements = 0;
+  Volumes[0]->geometry.direct_children.num_elements = 0;
+  Volumes[0]->geometry.destinations_list.num_elements = 0;
+  Volumes[0]->geometry.reduced_destinations_list.num_elements = 0;
 
   Volumes[0]->geometry.is_exit_volume = 0;
   Volumes[0]->geometry.masked_by_list.num_elements = 0;
   Volumes[0]->geometry.mask_list.num_elements = 0;
   Volumes[0]->geometry.masked_by_mask_index_list.num_elements = 0;
-  Volumes[0]->geometry.mask_mode=0;
-  Volumes[0]->geometry.is_mask_volume=0;
-  Volumes[0]->geometry.is_masked_volume=0;
+  Volumes[0]->geometry.mask_mode = 0;
+  Volumes[0]->geometry.is_mask_volume = 0;
+  Volumes[0]->geometry.is_masked_volume = 0;
 
   // A pointer to the geometry structure
   Geometries[0] = &Volumes[0]->geometry;
@@ -568,7 +591,6 @@ INITIALIZE
   Volumes[0]->loggers.num_elements = 0;
   Volumes[0]->abs_loggers.num_elements = 0;
 
-
   // --- Loop over user defined volumes ------------------------------------------------------------------------
   // Here the user defined volumes are loaded into the volume structure that is used in the ray-tracing
   //  algorithm. Not all user defined volumes are used, some could be used by a previous master, some
@@ -576,12 +598,11 @@ INITIALIZE
   //  activation counter input for geometries, and is here condensed to the active variable.
   // Volumes that were used before
 
-
   max_number_of_processes = 0; // The maximum number of processes in a volume is assumed 0 and updated during the following loop
 
   volume_index = 0;
   mask_index_main = 0;
-  for (geometry_list_index=0;geometry_list_index<global_geometry_list_master->num_elements;geometry_list_index++) {
+  for (geometry_list_index = 0; geometry_list_index < global_geometry_list_master->num_elements; geometry_list_index++) {
     if (global_geometry_list_master->elements[geometry_list_index].active == 1) { // Only include the volume if it is active
       volume_index++;
       // Connect a volume for each of the geometry.comp instances in the McStas instrument files
@@ -591,41 +612,41 @@ INITIALIZE
       } else {
         // Since this volume is still needed more than this once, we need to make a shallow copy and use instead
 
-        Volume_copies[volume_index] = malloc(sizeof(struct Volume_struct));
+        Volume_copies[volume_index] = malloc (sizeof (struct Volume_struct));
         *(Volume_copies[volume_index]) = *global_geometry_list_master->elements[geometry_list_index].Volume; // Makes shallow copy
         Volumes[volume_index] = Volume_copies[volume_index];
-        add_element_to_int_list(&Volume_copies_allocated,volume_index); // Keep track of dynamically allocated volumes in order to free them in FINALLY.
+        add_element_to_int_list (&Volume_copies_allocated, volume_index); // Keep track of dynamically allocated volumes in order to free them in FINALLY.
 
         // The geometry storage needs a shallow copy as well (hard copy not necessary for any current geometries), may need changes in future
         // A simple copy_geometry_parameters function is added to the geometry in each geometry component
-        Volumes[volume_index]->geometry.geometry_parameters = Volumes[volume_index]->geometry.copy_geometry_parameters(&global_geometry_list_master->elements[geometry_list_index].Volume->geometry.geometry_parameters);
-
+        Volumes[volume_index]->geometry.geometry_parameters = Volumes[volume_index]->geometry.copy_geometry_parameters (
+            &global_geometry_list_master->elements[geometry_list_index].Volume->geometry.geometry_parameters);
       }
 
       // This section identifies the different non isotropic processes in the current volume and give them appropriate transformation matrices
       // Identify the number of non isotropic processes in a material (this code can be safely executed for the same material many times)
       // A setting of -1 means no transformation necessary, other settings are assigned a unique identifier instead
       non_isotropic_found = 0;
-      for (iterator=0;iterator<Volumes[volume_index]->p_physics->number_of_processes;iterator++) {
+      for (iterator = 0; iterator < Volumes[volume_index]->p_physics->number_of_processes; iterator++) {
         if (Volumes[volume_index]->p_physics->p_scattering_array[iterator].non_isotropic_rot_index != -1) {
-            Volumes[volume_index]->p_physics->p_scattering_array[iterator].non_isotropic_rot_index = non_isotropic_found;
-            non_isotropic_found++;
+          Volumes[volume_index]->p_physics->p_scattering_array[iterator].non_isotropic_rot_index = non_isotropic_found;
+          non_isotropic_found++;
         }
       }
 
-      Volumes[volume_index]->geometry.focus_array_indices.num_elements=0;
+      Volumes[volume_index]->geometry.focus_array_indices.num_elements = 0;
       // For the non_isotropic volumes found, rotation matrices need to be allocated and calculated
       if (non_isotropic_found > 0) {
         // Allocation of rotation and transpose rotation matrices
         if (Volumes[volume_index]->geometry.process_rot_allocated == 0) {
-          Volumes[volume_index]->geometry.process_rot_matrix_array = malloc(non_isotropic_found * sizeof(Rotation));
-          Volumes[volume_index]->geometry.transpose_process_rot_matrix_array = malloc(non_isotropic_found * sizeof(Rotation));
+          Volumes[volume_index]->geometry.process_rot_matrix_array = malloc (non_isotropic_found * sizeof (Rotation));
+          Volumes[volume_index]->geometry.transpose_process_rot_matrix_array = malloc (non_isotropic_found * sizeof (Rotation));
           Volumes[volume_index]->geometry.process_rot_allocated = 1;
         }
 
         // Calculation of the appropriate rotation matrices for transformation between Union_master and the process in a given volume.
         non_isotropic_found = 0;
-        for (iterator=0;iterator<Volumes[volume_index]->p_physics->number_of_processes;iterator++) {
+        for (iterator = 0; iterator < Volumes[volume_index]->p_physics->number_of_processes; iterator++) {
           if (Volumes[volume_index]->p_physics->p_scattering_array[iterator].non_isotropic_rot_index != -1) {
             // Transformation for each process / geometry combination
 
@@ -634,49 +655,51 @@ INITIALIZE
             temporary_focus_data = Volumes[volume_index]->geometry.focus_data_array.elements[0];
 
             // Correct for process rotation
-            temporary_focus_data.Aim = rot_apply(Volumes[volume_index]->p_physics->p_scattering_array[iterator].rotation_matrix,temporary_focus_data.Aim);
+            temporary_focus_data.Aim = rot_apply (Volumes[volume_index]->p_physics->p_scattering_array[iterator].rotation_matrix, temporary_focus_data.Aim);
 
             // Add element to focus_array_indices
             // focus_array_indices refers to the correct element in focus_data_array for this volume/process combination
             // focus_data_array[0] is the isotropic version in all cases, so the first non_isotropic goes to focus_data_array[1]
             //  and so forth. When a process is isotropic, this array is appended with a zero.
             // The focus_array_indices maps process numbers to the correct focus_data_array index.
-            add_element_to_int_list(&Volumes[volume_index]->geometry.focus_array_indices,non_isotropic_found+1);
+            add_element_to_int_list (&Volumes[volume_index]->geometry.focus_array_indices, non_isotropic_found + 1);
 
             // Add the new focus_data element to this volumes focus_data_array.
-            add_element_to_focus_data_array(&Volumes[volume_index]->geometry.focus_data_array,temporary_focus_data);
+            add_element_to_focus_data_array (&Volumes[volume_index]->geometry.focus_data_array, temporary_focus_data);
 
             // Quick error check to see the length is correct which indirectly confirms the indices are correct
             if (Volumes[volume_index]->geometry.focus_data_array.num_elements != non_isotropic_found + 2) {
-              printf("ERROR, focus_data_array length for volume %s inconsistent with number of non isotropic processes found!\n",Volumes[volume_index]->name);
-              exit(1);
+              printf ("ERROR, focus_data_array length for volume %s inconsistent with number of non isotropic processes found!\n", Volumes[volume_index]->name);
+              exit (1);
             }
 
-            // Create rotation matrix for this specific volume / process combination to transform from master coordinate system to the non-isotropics process coordinate system
-            // This is done by multipling the transpose master component roration matrix, the volume rotation, and then the process rotation matrix onto the velocity / wavevector
-            rot_mul(Volumes[volume_index]->geometry.rotation_matrix,master_transposed_rotation_matrix,temp_rotation_matrix);
-            rot_mul(Volumes[volume_index]->p_physics->p_scattering_array[iterator].rotation_matrix,temp_rotation_matrix,Volumes[volume_index]->geometry.process_rot_matrix_array[non_isotropic_found]);
+            // Create rotation matrix for this specific volume / process combination to transform from master coordinate system to the non-isotropics process
+            // coordinate system This is done by multipling the transpose master component roration matrix, the volume rotation, and then the process rotation
+            // matrix onto the velocity / wavevector
+            rot_mul (Volumes[volume_index]->geometry.rotation_matrix, master_transposed_rotation_matrix, temp_rotation_matrix);
+            rot_mul (Volumes[volume_index]->p_physics->p_scattering_array[iterator].rotation_matrix, temp_rotation_matrix,
+                     Volumes[volume_index]->geometry.process_rot_matrix_array[non_isotropic_found]);
 
             // Need to transpose as well to transform back to the master coordinate system
-            rot_transpose(Volumes[volume_index]->geometry.process_rot_matrix_array[non_isotropic_found],Volumes[volume_index]->geometry.transpose_process_rot_matrix_array[non_isotropic_found]);
+            rot_transpose (Volumes[volume_index]->geometry.process_rot_matrix_array[non_isotropic_found],
+                           Volumes[volume_index]->geometry.transpose_process_rot_matrix_array[non_isotropic_found]);
 
             // Debug print
-            //print_rotation(Volumes[volume_index]->geometry.process_rot_matrix_array[non_isotropic_found],"Process rotation matrix");
-            //print_rotation(Volumes[volume_index]->geometry.transpose_process_rot_matrix_array[non_isotropic_found],"Transpose process rotation matrix");
+            // print_rotation(Volumes[volume_index]->geometry.process_rot_matrix_array[non_isotropic_found],"Process rotation matrix");
+            // print_rotation(Volumes[volume_index]->geometry.transpose_process_rot_matrix_array[non_isotropic_found],"Transpose process rotation matrix");
 
             non_isotropic_found++;
           } else {
             // This process can use the standard isotropic focus_data_array which is indexed zero.
-            add_element_to_int_list(&Volumes[volume_index]->geometry.focus_array_indices,0);
+            add_element_to_int_list (&Volumes[volume_index]->geometry.focus_array_indices, 0);
           }
         }
       } else {
-      // No non isotropic volumes found, focus_array_indices should just be a list of 0's of same length as the number of processes.
-      // In this way all processes use the isotropic focus_data structure
-        Volumes[volume_index]->geometry.focus_array_indices.elements = malloc(Volumes[volume_index]->p_physics->number_of_processes * sizeof(int));
-        for (iterator=0;iterator<Volumes[volume_index]->p_physics->number_of_processes;iterator++)
+        // No non isotropic volumes found, focus_array_indices should just be a list of 0's of same length as the number of processes.
+        // In this way all processes use the isotropic focus_data structure
+        Volumes[volume_index]->geometry.focus_array_indices.elements = malloc (Volumes[volume_index]->p_physics->number_of_processes * sizeof (int));
+        for (iterator = 0; iterator < Volumes[volume_index]->p_physics->number_of_processes; iterator++)
           Volumes[volume_index]->geometry.focus_array_indices.elements[iterator] = 0;
-
       }
 
       // This component works in its local coordinate system, and thus all information from the input components should be transformed to its coordinate system.
@@ -684,44 +707,46 @@ INITIALIZE
       // The next section finds the relative rotation and translation of all the volumes and the master component.
 
       // Transform the rotation matrices for each volume
-      rot_mul(ROT_A_CURRENT_COMP,Volumes[volume_index]->geometry.transpose_rotation_matrix,temp_rotation_matrix);
+      rot_mul (ROT_A_CURRENT_COMP, Volumes[volume_index]->geometry.transpose_rotation_matrix, temp_rotation_matrix);
       // Copy the result back to the volumes structure
-      rot_copy(Volumes[volume_index]->geometry.rotation_matrix,temp_rotation_matrix);
+      rot_copy (Volumes[volume_index]->geometry.rotation_matrix, temp_rotation_matrix);
       // Now update the transpose as well
-      rot_transpose(Volumes[volume_index]->geometry.rotation_matrix,temp_rotation_matrix);
-      rot_copy(Volumes[volume_index]->geometry.transpose_rotation_matrix,temp_rotation_matrix);
+      rot_transpose (Volumes[volume_index]->geometry.rotation_matrix, temp_rotation_matrix);
+      rot_copy (Volumes[volume_index]->geometry.transpose_rotation_matrix, temp_rotation_matrix);
 
       // Transform the position for each volume
       non_rotated_position.x = Volumes[volume_index]->geometry.center.x - POS_A_CURRENT_COMP.x;
       non_rotated_position.y = Volumes[volume_index]->geometry.center.y - POS_A_CURRENT_COMP.y;
       non_rotated_position.z = Volumes[volume_index]->geometry.center.z - POS_A_CURRENT_COMP.z;
 
-      rot_transpose(ROT_A_CURRENT_COMP,temp_rotation_matrix); // REVIEW LINE
-      rotated_position = rot_apply(ROT_A_CURRENT_COMP, non_rotated_position);
+      rot_transpose (ROT_A_CURRENT_COMP, temp_rotation_matrix); // REVIEW LINE
+      rotated_position = rot_apply (ROT_A_CURRENT_COMP, non_rotated_position);
 
       Volumes[volume_index]->geometry.center.x = rotated_position.x;
       Volumes[volume_index]->geometry.center.y = rotated_position.y;
       Volumes[volume_index]->geometry.center.z = rotated_position.z;
 
       // The focus_data information need to be updated as well
-      rot_mul(ROT_A_CURRENT_COMP,Volumes[volume_index]->geometry.focus_data_array.elements[0].absolute_rotation,temp_rotation_matrix);
+      rot_mul (ROT_A_CURRENT_COMP, Volumes[volume_index]->geometry.focus_data_array.elements[0].absolute_rotation, temp_rotation_matrix);
       // Copy the result back to the volumes structure
-      rot_copy(Volumes[volume_index]->geometry.focus_data_array.elements[0].absolute_rotation,temp_rotation_matrix);
+      rot_copy (Volumes[volume_index]->geometry.focus_data_array.elements[0].absolute_rotation, temp_rotation_matrix);
 
       // Use same rotation on the aim vector of the isotropic focus_data element
-      Volumes[volume_index]->geometry.focus_data_array.elements[0].Aim = rot_apply(Volumes[volume_index]->geometry.rotation_matrix,Volumes[volume_index]->geometry.focus_data_array.elements[0].Aim);
+      Volumes[volume_index]->geometry.focus_data_array.elements[0].Aim
+          = rot_apply (Volumes[volume_index]->geometry.rotation_matrix, Volumes[volume_index]->geometry.focus_data_array.elements[0].Aim);
 
       // To allocate enough memory to hold information on all processes, the maximum of these is updated if this volume has more
       if (Volumes[volume_index]->p_physics->number_of_processes > max_number_of_processes)
-          max_number_of_processes = Volumes[volume_index]->p_physics->number_of_processes;
+        max_number_of_processes = Volumes[volume_index]->p_physics->number_of_processes;
 
       // Allocate memory to scattered_flag_VP (holds statistics for scatterings in each process of the volume)
-      scattered_flag_VP[volume_index] = malloc(Volumes[volume_index]->p_physics->number_of_processes * sizeof(int));
+      scattered_flag_VP[volume_index] = malloc (Volumes[volume_index]->p_physics->number_of_processes * sizeof (int));
       number_of_processes_array[volume_index] = Volumes[volume_index]->p_physics->number_of_processes;
 
       // Normalizing and error checking process interact fraction
-      number_of_process_interacts_set = 0; total_process_interact=0;
-      for (process_index=0;process_index<Volumes[volume_index]->p_physics->number_of_processes;process_index++) {
+      number_of_process_interacts_set = 0;
+      total_process_interact = 0;
+      for (process_index = 0; process_index < Volumes[volume_index]->p_physics->number_of_processes; process_index++) {
         if (Volumes[volume_index]->p_physics->p_scattering_array[process_index].process_p_interact != -1) {
           number_of_process_interacts_set++;
           total_process_interact += Volumes[volume_index]->p_physics->p_scattering_array[process_index].process_p_interact;
@@ -730,32 +755,38 @@ INITIALIZE
         }
       }
 
-      if (number_of_process_interacts_set == 0) Volumes[volume_index]->p_physics->interact_control = 0;
-      else Volumes[volume_index]->p_physics->interact_control = 1;
+      if (number_of_process_interacts_set == 0)
+        Volumes[volume_index]->p_physics->interact_control = 0;
+      else
+        Volumes[volume_index]->p_physics->interact_control = 1;
 
       // If all are set, check if they need renormalization so that the sum is one.
       if (number_of_process_interacts_set == Volumes[volume_index]->p_physics->number_of_processes) {
         if (total_process_interact > 1.001 || total_process_interact < 0.999) {
-          for (process_index=0;process_index<Volumes[volume_index]->p_physics->number_of_processes;process_index++) {
-            Volumes[volume_index]->p_physics->p_scattering_array[process_index].process_p_interact = Volumes[volume_index]->p_physics->p_scattering_array[process_index].process_p_interact/total_process_interact;
+          for (process_index = 0; process_index < Volumes[volume_index]->p_physics->number_of_processes; process_index++) {
+            Volumes[volume_index]->p_physics->p_scattering_array[process_index].process_p_interact
+                = Volumes[volume_index]->p_physics->p_scattering_array[process_index].process_p_interact / total_process_interact;
           }
         }
-      } else if ( number_of_process_interacts_set != 0) {
-        if (number_of_process_interacts_set == Volumes[volume_index]->p_physics->number_of_processes - 1) {// If all but one is set, it is an easy fix
+      } else if (number_of_process_interacts_set != 0) {
+        if (number_of_process_interacts_set == Volumes[volume_index]->p_physics->number_of_processes - 1) { // If all but one is set, it is an easy fix
           Volumes[volume_index]->p_physics->p_scattering_array[index_of_lacking_process].process_p_interact = 1 - total_process_interact;
           if (total_process_interact >= 1) {
-            printf("ERROR, material %s has a total interact_fraction above 1 and a process without an interact_fraction. Either set all so they can be renormalized, or have a sum below 1, so that the last can have 1 - sum.\n",Volumes[volume_index]->p_physics->name);
-            exit(1);
+            printf ("ERROR, material %s has a total interact_fraction above 1 and a process without an interact_fraction. Either set all so they can be "
+                    "renormalized, or have a sum below 1, so that the last can have 1 - sum.\n",
+                    Volumes[volume_index]->p_physics->name);
+            exit (1);
           }
         } else {
-            printf("ERROR, material %s needs to have all, all minus one or none of its processes with an interact_fraction \n",Volumes[volume_index]->p_physics->name);
-            exit(1);
+          printf ("ERROR, material %s needs to have all, all minus one or none of its processes with an interact_fraction \n",
+                  Volumes[volume_index]->p_physics->name);
+          exit (1);
         }
       }
 
       // Some initialization can only happen after the rotation matrix relative to the master is known
       // Such initialization is placed in the geometry component, and executed here through a function pointer
-      Volumes[volume_index]->geometry.initialize_from_main_function(&Volumes[volume_index]->geometry);
+      Volumes[volume_index]->geometry.initialize_from_main_function (&Volumes[volume_index]->geometry);
 
       // Add pointer to geometry to Geometries
       Geometries[volume_index] = &Volumes[volume_index]->geometry;
@@ -764,198 +795,214 @@ INITIALIZE
       Volumes[volume_index]->geometry.mask_intersect_list.num_elements = 0;
 
       // Here the mask_list and masked_by_list for the volume is updated from component index values to volume indexes
-      for (iterator=0;iterator<Volumes[volume_index]->geometry.mask_list.num_elements;iterator++)
-        Volumes[volume_index]->geometry.mask_list.elements[iterator] = find_on_int_list(geometry_component_index_list,Volumes[volume_index]->geometry.mask_list.elements[iterator]);
+      for (iterator = 0; iterator < Volumes[volume_index]->geometry.mask_list.num_elements; iterator++)
+        Volumes[volume_index]->geometry.mask_list.elements[iterator]
+            = find_on_int_list (geometry_component_index_list, Volumes[volume_index]->geometry.mask_list.elements[iterator]);
 
-      for (iterator=0;iterator<Volumes[volume_index]->geometry.masked_by_list.num_elements;iterator++)
-        Volumes[volume_index]->geometry.masked_by_list.elements[iterator] = find_on_int_list(geometry_component_index_list,Volumes[volume_index]->geometry.masked_by_list.elements[iterator]);
+      for (iterator = 0; iterator < Volumes[volume_index]->geometry.masked_by_list.num_elements; iterator++)
+        Volumes[volume_index]->geometry.masked_by_list.elements[iterator]
+            = find_on_int_list (geometry_component_index_list, Volumes[volume_index]->geometry.masked_by_list.elements[iterator]);
 
       // If the volume is a mask, its volume number is added to the mask_volume_index list so volume index can be converted to mask_index.
-      if (Volumes[volume_index]->geometry.is_mask_volume == 1) Volumes[volume_index]->geometry.mask_index = mask_index_main;
-      if (Volumes[volume_index]->geometry.is_mask_volume == 1) mask_volume_index_list.elements[mask_index_main++] = volume_index;
+      if (Volumes[volume_index]->geometry.is_mask_volume == 1)
+        Volumes[volume_index]->geometry.mask_index = mask_index_main;
+      if (Volumes[volume_index]->geometry.is_mask_volume == 1)
+        mask_volume_index_list.elements[mask_index_main++] = volume_index;
 
       // Check all loggers assosiated with this volume and update the max_conditional_extend_index if necessary
-      for (iterator=0;iterator<Volumes[volume_index]->loggers.num_elements;iterator++) {
-        for (process_index=0;process_index<Volumes[volume_index]->loggers.p_logger_volume[iterator].num_elements;process_index++) {
+      for (iterator = 0; iterator < Volumes[volume_index]->loggers.num_elements; iterator++) {
+        for (process_index = 0; process_index < Volumes[volume_index]->loggers.p_logger_volume[iterator].num_elements; process_index++) {
           if (Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process[process_index] != NULL) {
             if (Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process[process_index]->logger_extend_index > max_conditional_extend_index)
               max_conditional_extend_index = Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process[process_index]->logger_extend_index;
           }
         }
       }
-
-
     }
   } // Initialization for each volume done
 
   // ------- Initialization of ray-tracing algorithm ------------------------------------
 
-  my_trace = malloc(max_number_of_processes*sizeof(double));
-  my_trace_fraction_control = malloc(max_number_of_processes*sizeof(double));
+  my_trace = malloc (max_number_of_processes * sizeof (double));
+  my_trace_fraction_control = malloc (max_number_of_processes * sizeof (double));
 
   // All geometries can have 2 intersections currently, when this changes the maximum number of solutions need to be reported to the Union_master.
   number_of_solutions = &number_of_solutions_static;
   component_error_msg = 0;
 
   // Pre allocated memory for destination list search
-  pre_allocated1 = malloc(number_of_volumes * sizeof(int));
-  pre_allocated2 = malloc(number_of_volumes * sizeof(int));
-  pre_allocated3 = malloc(number_of_volumes * sizeof(int));
+  pre_allocated1 = malloc (number_of_volumes * sizeof (int));
+  pre_allocated2 = malloc (number_of_volumes * sizeof (int));
+  pre_allocated3 = malloc (number_of_volumes * sizeof (int));
 
   // Allocate memory for logger_conditional_extend_array used in the extend section of the master component, if it is needed.
   if (max_conditional_extend_index > -1) {
-    logger_conditional_extend_array = malloc((max_conditional_extend_index + 1)*sizeof(int));
+    logger_conditional_extend_array = malloc ((max_conditional_extend_index + 1) * sizeof (int));
   }
 
   // In this function different lists of volume indecies are generated. They are the key to the speed of the component and central for the logic.
   // They use simple set algebra to generate these lists for each volume:
   // Children list for volume n: Indicies of volumes that are entirely within the set described by volume n
   // Overlap list for volume n: Indicies of volume that contains some of the set described by volume n (excluding volume n)
-  // Intersect check list for volume n: Indicies of volumes to check for intersection if a ray originates from volume n (is generated from the children and overlap lists)
-  // Parents list for volume n: Indicies of volumes that contain the entire set of volume n
-  // Grandparents lists for volume n: Indicies of volumes that contain the entire set of at least one parent of volume n
-  // Destination list for volume n: Indicies of volumes that could be the destination volume when a ray leaves volume n
-  // The overlap, parents and grandparents lists are local variables in the function, and not in the main scope.
+  // Intersect check list for volume n: Indicies of volumes to check for intersection if a ray originates from volume n (is generated from the children and
+  // overlap lists) Parents list for volume n: Indicies of volumes that contain the entire set of volume n Grandparents lists for volume n: Indicies of volumes
+  // that contain the entire set of at least one parent of volume n Destination list for volume n: Indicies of volumes that could be the destination volume when a
+  // ray leaves volume n The overlap, parents and grandparents lists are local variables in the function, and not in the main scope.
 
-  generate_lists(Volumes, &starting_lists, number_of_volumes, list_verbal);
+  generate_lists (Volumes, &starting_lists, number_of_volumes, list_verbal);
 
   // Generate "safe starting list", which contains all volumes that the ray may enter from other components
   // These are all volumes without scattering or absorption
 
   // Updating mask lists from volume index to global_mask_indices
   // Filling out the masked_by list that uses mask indices
-  for (volume_index=0;volume_index<number_of_volumes;volume_index++) {
+  for (volume_index = 0; volume_index < number_of_volumes; volume_index++) {
     Volumes[volume_index]->geometry.masked_by_mask_index_list.num_elements = Volumes[volume_index]->geometry.masked_by_list.num_elements;
-    Volumes[volume_index]->geometry.masked_by_mask_index_list.elements = malloc(Volumes[volume_index]->geometry.masked_by_mask_index_list.num_elements * sizeof(int));
-    for (iterator=0;iterator<Volumes[volume_index]->geometry.masked_by_list.num_elements;iterator++)
-        Volumes[volume_index]->geometry.masked_by_mask_index_list.elements[iterator] = find_on_int_list(mask_volume_index_list,Volumes[volume_index]->geometry.masked_by_list.elements[iterator]);
+    Volumes[volume_index]->geometry.masked_by_mask_index_list.elements
+        = malloc (Volumes[volume_index]->geometry.masked_by_mask_index_list.num_elements * sizeof (int));
+    for (iterator = 0; iterator < Volumes[volume_index]->geometry.masked_by_list.num_elements; iterator++)
+      Volumes[volume_index]->geometry.masked_by_mask_index_list.elements[iterator]
+          = find_on_int_list (mask_volume_index_list, Volumes[volume_index]->geometry.masked_by_list.elements[iterator]);
   }
 
   int volume_index_main;
 
   // Checking for equal priorities in order to alert the user to a potential input error
-  for (volume_index_main=0;volume_index_main<number_of_volumes;volume_index_main++) {
-    for (volume_index=0;volume_index<number_of_volumes;volume_index++)
-        if (Volumes[volume_index_main]->geometry.priority_value == Volumes[volume_index]->geometry.priority_value && volume_index_main != volume_index) {
-            if (Volumes[volume_index_main]->geometry.is_mask_volume == 0 && Volumes[volume_index]->geometry.is_mask_volume == 0) {
-              // Priority of masks do not matter
-              printf("ERROR in Union_master with name %s. The volumes named %s and %s have the same priority. Change the priorities so the one present in case of overlap has highest priority.\n",NAME_CURRENT_COMP,Volumes[volume_index_main]->name,Volumes[volume_index]->name);
-              exit(1);
-            }
+  for (volume_index_main = 0; volume_index_main < number_of_volumes; volume_index_main++) {
+    for (volume_index = 0; volume_index < number_of_volumes; volume_index++)
+      if (Volumes[volume_index_main]->geometry.priority_value == Volumes[volume_index]->geometry.priority_value && volume_index_main != volume_index) {
+        if (Volumes[volume_index_main]->geometry.is_mask_volume == 0 && Volumes[volume_index]->geometry.is_mask_volume == 0) {
+          // Priority of masks do not matter
+          printf ("ERROR in Union_master with name %s. The volumes named %s and %s have the same priority. Change the priorities so the one present in case of "
+                  "overlap has highest priority.\n",
+                  NAME_CURRENT_COMP, Volumes[volume_index_main]->name, Volumes[volume_index]->name);
+          exit (1);
         }
+      }
   }
-
 
   // Printing the generated lists for all volumes.
-  MPI_MASTER(
-  if (verbal) printf("\n ---- Overview of the lists generated for each volume ---- \n");
+  MPI_MASTER (if (verbal) printf ("\n ---- Overview of the lists generated for each volume ---- \n");
 
+              printf ("List overview for surrounding vacuum\n"); for (volume_index_main = 0; volume_index_main < number_of_volumes; volume_index_main++) {
+                if (verbal) {
+                  if (volume_index_main != 0) {
+                    if (Volumes[volume_index_main]->geometry.is_mask_volume == 0 || Volumes[volume_index_main]->geometry.is_masked_volume == 0
+                        || Volumes[volume_index_main]->geometry.is_exit_volume == 0) {
+                      printf ("List overview for %s with %s shape made of %s\n", Volumes[volume_index_main]->name, Volumes[volume_index_main]->geometry.shape,
+                              Volumes[volume_index_main]->p_physics->name);
+                    } else {
+                      printf ("List overview for %s with shape %s\n", Volumes[volume_index_main]->name, Volumes[volume_index_main]->geometry.shape);
+                    }
+                  }
+                }
 
-  printf("List overview for surrounding vacuum\n");
-  for (volume_index_main=0;volume_index_main<number_of_volumes;volume_index_main++) {
+                if (verbal)
+                  sprintf (string_output, "Children for Volume                  %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.children, string_output);
 
-      if (verbal) {
-        if (volume_index_main != 0) {
-          if (Volumes[volume_index_main]->geometry.is_mask_volume == 0 ||
-              Volumes[volume_index_main]->geometry.is_masked_volume == 0 ||
-              Volumes[volume_index_main]->geometry.is_exit_volume == 0) {
-            printf("List overview for %s with %s shape made of %s\n",
-                   Volumes[volume_index_main]->name,
-                   Volumes[volume_index_main]->geometry.shape,
-                   Volumes[volume_index_main]->p_physics->name);
-          } else {
-            printf("List overview for %s with shape %s\n",
-                   Volumes[volume_index_main]->name,
-                   Volumes[volume_index_main]->geometry.shape);
-          }
-        }
-      }
+                if (verbal)
+                  sprintf (string_output, "Direct_children for Volume           %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.direct_children, string_output);
 
-      if (verbal) sprintf(string_output,"Children for Volume                  %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.children,string_output);
+                if (verbal)
+                  sprintf (string_output, "Intersect_check_list for Volume      %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.intersect_check_list, string_output);
 
-      if (verbal) sprintf(string_output,"Direct_children for Volume           %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.direct_children,string_output);
+                if (verbal)
+                  sprintf (string_output, "Mask_intersect_list for Volume       %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.mask_intersect_list, string_output);
 
-      if (verbal) sprintf(string_output,"Intersect_check_list for Volume      %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.intersect_check_list,string_output);
+                if (verbal)
+                  sprintf (string_output, "Destinations_list for Volume         %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.destinations_list, string_output);
 
-      if (verbal) sprintf(string_output,"Mask_intersect_list for Volume       %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.mask_intersect_list,string_output);
+                // if (verbal) sprintf(string_output,"Destinations_logic_list for Volume   %d",volume_index_main);
+                // if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.destinations_logic_list,string_output);
 
-      if (verbal) sprintf(string_output,"Destinations_list for Volume         %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.destinations_list,string_output);
+                if (verbal)
+                  sprintf (string_output, "Reduced_destinations_list for Volume %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.reduced_destinations_list, string_output);
 
-      //if (verbal) sprintf(string_output,"Destinations_logic_list for Volume   %d",volume_index_main);
-      //if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.destinations_logic_list,string_output);
+                if (verbal)
+                  sprintf (string_output, "Next_volume_list for Volume          %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.next_volume_list, string_output);
 
-      if (verbal) sprintf(string_output,"Reduced_destinations_list for Volume %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.reduced_destinations_list,string_output);
+                if (verbal) {
+                  if (volume_index_main != 0)
+                    printf ("      Is_vacuum for Volume                 %d = %d\n", volume_index_main, Volumes[volume_index_main]->p_physics->is_vacuum);
+                }
+                if (verbal) {
+                  if (volume_index_main != 0)
+                    printf ("      is_mask_volume for Volume            %d = %d\n", volume_index_main, Volumes[volume_index_main]->geometry.is_mask_volume);
+                }
+                if (verbal) {
+                  if (volume_index_main != 0)
+                    printf ("      is_masked_volume for Volume          %d = %d\n", volume_index_main, Volumes[volume_index_main]->geometry.is_masked_volume);
+                }
+                if (verbal) {
+                  if (volume_index_main != 0)
+                    printf ("      is_exit_volume for Volume            %d = %d\n", volume_index_main, Volumes[volume_index_main]->geometry.is_exit_volume);
+                }
 
-      if (verbal) sprintf(string_output,"Next_volume_list for Volume          %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.next_volume_list,string_output);
+                if (verbal)
+                  sprintf (string_output, "mask_list for Volume                 %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.mask_list, string_output);
 
-      if (verbal) {
-        if (volume_index_main != 0)
-                           printf("      Is_vacuum for Volume                 %d = %d\n",volume_index_main,Volumes[volume_index_main]->p_physics->is_vacuum);
-      }
-      if (verbal) {
-        if (volume_index_main != 0)
-                           printf("      is_mask_volume for Volume            %d = %d\n",volume_index_main,Volumes[volume_index_main]->geometry.is_mask_volume);
-      }
-      if (verbal) {
-        if (volume_index_main != 0)
-                           printf("      is_masked_volume for Volume          %d = %d\n",volume_index_main,Volumes[volume_index_main]->geometry.is_masked_volume);
-      }
-      if (verbal) {
-        if (volume_index_main != 0)
-                           printf("      is_exit_volume for Volume            %d = %d\n",volume_index_main,Volumes[volume_index_main]->geometry.is_exit_volume);
-      }
+                if (verbal)
+                  sprintf (string_output, "masked_by_list for Volume            %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.masked_by_list, string_output);
 
-      if (verbal) sprintf(string_output,"mask_list for Volume                 %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.mask_list,string_output);
+                if (verbal)
+                  sprintf (string_output, "masked_by_mask_index_list for Volume %d", volume_index_main);
+                if (verbal)
+                  print_1d_int_list (Volumes[volume_index_main]->geometry.masked_by_mask_index_list, string_output);
 
-      if (verbal) sprintf(string_output,"masked_by_list for Volume            %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.masked_by_list,string_output);
-
-      if (verbal) sprintf(string_output,"masked_by_mask_index_list for Volume %d",volume_index_main);
-      if (verbal) print_1d_int_list(Volumes[volume_index_main]->geometry.masked_by_mask_index_list,string_output);
-
-      if (verbal)          printf("      mask_mode for Volume                 %d = %d\n",volume_index_main,Volumes[volume_index_main]->geometry.mask_mode);
-      if (verbal) printf("\n");
-  }
-  ) // End of MPI_MASTER
-
+                if (verbal)
+                  printf ("      mask_mode for Volume                 %d = %d\n", volume_index_main, Volumes[volume_index_main]->geometry.mask_mode);
+                if (verbal)
+                  printf ("\n");
+              }) // End of MPI_MASTER
 
   // Initializing intersection_time_table
-  // The intersection time table contains all information on intersection times for the current position/direction, and is cleared everytime a ray changes direction.
-  // Not all entries needs to be calculated, so there is a variable that keeps track of which intersection times have been calculated in order to avoid redoing that.
-  // When the intersections times are calculated for a volume, all future intersections are kept in the time table.
-  // Thus the memory allocation have to take into account how many intersections there can be with each volume, but it is currently set to 2, but can easily be changed. This may need to be reported by individual geometry components in the future.
+  // The intersection time table contains all information on intersection times for the current position/direction, and is cleared everytime a ray changes
+  // direction. Not all entries needs to be calculated, so there is a variable that keeps track of which intersection times have been calculated in order to avoid
+  // redoing that. When the intersections times are calculated for a volume, all future intersections are kept in the time table. Thus the memory allocation have
+  // to take into account how many intersections there can be with each volume, but it is currently set to 2, but can easily be changed. This may need to be
+  // reported by individual geometry components in the future.
 
   intersection_time_table.num_volumes = number_of_volumes;
 
-  intersection_time_table.n_elements = (int*) malloc(intersection_time_table.num_volumes * sizeof(int));
-  intersection_time_table.calculated = (int*) malloc(intersection_time_table.num_volumes * sizeof(int));
-  intersection_time_table.intersection_times = (double**) malloc(intersection_time_table.num_volumes * sizeof(double));
-  for (iterator = 0;iterator < intersection_time_table.num_volumes;iterator++){
-      if (strcmp(Volumes[iterator]->geometry.shape, "mesh") == 0) {
-        intersection_time_table.n_elements[iterator] = (int) 100; // Meshes can have any number of intersections, here we allocate room for 100
-      } else {
-        intersection_time_table.n_elements[iterator] = (int) 2; // number of intersection for all other geometries
-      }
-      if (iterator == 0) intersection_time_table.n_elements[iterator] = (int) 0; // number of intersection solutions
-      intersection_time_table.calculated[iterator] = (int) 0; // Initializing calculated logic
+  intersection_time_table.n_elements = (int*)malloc (intersection_time_table.num_volumes * sizeof (int));
+  intersection_time_table.calculated = (int*)malloc (intersection_time_table.num_volumes * sizeof (int));
+  intersection_time_table.intersection_times = (double**)malloc (intersection_time_table.num_volumes * sizeof (double));
+  for (iterator = 0; iterator < intersection_time_table.num_volumes; iterator++) {
+    if (strcmp (Volumes[iterator]->geometry.shape, "mesh") == 0) {
+      intersection_time_table.n_elements[iterator] = (int)100; // Meshes can have any number of intersections, here we allocate room for 100
+    } else {
+      intersection_time_table.n_elements[iterator] = (int)2; // number of intersection for all other geometries
+    }
+    if (iterator == 0)
+      intersection_time_table.n_elements[iterator] = (int)0; // number of intersection solutions
+    intersection_time_table.calculated[iterator] = (int)0;   // Initializing calculated logic
 
-      if (iterator == 0) {
-           intersection_time_table.intersection_times[0] = NULL;
+    if (iterator == 0) {
+      intersection_time_table.intersection_times[0] = NULL;
+    } else {
+      intersection_time_table.intersection_times[iterator] = (double*)malloc (intersection_time_table.n_elements[iterator] * sizeof (double));
+      for (solutions = 0; solutions < intersection_time_table.n_elements[iterator]; solutions++) {
+        intersection_time_table.intersection_times[iterator][solutions] = -1.0;
       }
-      else {
-        intersection_time_table.intersection_times[iterator] = (double*) malloc(intersection_time_table.n_elements[iterator]*sizeof(double));
-        for (solutions = 0;solutions < intersection_time_table.n_elements[iterator];solutions++) {
-              intersection_time_table.intersection_times[iterator][solutions] = -1.0;
-        }
-      }
+    }
   }
 
   // If enabled, the tagging system tracks all different histories sampled by the program.
@@ -963,16 +1010,19 @@ INITIALIZE
   // Initialize the tagging tree
   // Allocate a list of host nodes with the same length as the number of volumes
 
-  stop_creating_nodes = 0; stop_tagging_ray = 0; tagging_leaf_counter = 0;
+  stop_creating_nodes = 0;
+  stop_tagging_ray = 0;
+  tagging_leaf_counter = 0;
   if (enable_tagging) {
     master_tagging_node_list.num_elements = number_of_volumes;
-    master_tagging_node_list.elements = malloc(master_tagging_node_list.num_elements * sizeof(struct tagging_tree_node_struct*));
+    master_tagging_node_list.elements = malloc (master_tagging_node_list.num_elements * sizeof (struct tagging_tree_node_struct*));
 
     // Initialize
-    for (volume_index=0;volume_index<number_of_volumes;volume_index++) {
-      //if (verbal) printf("Allocating master tagging node for volume number %d \n",volume_index);
-      master_tagging_node_list.elements[volume_index] = initialize_tagging_tree_node(master_tagging_node_list.elements[volume_index], NULL, Volumes[volume_index]);
-      //if (verbal) printf("Allocated master tagging node for volume number %d \n",volume_index);
+    for (volume_index = 0; volume_index < number_of_volumes; volume_index++) {
+      // if (verbal) printf("Allocating master tagging node for volume number %d \n",volume_index);
+      master_tagging_node_list.elements[volume_index]
+          = initialize_tagging_tree_node (master_tagging_node_list.elements[volume_index], NULL, Volumes[volume_index]);
+      // if (verbal) printf("Allocated master tagging node for volume number %d \n",volume_index);
     }
   }
 
@@ -983,40 +1033,36 @@ INITIALIZE
   abs_loggers_with_data_array.allocated_elements = 0;
   abs_loggers_with_data_array.used_elements = 0;
 
-
   // Signal initialization complete
-  MPI_MASTER(
-    printf("Union_master component %s initialized sucessfully\n",NAME_CURRENT_COMP);
-  )
-
+  MPI_MASTER (printf ("Union_master component %s initialized sucessfully\n", NAME_CURRENT_COMP);)
 %}
 
 TRACE
 %{
 
   #ifdef Union_trace_verbal_setting
-    printf("\n\n\n\n\n----------- NEW RAY -------------------------------------------------\n");
-    printf("Union_master component name: %s \n \n",NAME_CURRENT_COMP);
+  printf ("\n\n\n\n\n----------- NEW RAY -------------------------------------------------\n");
+  printf ("Union_master component name: %s \n \n", NAME_CURRENT_COMP);
   #endif
 
   // Initialize logic
   done = 0;
   error_msg = 0;
-  clear_intersection_table(&intersection_time_table);
+  clear_intersection_table (&intersection_time_table);
 
   time_propagated_without_scattering = 0;
-  k_length = sqrt(kx*kx+ky*ky+kz*kz);
+  k_length = sqrt (kx * kx + ky * ky + kz * kz);
 
   // Initialize logger system / Statistics
   number_of_scattering_events = 0;
 
-  if (inherit_number_of_scattering_events==1) // Continue number of scattering from previous Union_master
-    number_of_scattering_events = global_master_list_master->elements[this_global_master_index-1].stored_number_of_scattering_events;
+  if (inherit_number_of_scattering_events == 1) // Continue number of scattering from previous Union_master
+    number_of_scattering_events = global_master_list_master->elements[this_global_master_index - 1].stored_number_of_scattering_events;
 
   // Zero scattered_flag_VP data
-  for (volume_index = 1;volume_index<number_of_volumes;volume_index++) { // No reason to update volume 0, as scattering doesn't happen there
+  for (volume_index = 1; volume_index < number_of_volumes; volume_index++) { // No reason to update volume 0, as scattering doesn't happen there
     scattered_flag[volume_index] = 0;
-    for (process_index=0;process_index<number_of_processes_array[volume_index];process_index++)
+    for (process_index = 0; process_index < number_of_processes_array[volume_index]; process_index++)
       scattered_flag_VP[volume_index][process_index] = 0;
   }
 
@@ -1025,34 +1071,43 @@ TRACE
   // Could be improved by using the precompiler instead as ncount times the number of Union_masters could be avoided.
   if (global_master_list_master->elements[0].component_index == INDEX_CURRENT_COMP) {
     // If this is the first Union master, clean up logger data for rays that did not make it through Union components
-    for (log_index=loggers_with_data_array.used_elements-1;log_index>-1;log_index--) {
-      loggers_with_data_array.logger_pointers[log_index]->function_pointers.clear_temp(&loggers_with_data_array.logger_pointers[log_index]->data_union);
+    for (log_index = loggers_with_data_array.used_elements - 1; log_index > -1; log_index--) {
+      loggers_with_data_array.logger_pointers[log_index]->function_pointers.clear_temp (&loggers_with_data_array.logger_pointers[log_index]->data_union);
     }
     loggers_with_data_array.used_elements = 0;
-    for (log_index=abs_loggers_with_data_array.used_elements-1;log_index>-1;log_index--) {
-      abs_loggers_with_data_array.abs_logger_pointers[log_index]->function_pointers.clear_temp(&abs_loggers_with_data_array.abs_logger_pointers[log_index]->data_union);
+    for (log_index = abs_loggers_with_data_array.used_elements - 1; log_index > -1; log_index--) {
+      abs_loggers_with_data_array.abs_logger_pointers[log_index]->function_pointers.clear_temp (
+          &abs_loggers_with_data_array.abs_logger_pointers[log_index]->data_union);
     }
     abs_loggers_with_data_array.used_elements = 0;
   }
   tagging_conditional_extend = 0;
-  for (iterator=0;iterator<max_conditional_extend_index+1;iterator++) {
+  for (iterator = 0; iterator < max_conditional_extend_index + 1; iterator++) {
     logger_conditional_extend_array[iterator] = 0;
   }
 
   // Need to clean up the double notation for position and velocity. // REVIEW_LINE
-  r_start[0] = x; r_start[1] = y; r_start[2] = z;
-  r[0]=x;r[1]=y;r[2]=z;k[0]=kx;k[1]=ky;k[2]=kz; // REVIEW_LINE r and v are bad names
+  r_start[0] = x;
+  r_start[1] = y;
+  r_start[2] = z;
+  r[0] = x;
+  r[1] = y;
+  r[2] = z;
+  k[0] = kx;
+  k[1] = ky;
+  k[2] = kz; // REVIEW_LINE r and v are bad names
 
-  ray_position = coords_set(x,y,z);
-  ray_wavevector = coords_set(kx,ky,kz);
+  ray_position = coords_set (x, y, z);
+  ray_wavevector = coords_set (kx, ky, kz);
 
   // Mask update: need to check the mask status for the initial position
   // mask status for a mask is 1 if the ray position is inside, 0 if it is outside
-  for (iterator=0;iterator<number_of_masks;iterator++) {
+  for (iterator = 0; iterator < number_of_masks; iterator++) {
     // CPU Only
-    //if(Volumes[mask_volume_index_list.elements[iterator]]->geometry.within_function(ray_position,&Volumes[mask_volume_index_list.elements[iterator]]->geometry) == 1) {
+    // if(Volumes[mask_volume_index_list.elements[iterator]]->geometry.within_function(ray_position,&Volumes[mask_volume_index_list.elements[iterator]]->geometry)
+    // == 1) {
     // GPU
-    if (r_within_function(ray_position, &Volumes[mask_volume_index_list.elements[iterator]]->geometry) == 1) {
+    if (r_within_function (ray_position, &Volumes[mask_volume_index_list.elements[iterator]]->geometry) == 1) {
       mask_status_list.elements[iterator] = 1;
     } else {
       mask_status_list.elements[iterator] = 0;
@@ -1060,31 +1115,33 @@ TRACE
   }
 
   #ifdef Union_trace_verbal_setting
-    print_1d_int_list(mask_status_list,"Initial mask status list");
+  print_1d_int_list (mask_status_list, "Initial mask status list");
   #endif
 
   // Now the initial current_volume can be found, which requires the up to date mask_status_list
-  current_volume = within_which_volume_GPU(ray_position, starting_lists.reduced_start_list, starting_lists.starting_destinations_list, Volumes, &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
+  current_volume = within_which_volume_GPU (ray_position, starting_lists.reduced_start_list, starting_lists.starting_destinations_list, Volumes,
+                                            &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
 
   // Using the mask_status_list and the current volume, the current_mask_intersect_list_status can be made
   //  it contains the effective mask status of all volumes on the current volumes mask intersect list, which needs to be calculated,
   //  but only when the current volume or mask status changes, not under for example scattering inside the current volume
-  update_current_mask_intersect_status(&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
+  update_current_mask_intersect_status (&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
 
   #ifdef Union_trace_verbal_setting
-    printf("Starting current_volume = %d\n",current_volume);
+  printf ("Starting current_volume = %d\n", current_volume);
   #endif
 
   // Check if the ray appeared in an allowed starting volume, unless this check is disabled by the user for advanced cases
   if (allow_inside_start == 0 && starting_lists.allowed_starting_volume_logic_list.elements[current_volume] == 0) {
-    printf("ERROR, ray ''teleported'' into Union component %s, if intentional, set allow_inside_start=1\n", NAME_CURRENT_COMP);
+    printf ("ERROR, ray ''teleported'' into Union component %s, if intentional, set allow_inside_start=1\n", NAME_CURRENT_COMP);
     // NEED ERROR FLAG: Need to set an error flag that is read in finally to warn user of problem.
-    exit(1);
+    exit (1);
   }
   // Warn the user that rays have appeared inside a volume instead of outside as expected
   if (starting_volume_warning == 0 && current_volume != 0) {
-        printf("WARNING: Ray started in volume ''%s'' rather than the surrounding vacuum in component %s. This warning is only shown once.\n",Volumes[current_volume]->name,NAME_CURRENT_COMP);
-        starting_volume_warning = 1;
+    printf ("WARNING: Ray started in volume ''%s'' rather than the surrounding vacuum in component %s. This warning is only shown once.\n",
+            Volumes[current_volume]->name, NAME_CURRENT_COMP);
+    starting_volume_warning = 1;
   }
 
   // Placing the new ray at the start of the tagging tree corresponding to current volume
@@ -1095,12 +1152,15 @@ TRACE
   if (enable_tagging) {
     current_tagging_node = master_tagging_node_list.elements[current_volume];
     stop_tagging_ray = 0; // Allow this ray to be tracked
-    if (tagging_leaf_counter > history_limit) stop_creating_nodes = 1;
+    if (tagging_leaf_counter > history_limit)
+      stop_creating_nodes = 1;
   }
 
   #ifdef Union_trace_verbal_setting
-    if (enable_tagging) printf("current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-    if (enable_tagging) printf("current_tagging_node->number_of_rays = %d \n",current_tagging_node->number_of_rays);
+  if (enable_tagging)
+    printf ("current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+  if (enable_tagging)
+    printf ("current_tagging_node->number_of_rays = %d \n", current_tagging_node->number_of_rays);
   #endif
 
   // Propagation loop including scattering
@@ -1113,9 +1173,9 @@ TRACE
     limit--;
 
     #ifdef Union_trace_verbal_setting
-      printf("----------- START OF WHILE LOOP --------------------------------------\n");
-      print_intersection_table(&intersection_time_table);
-      printf("current_volume = %d \n",current_volume);
+    printf ("----------- START OF WHILE LOOP --------------------------------------\n");
+    print_intersection_table (&intersection_time_table);
+    printf ("current_volume = %d \n", current_volume);
     #endif
 
     // Calculating intersections with the necessary volumes. The relevant set of volumes depend on the current volume and the mask status array.
@@ -1124,46 +1184,50 @@ TRACE
     //  skipped.
 
     // Checking intersections for all volumes in the intersect list.
-    for (start=check=Volumes[current_volume]->geometry.intersect_check_list.elements;check-start<Volumes[current_volume]->geometry.intersect_check_list.num_elements;check++) {
-    // This will leave check as a pointer to the intergers in the intersect_check_list and iccrement nicely
+    for (start = check = Volumes[current_volume]->geometry.intersect_check_list.elements;
+         check - start < Volumes[current_volume]->geometry.intersect_check_list.num_elements; check++) {
+      // This will leave check as a pointer to the intergers in the intersect_check_list and iccrement nicely
+      #ifdef Union_trace_verbal_setting
+      printf ("Intersect_list = %d being checked \n", *check);
+      #endif
+
+      if (intersection_time_table.calculated[*check] == 0) {
         #ifdef Union_trace_verbal_setting
-          printf("Intersect_list = %d being checked \n",*check);
+        printf ("running intersection for intersect_list with *check = %d \n", *check);
         #endif
+        // Calculate intersections using intersect function embedded in the relevant volume structure using parameters
+        //  that are also embedded in the structure.
 
-        if (intersection_time_table.calculated[*check] == 0) {
-             #ifdef Union_trace_verbal_setting
-               printf("running intersection for intersect_list with *check = %d \n",*check);
-             #endif
-            // Calculate intersections using intersect function embedded in the relevant volume structure using parameters
-            //  that are also embedded in the structure.
-
-            // GPU Flexible intersect_function call
-            // intersection_times is now actually intersection_lengths in m
-            geometry_output = Volumes[*check]->geometry.intersect_function(intersection_time_table.intersection_times[*check],number_of_solutions,r_start,k,&Volumes[*check]->geometry);
-            intersection_time_table.calculated[*check] = 1;
-        }
+        // GPU Flexible intersect_function call
+        // intersection_times is now actually intersection_lengths in m
+        geometry_output = Volumes[*check]->geometry.intersect_function (intersection_time_table.intersection_times[*check], number_of_solutions, r_start, k,
+                                                                        &Volumes[*check]->geometry);
+        intersection_time_table.calculated[*check] = 1;
+      }
     }
 
     // Mask update: add additional loop for checking intersections with masked volumes depending on mask statuses
-    for (mask_iterator=0;mask_iterator<Volumes[current_volume]->geometry.mask_intersect_list.num_elements;mask_iterator++) {
+    for (mask_iterator = 0; mask_iterator < Volumes[current_volume]->geometry.mask_intersect_list.num_elements; mask_iterator++) {
       if (current_mask_intersect_list_status.elements[mask_iterator] == 1) { // Only check if the mask is active
-        #ifdef Union_trace_verbal_setting
-          printf("Mask Intersect_list = %d being checked \n",Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]);
+                                                                             #ifdef Union_trace_verbal_setting
+        printf ("Mask Intersect_list = %d being checked \n", Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]);
         #endif
         if (intersection_time_table.calculated[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]] == 0) {
           #ifdef Union_trace_verbal_setting
-            printf("running intersection for mask_intersect_list element = %d \n",Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]);
+          printf ("running intersection for mask_intersect_list element = %d \n", Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]);
           //  printf("r = (%f,%f,%f) k = (%f,%f,%f) \n",r[0],r[1],r[2],k[0],k[1],k[2]);
           #endif
           // Calculate intersections using intersect function imbedded in the relevant volume structure using parameters
-            //  that are also imbedded in the structure.
+          //  that are also imbedded in the structure.
           // CPU Only
-          //geometry_output = Volumes[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]]->geometry.intersect_function(intersection_time_table.intersection_times[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]],number_of_solutions,r_start,k,&Volumes[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]]->geometry);
+          // geometry_output =
+          // Volumes[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]]->geometry.intersect_function(intersection_time_table.intersection_times[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]],number_of_solutions,r_start,k,&Volumes[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]]->geometry);
 
           // GPU allowed
           int selected_index;
           selected_index = Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator];
-          geometry_output = intersect_function(intersection_time_table.intersection_times[selected_index], number_of_solutions, r_start, k, &Volumes[selected_index]->geometry);
+          geometry_output = intersect_function (intersection_time_table.intersection_times[selected_index], number_of_solutions, r_start, k,
+                                                &Volumes[selected_index]->geometry);
 
           intersection_time_table.calculated[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]] = 1;
           // if (trace_verbal) printf("succesfully calculated intersection times for volume *check = %d \n",*check);
@@ -1171,68 +1235,75 @@ TRACE
       }
     }
 
-    // Checking if there are intersections with children of current volume, which means there is an intersection before current_volume, and thus can be skipped. But only if they have not been overwritten. In case current_volume is 0, there is no need to do this regardless.
+    // Checking if there are intersections with children of current volume, which means there is an intersection before current_volume, and thus can be skipped.
+    // But only if they have not been overwritten. In case current_volume is 0, there is no need to do this regardless.
     if (current_volume != 0 && intersection_time_table.calculated[current_volume] == 0) {
+      #ifdef Union_trace_verbal_setting
+      printf ("Checking if children of current_volume = %d have intersections. \n", current_volume);
+      #endif
+      intersection_with_children = 0;
+      // for (start = check = Volumes[current_volume]->geometry.direct_children.elements;check - start <
+      // Volumes[current_volume]->geometry.children.num_elements;check++) { // REVIEW LINE. Caused bug with masks.
+      for (start = check = Volumes[current_volume]->geometry.children.elements; check - start < Volumes[current_volume]->geometry.children.num_elements;
+           check++) {
         #ifdef Union_trace_verbal_setting
-          printf("Checking if children of current_volume = %d have intersections. \n",current_volume);
+        printf ("Checking if child %d of current_volume = %d have intersections. \n", *check, current_volume);
         #endif
-        intersection_with_children = 0;
-        //for (start = check = Volumes[current_volume]->geometry.direct_children.elements;check - start < Volumes[current_volume]->geometry.children.num_elements;check++) { // REVIEW LINE. Caused bug with masks.
-        for (start = check = Volumes[current_volume]->geometry.children.elements;check - start < Volumes[current_volume]->geometry.children.num_elements;check++) {
+        // Only check the first of the two results in the intersection table, as they are ordered, and the second is of no interest
+        if (intersection_time_table.calculated[*check] == 1 && intersection_time_table.intersection_times[*check][0] > time_propagated_without_scattering) {
+          // If this child is masked, its mask status need to be 1 in order to be taken into account
+          if (Volumes[*check]->geometry.is_masked_volume == 0) {
             #ifdef Union_trace_verbal_setting
-              printf("Checking if child %d of current_volume = %d have intersections. \n",*check,current_volume);
+            printf ("Found an child of current_volume with an intersection. Skips calculating for current_volume \n");
             #endif
-            // Only check the first of the two results in the intersection table, as they are ordered, and the second is of no interest
-            if (intersection_time_table.calculated[*check] == 1 && intersection_time_table.intersection_times[*check][0] > time_propagated_without_scattering) {
-                // If this child is masked, its mask status need to be 1 in order to be taken into account
-                if (Volumes[*check]->geometry.is_masked_volume == 0) {
-                  #ifdef Union_trace_verbal_setting
-                    printf("Found an child of current_volume with an intersection. Skips calculating for current_volume \n");
-                  #endif
-                  intersection_with_children = 1;
-                  break; // No need to check more, if there is just one it is not necessary to calculate intersection with current_volume yet
-                } else {
-                  #ifdef Union_trace_verbal_setting
-                    printf("Found an child of current_volume with an intersection, but it is masked. Check to see if it can skip calculating for current_volume \n");
-                  #endif
+            intersection_with_children = 1;
+            break; // No need to check more, if there is just one it is not necessary to calculate intersection with current_volume yet
+          } else {
+            #ifdef Union_trace_verbal_setting
+            printf ("Found an child of current_volume with an intersection, but it is masked. Check to see if it can skip calculating for current_volume \n");
+            #endif
 
-                  if (Volumes[*check]->geometry.mask_mode == 2) { // ANY mask mode
-                    tree_next_volume = 0;
-                    for (mask_start=mask_check=Volumes[*check]->geometry.masked_by_mask_index_list.elements;mask_check-mask_start<Volumes[*check]->geometry.masked_by_mask_index_list.num_elements;mask_check++) {
-                       if (mask_status_list.elements[*mask_check] == 1) {
-                         intersection_with_children = 1;
-                         break;
-                       }
-                    }
-                  } else { // ALL mask mode
-                    intersection_with_children = 1;
-                    for (mask_start=mask_check=Volumes[*check]->geometry.masked_by_mask_index_list.elements;mask_check-mask_start<Volumes[*check]->geometry.masked_by_mask_index_list.num_elements;mask_check++) {
-                      if (mask_status_list.elements[*mask_check] == 0) {
-                        intersection_with_children = 0;
-                        break;
-                      }
-                    }
-                  }
-                  #ifdef Union_trace_verbal_setting
-                    printf("The mask status was 1, can actually skip intersection calculation for current volume \n");
-                  #endif
-                  if (intersection_with_children == 1) break;
+            if (Volumes[*check]->geometry.mask_mode == 2) { // ANY mask mode
+              tree_next_volume = 0;
+              for (mask_start = mask_check = Volumes[*check]->geometry.masked_by_mask_index_list.elements;
+                   mask_check - mask_start < Volumes[*check]->geometry.masked_by_mask_index_list.num_elements; mask_check++) {
+                if (mask_status_list.elements[*mask_check] == 1) {
+                  intersection_with_children = 1;
+                  break;
                 }
+              }
+            } else { // ALL mask mode
+              intersection_with_children = 1;
+              for (mask_start = mask_check = Volumes[*check]->geometry.masked_by_mask_index_list.elements;
+                   mask_check - mask_start < Volumes[*check]->geometry.masked_by_mask_index_list.num_elements; mask_check++) {
+                if (mask_status_list.elements[*mask_check] == 0) {
+                  intersection_with_children = 0;
+                  break;
+                }
+              }
             }
+            #ifdef Union_trace_verbal_setting
+            printf ("The mask status was 1, can actually skip intersection calculation for current volume \n");
+            #endif
+            if (intersection_with_children == 1)
+              break;
+          }
         }
-        #ifdef Union_trace_verbal_setting
-          printf("intersection_with_children = %d \n",intersection_with_children);
-        #endif
-        if (intersection_with_children == 0) {
-            // GPU Allowed
-            geometry_output = intersect_function(intersection_time_table.intersection_times[current_volume], number_of_solutions, r_start, k, &Volumes[current_volume]->geometry);
-            intersection_time_table.calculated[current_volume] = 1;
-        }
+      }
+      #ifdef Union_trace_verbal_setting
+      printf ("intersection_with_children = %d \n", intersection_with_children);
+      #endif
+      if (intersection_with_children == 0) {
+        // GPU Allowed
+        geometry_output = intersect_function (intersection_time_table.intersection_times[current_volume], number_of_solutions, r_start, k,
+                                              &Volumes[current_volume]->geometry);
+        intersection_time_table.calculated[current_volume] = 1;
+      }
     }
 
     // At this point, intersection_time_table is updated with intersection times of all possible intersections.
     #ifdef Union_trace_verbal_setting
-      print_intersection_table(&intersection_time_table);
+    print_intersection_table (&intersection_time_table);
     #endif
 
     // Next task is to find the next intersection time. The next intersection must be greater than the time_propagated_without_scattering (0 at start of loop)
@@ -1240,71 +1311,92 @@ TRACE
 
     // First loop for checking intersect_check_list
     #ifdef Union_trace_verbal_setting
-      min_intersection_time=0;
-      printf("Incoming value of MIN_intersection_length=%g\n",min_intersection_time);
+    min_intersection_time = 0;
+    printf ("Incoming value of MIN_intersection_length=%g\n", min_intersection_time);
     #endif
     time_found = 0;
-    for (start=check=Volumes[current_volume]->geometry.intersect_check_list.elements;check-start<Volumes[current_volume]->geometry.intersect_check_list.num_elements;check++) {
-        for (solution = 0;solution<intersection_time_table.n_elements[*check];solution++) {
-            if (time_found) {
-                if ((intersection_time = intersection_time_table.intersection_times[*check][solution]) > time_propagated_without_scattering &&  intersection_time < min_intersection_time) {
-                    min_intersection_time = intersection_time;min_solution = solution;min_volume = *check;
-                   #ifdef Union_trace_verbal_setting
-		    printf("found A at %i x %i\n",*check,solution);
-		    #endif
-                }
-            } else {
-                if ((intersection_time = intersection_time_table.intersection_times[*check][solution]) > time_propagated_without_scattering) {
-                    min_intersection_time = intersection_time;min_solution = solution;min_volume = *check;
-                    time_found = 1;
-                    #ifdef Union_trace_verbal_setting
-		     printf("found B at %i x %i\n",*check,solution);
-                    #endif
-                }
-            }
+    for (start = check = Volumes[current_volume]->geometry.intersect_check_list.elements;
+         check - start < Volumes[current_volume]->geometry.intersect_check_list.num_elements; check++) {
+      for (solution = 0; solution < intersection_time_table.n_elements[*check]; solution++) {
+        if (time_found) {
+          if ((intersection_time = intersection_time_table.intersection_times[*check][solution]) > time_propagated_without_scattering
+              && intersection_time < min_intersection_time) {
+            min_intersection_time = intersection_time;
+            min_solution = solution;
+            min_volume = *check;
+            #ifdef Union_trace_verbal_setting
+            printf ("found A at %i x %i\n", *check, solution);
+            #endif
+          }
+        } else {
+          if ((intersection_time = intersection_time_table.intersection_times[*check][solution]) > time_propagated_without_scattering) {
+            min_intersection_time = intersection_time;
+            min_solution = solution;
+            min_volume = *check;
+            time_found = 1;
+            #ifdef Union_trace_verbal_setting
+            printf ("found B at %i x %i\n", *check, solution);
+            #endif
+          }
         }
+      }
     }
     #ifdef Union_trace_verbal_setting
-    printf("min_intersection_length=%g min_solution=%i\n",min_intersection_time,min_solution);
+    printf ("min_intersection_length=%g min_solution=%i\n", min_intersection_time, min_solution);
     #endif
 
     // Now check the masked_intersect_list, but only the ones that are currently active
-    for (mask_iterator=0;mask_iterator<Volumes[current_volume]->geometry.mask_intersect_list.num_elements;mask_iterator++) {
+    for (mask_iterator = 0; mask_iterator < Volumes[current_volume]->geometry.mask_intersect_list.num_elements; mask_iterator++) {
       if (current_mask_intersect_list_status.elements[mask_iterator] == 1) {
-        for (solution = 0;solution<intersection_time_table.n_elements[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]];solution++) {
-            if (time_found) {
-                if ((intersection_time = intersection_time_table.intersection_times[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]][solution]) > time_propagated_without_scattering &&  intersection_time < min_intersection_time) {
-                    min_intersection_time = intersection_time;min_solution = solution;min_volume = Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator];
-                }
-            } else {
-                if ((intersection_time = intersection_time_table.intersection_times[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]][solution]) > time_propagated_without_scattering) {
-                    min_intersection_time = intersection_time;min_solution = solution;min_volume = Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator];
-                    time_found = 1;
-                }
+        for (solution = 0; solution < intersection_time_table.n_elements[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]];
+             solution++) {
+          if (time_found) {
+            if ((intersection_time
+                 = intersection_time_table.intersection_times[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]][solution])
+                    > time_propagated_without_scattering
+                && intersection_time < min_intersection_time) {
+              min_intersection_time = intersection_time;
+              min_solution = solution;
+              min_volume = Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator];
             }
+          } else {
+            if ((intersection_time
+                 = intersection_time_table.intersection_times[Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator]][solution])
+                > time_propagated_without_scattering) {
+              min_intersection_time = intersection_time;
+              min_solution = solution;
+              min_volume = Volumes[current_volume]->geometry.mask_intersect_list.elements[mask_iterator];
+              time_found = 1;
+            }
+          }
         }
       }
     }
 
     // And check the current_volume
-    for (solution = 0;solution<intersection_time_table.n_elements[current_volume];solution++) {
-        if (time_found) {
-            if ((intersection_time = intersection_time_table.intersection_times[current_volume][solution]) > time_propagated_without_scattering && intersection_time < min_intersection_time) {
-                min_intersection_time = intersection_time;min_solution = solution;min_volume = current_volume;
-            }
-        } else {
-            if ((intersection_time = intersection_time_table.intersection_times[current_volume][solution]) > time_propagated_without_scattering) {
-                min_intersection_time = intersection_time;min_solution = solution;min_volume = current_volume;
-                time_found = 1;
-            }
+    for (solution = 0; solution < intersection_time_table.n_elements[current_volume]; solution++) {
+      if (time_found) {
+        if ((intersection_time = intersection_time_table.intersection_times[current_volume][solution]) > time_propagated_without_scattering
+            && intersection_time < min_intersection_time) {
+          min_intersection_time = intersection_time;
+          min_solution = solution;
+          min_volume = current_volume;
         }
+      } else {
+        if ((intersection_time = intersection_time_table.intersection_times[current_volume][solution]) > time_propagated_without_scattering) {
+          min_intersection_time = intersection_time;
+          min_solution = solution;
+          min_volume = current_volume;
+          time_found = 1;
+        }
+      }
     }
 
     #ifdef Union_trace_verbal_setting
-      printf("min_intersection_time = %f \n",min_intersection_time);/*actually a length now*/
-      printf("min_solution          = %d \n",min_solution);
-      printf("min_volume            = %d \n",min_volume);
-      printf("time_found            = %d \n",time_found);
+    printf ("min_intersection_time = %f \n", min_intersection_time); /*actually a length now*/
+    printf ("min_solution          = %d \n", min_solution);
+    printf ("min_volume            = %d \n", min_volume);
+    printf ("time_found            = %d \n", time_found);
     #endif
 
     abs_weight_factor = 1.0;
@@ -1313,708 +1405,816 @@ TRACE
     // If a time is found, propagation continues, and it will be checked if a scattering occurs before the next intersection.
     // If a time is not found, the ray must be leaving the ensamble of volumes and the loop will be concluded
     if (time_found) {
-        time_to_boundery = min_intersection_time - time_propagated_without_scattering; // calculate the time remaining before the next intersection
-        length_to_boundery = time_to_boundery;
-        scattering_event = 0; // Assume a scattering event will not occur
+      time_to_boundery = min_intersection_time - time_propagated_without_scattering; // calculate the time remaining before the next intersection
+      length_to_boundery = time_to_boundery;
+      scattering_event = 0; // Assume a scattering event will not occur
 
-        // Check if a scattering event should occur
-        if (current_volume != 0) { // Volume 0 is always vacuum, and if this is the current volume, an event will not occur
-          if (Volumes[current_volume]->p_physics->number_of_processes == 0) { // If there are no processes, the volume could be vacuum or an absorber
-            if (Volumes[current_volume]->p_physics->is_vacuum == 0) {
-              // This volume does not have physical processes but does have an absorption cross section, so the ray weight is reduced accordingly
-              //  change to file based absorption change time_to_boundery to lenght_to_boundary
-              p *= exp(-1.0*get_my_abs(Volumes[current_volume]->p_physics,k_length)*length_to_boundery);
+      // Check if a scattering event should occur
+      if (current_volume != 0) { // Volume 0 is always vacuum, and if this is the current volume, an event will not occur
+        if (Volumes[current_volume]->p_physics->number_of_processes == 0) { // If there are no processes, the volume could be vacuum or an absorber
+          if (Volumes[current_volume]->p_physics->is_vacuum == 0) {
+            // This volume does not have physical processes but does have an absorption cross section, so the ray weight is reduced accordingly
+            //  change to file based absorption change time_to_boundery to lenght_to_boundary
+            p *= exp (-1.0 * get_my_abs (Volumes[current_volume]->p_physics, k_length) * length_to_boundery);
 
-              //#ifdef Union_trace_verbal_setting
-              //printf("name of material: %s \n",Volumes[current_volume]->name);
-              //printf("length to boundery  = %f\n",length_to_boundery);
-              //printf("absorption cross section  = %f\n",Volumes[current_volume]->p_physics->my_a);
-              //printf("chance to get through this length of absorber: %f \%\n",100*exp(-Volumes[current_volume]->p_physics->my_a*length_to_boundery));
-              //#endif
-            }
-          } else {
-            // Since there is a non-zero number of processes in this material, all the scattering cross section for these are calculated
-            my_sum = 0; k[0] = kx; k[1] = ky; k[2] = kz; p_my_trace = my_trace; wavevector = coords_set(k[0],k[1],k[2]);
-            //for (process_start = process = Volumes[current_volume]->p_physics->p_scattering_array;process - process_start < Volumes[current_volume]->p_physics->number_of_processes;process++) {
-            int p_index;
-            for (p_index=0; p_index < Volumes[current_volume]->p_physics->number_of_processes; p_index++ ){ // GPU
-
-              if (Volumes[current_volume]->p_physics->p_scattering_array[p_index].non_isotropic_rot_index != -1) {
-                // If the process is not isotropic, the wavevector is transformed into the local coordinate system of the process
-                wavevector_rotated = rot_apply(Volumes[current_volume]->geometry.process_rot_matrix_array[Volumes[current_volume]->p_physics->p_scattering_array[p_index].non_isotropic_rot_index],wavevector);
-
-                coords_get(wavevector_rotated,&k_rotated[0],&k_rotated[1],&k_rotated[2]);
-
-              } else {
-                k_rotated[0] = k[0]; k_rotated[1] = k[1]; k_rotated[2] = k[2];
-              }
-
-              // Find correct focus_data_array index for this volume/process
-              focus_data_index = Volumes[current_volume]->geometry.focus_array_indices.elements[p_index];
-
-              // Call the probability for scattering function assighed to this specific procress (the process pointer is updated in the for loop)
-              process = &Volumes[current_volume]->p_physics->p_scattering_array[p_index]; // GPU Allowed
-
-              int physics_output;
-              physics_output = physics_my(process->eProcess, p_my_trace, k_rotated, process->data_transfer,&Volumes[current_volume]->geometry.focus_data_array.elements[focus_data_index], _particle);
-
-              my_sum += *p_my_trace;
-              #ifdef Union_trace_verbal_setting
-                printf("my_trace = %f, my_sum = %f\n",*p_my_trace,my_sum);
-              #endif
-              p_my_trace++; // increment the pointer so that it point to the next element (max number of process in any material is allocated)
-            }
-
-            #ifdef Union_trace_verbal_setting
-              printf("time_propagated_without_scattering = %f.\n",time_propagated_without_scattering);
-              printf("k_length                           = %f.\n",k_length);
-            #endif
-
-            //length_to_boundery = time_to_boundery * v_length;
-
-            #ifdef Union_trace_verbal_setting
-              printf("exp(- length_to_boundery*my_sum) = %f. length_to_boundery = %f. my_sum = %f.\n",exp(-length_to_boundery*my_sum),length_to_boundery,my_sum);
-            #endif
-
-            // Selecting if a scattering takes place, and what scattering process.
-            // This section have too many if statements, and unessecary calculations
-            // Could make seperate functions for p_interact on/off and interact_fraction on/off,
-            //   and set function pointers to these in initialize, thus avoiding many unessecary if statements and calculations of x/x.
-            // change to new absorption
-            my_sum_plus_abs = my_sum + get_my_abs(Volumes[current_volume]->p_physics, k_length);
-
-            if (my_sum < 1E-18) {
-                // The scattering cross section is basicly zero, no scattering should occur.
-                scattering_event = 0;
-                p *= exp(-length_to_boundery*my_sum_plus_abs); // Correct for absorption and the almost zero scattering
-            } else if (length_to_boundery < safty_distance2) {
-                // Too close to boundery to safly make another scattering, attenuate
-                p *= exp(-length_to_boundery*my_sum_plus_abs); // Attentuate the beam for the small distance
-                scattering_event = 0;
-            } else {
-                // The scattering cross section is above zero and the distance to the boundery is sufficient for a scattering
-                if (Volumes[current_volume]->geometry.geometry_p_interact != 0) {
-                    // a fraction of the beam (geometry_p_interact) is forced to scatter
-                    real_transmission_probability = exp(-length_to_boundery*my_sum_plus_abs);
-                    mc_transmission_probability = (1.0 - Volumes[current_volume]->geometry.geometry_p_interact);
-                    if ((scattering_event = (rand01() > mc_transmission_probability))) {
-                        // Scattering event happens, this is the correction for the weight
-                        p *= (1.0-real_transmission_probability)/(1.0-mc_transmission_probability); // Absorption simulated in weight
-
-                        // Find length to next scattering knowing the ray will scatter.
-                        length_to_scattering = safty_distance -log(1.0 - rand0max((1.0 - exp(-my_sum_plus_abs*(length_to_boundery-safty_distance2))))) / my_sum_plus_abs;
-                    } else {
-                        // Scattering event does not happen, this is the appropriate correction
-                        p *= real_transmission_probability/mc_transmission_probability; // Absorption simulated in weight
-                    }
-                } else {
-                    // probability to scatter is the natural value
-                    if(my_sum*length_to_boundery < 1e-6) { // Scattering probability very small, linear method is used as exponential is unreliable
-                      if (length_to_boundery > safty_distance2) {
-                        if (rand01() < exp(-length_to_boundery*my_sum_plus_abs)) {
-                          // Scattering happens, use linear description to select scattering position
-                          length_to_scattering = safty_distance + rand0max(length_to_boundery - safty_distance2);
-                          // Weight factor necessary to correct for using the linear scattering position distribution
-                          p *= length_to_boundery*my_sum*exp(-length_to_scattering*my_sum_plus_abs); // Absorption simulated in weight
-                          scattering_event = 1;
-                        } else scattering_event = 0;
-                      } else {
-                        // The distance is too short to reliably make a scattering event (in comparison to accuraccy of intersect functions)
-                        p *= exp(-length_to_boundery*my_sum_plus_abs); // Attentuate the beam for the small distance
-                        scattering_event = 0;
-                      }
-                    } else {
-                        // Strong scattering, use exponential description to select scattering position between safetydistance and infinity
-                        length_to_scattering = safty_distance -log(1 - rand01() ) / my_sum_plus_abs;
-                        // Scattering happens if the scattering position is before the boundery (and safty distance)
-                        if (length_to_scattering < length_to_boundery - safty_distance) scattering_event = 1;
-                        else scattering_event = 0;
-                    }
-                }
-
-                if (scattering_event == 1) {
-                  // Adjust weight for absorption
-                  p *= my_sum/my_sum_plus_abs;
-                  // Safety feature, alert in case of nonsense my results / negative absorption
-                  if (my_sum/my_sum_plus_abs > 1.0) printf("WARNING: Absorption weight factor above 1! Should not happen! \n");
-                  // Select process
-                  if (Volumes[current_volume]->p_physics->number_of_processes == 1) { // trivial case
-                    // Select the only available process, which will always have index 0
-                    selected_process = 0;
-                  } else {
-                    if (Volumes[current_volume]->p_physics->interact_control == 1) {
-                      // Interact_fraction is used to influence the choice of process in this material
-                      mc_prop = rand01();culmative_probability=0;total_process_interact=1.0;
-
-                      // If any of the processes have probability 0, they are excluded from the selection
-                      for (iterator = 0;iterator < Volumes[current_volume]->p_physics->number_of_processes;iterator++) {
-                        if (my_trace[iterator] < 1E-18) {
-                          // When this happens, the total force probability is corrected and the probability for this particular instance is set to 0
-                          total_process_interact -= Volumes[current_volume]->p_physics->p_scattering_array[iterator].process_p_interact;
-                          my_trace_fraction_control[iterator] = 0;
-                          // In cases where my_trace is not zero, the forced fraction is still used.
-                        } else my_trace_fraction_control[iterator] = Volumes[current_volume]->p_physics->p_scattering_array[iterator].process_p_interact;
-                      }
-                      // Randomly select a process using the weights stored in my_trace_fraction_control divided by total_process_interact
-                      for (iterator = 0;iterator < Volumes[current_volume]->p_physics->number_of_processes;iterator++) {
-                        culmative_probability += my_trace_fraction_control[iterator]/total_process_interact;
-                        if (culmative_probability > mc_prop) {
-                          selected_process = iterator;
-                          p *= (my_trace[iterator]/my_sum)*(total_process_interact/my_trace_fraction_control[iterator]);
-                          break;
-                        }
-                      }
-
-                    } else {
-                      // Select a process based on their relative attenuations factors
-                      mc_prop = rand01();culmative_probability=0;
-                      for (iterator = 0;iterator < Volumes[current_volume]->p_physics->number_of_processes;iterator++) {
-                        culmative_probability += my_trace[iterator]/my_sum;
-                        if (culmative_probability > mc_prop) {
-                          selected_process = iterator;
-                          break;
-                        }
-                      }
-                    }
-                  }
-                } // end of select process
-            }
-
+            // #ifdef Union_trace_verbal_setting
+            // printf("name of material: %s \n",Volumes[current_volume]->name);
+            // printf("length to boundery  = %f\n",length_to_boundery);
+            // printf("absorption cross section  = %f\n",Volumes[current_volume]->p_physics->my_a);
+            // printf("chance to get through this length of absorber: %f \%\n",100*exp(-Volumes[current_volume]->p_physics->my_a*length_to_boundery));
+            // #endif
           }
-        } // Done checking for scttering event and in case of scattering selecting a process
+        } else {
+          // Since there is a non-zero number of processes in this material, all the scattering cross section for these are calculated
+          my_sum = 0;
+          k[0] = kx;
+          k[1] = ky;
+          k[2] = kz;
+          p_my_trace = my_trace;
+          wavevector = coords_set (k[0], k[1], k[2]);
+          // for (process_start = process = Volumes[current_volume]->p_physics->p_scattering_array;process - process_start <
+          // Volumes[current_volume]->p_physics->number_of_processes;process++) {
+          int p_index;
+          for (p_index = 0; p_index < Volumes[current_volume]->p_physics->number_of_processes; p_index++) { // GPU
 
-        // Record initial weight, absorption weight factor and initial position
+            if (Volumes[current_volume]->p_physics->p_scattering_array[p_index].non_isotropic_rot_index != -1) {
+              // If the process is not isotropic, the wavevector is transformed into the local coordinate system of the process
+              wavevector_rotated
+                  = rot_apply (Volumes[current_volume]
+                                   ->geometry.process_rot_matrix_array[Volumes[current_volume]->p_physics->p_scattering_array[p_index].non_isotropic_rot_index],
+                               wavevector);
 
-        initial_weight = p;
-        r_old[0] = r[0]; r_old[1] = r[1]; r_old[2] = r[2]; time_old = t;
-        // Apply absorption
-        p *= abs_weight_factor;
+              coords_get (wavevector_rotated, &k_rotated[0], &k_rotated[1], &k_rotated[2]);
 
-        // Create event for absorption loggers
-        // Need to use start position and length travelled to sample that trajectory for absorption event. Could do several, here just one.
+            } else {
+              k_rotated[0] = k[0];
+              k_rotated[1] = k[1];
+              k_rotated[2] = k[2];
+            }
 
-        // min length: 0, max length: length_to_scattering if scattering, else length to boundary
+            // Find correct focus_data_array index for this volume/process
+            focus_data_index = Volumes[current_volume]->geometry.focus_array_indices.elements[p_index];
 
-        // Avoid logging absorption when the ray is in vacuum.
-        if (current_volume != 0 && abs_weight_factor_set == 1) { // Volume 0 is always vacuum, and if this is the current volume, an event will not occur
-          if (Volumes[current_volume]->p_physics->is_vacuum == 0) { // No absorption in vacuum
+            // Call the probability for scattering function assighed to this specific procress (the process pointer is updated in the for loop)
+            process = &Volumes[current_volume]->p_physics->p_scattering_array[p_index]; // GPU Allowed
+
+            int physics_output;
+            physics_output = physics_my (process->eProcess, p_my_trace, k_rotated, process->data_transfer,
+                                         &Volumes[current_volume]->geometry.focus_data_array.elements[focus_data_index], _particle);
+
+            my_sum += *p_my_trace;
+            #ifdef Union_trace_verbal_setting
+            printf ("my_trace = %f, my_sum = %f\n", *p_my_trace, my_sum);
+            #endif
+            p_my_trace++; // increment the pointer so that it point to the next element (max number of process in any material is allocated)
+          }
+
+          #ifdef Union_trace_verbal_setting
+          printf ("time_propagated_without_scattering = %f.\n", time_propagated_without_scattering);
+          printf ("k_length                           = %f.\n", k_length);
+          #endif
+
+          // length_to_boundery = time_to_boundery * v_length;
+
+          #ifdef Union_trace_verbal_setting
+          printf ("exp(- length_to_boundery*my_sum) = %f. length_to_boundery = %f. my_sum = %f.\n", exp (-length_to_boundery * my_sum), length_to_boundery,
+                  my_sum);
+          #endif
+
+          // Selecting if a scattering takes place, and what scattering process.
+          // This section have too many if statements, and unessecary calculations
+          // Could make seperate functions for p_interact on/off and interact_fraction on/off,
+          //   and set function pointers to these in initialize, thus avoiding many unessecary if statements and calculations of x/x.
+          // change to new absorption
+          my_sum_plus_abs = my_sum + get_my_abs (Volumes[current_volume]->p_physics, k_length);
+
+          if (my_sum < 1E-18) {
+            // The scattering cross section is basicly zero, no scattering should occur.
+            scattering_event = 0;
+            p *= exp (-length_to_boundery * my_sum_plus_abs); // Correct for absorption and the almost zero scattering
+          } else if (length_to_boundery < safty_distance2) {
+            // Too close to boundery to safly make another scattering, attenuate
+            p *= exp (-length_to_boundery * my_sum_plus_abs); // Attentuate the beam for the small distance
+            scattering_event = 0;
+          } else {
+            // The scattering cross section is above zero and the distance to the boundery is sufficient for a scattering
+            if (Volumes[current_volume]->geometry.geometry_p_interact != 0) {
+              // a fraction of the beam (geometry_p_interact) is forced to scatter
+              real_transmission_probability = exp (-length_to_boundery * my_sum_plus_abs);
+              mc_transmission_probability = (1.0 - Volumes[current_volume]->geometry.geometry_p_interact);
+              if ((scattering_event = (rand01 () > mc_transmission_probability))) {
+                // Scattering event happens, this is the correction for the weight
+                p *= (1.0 - real_transmission_probability) / (1.0 - mc_transmission_probability); // Absorption simulated in weight
+
+                // Find length to next scattering knowing the ray will scatter.
+                length_to_scattering
+                    = safty_distance - log (1.0 - rand0max ((1.0 - exp (-my_sum_plus_abs * (length_to_boundery - safty_distance2))))) / my_sum_plus_abs;
+              } else {
+                // Scattering event does not happen, this is the appropriate correction
+                p *= real_transmission_probability / mc_transmission_probability; // Absorption simulated in weight
+              }
+            } else {
+              // probability to scatter is the natural value
+              if (my_sum * length_to_boundery < 1e-6) { // Scattering probability very small, linear method is used as exponential is unreliable
+                if (length_to_boundery > safty_distance2) {
+                  if (rand01 () < exp (-length_to_boundery * my_sum_plus_abs)) {
+                    // Scattering happens, use linear description to select scattering position
+                    length_to_scattering = safty_distance + rand0max (length_to_boundery - safty_distance2);
+                    // Weight factor necessary to correct for using the linear scattering position distribution
+                    p *= length_to_boundery * my_sum * exp (-length_to_scattering * my_sum_plus_abs); // Absorption simulated in weight
+                    scattering_event = 1;
+                  } else
+                    scattering_event = 0;
+                } else {
+                  // The distance is too short to reliably make a scattering event (in comparison to accuraccy of intersect functions)
+                  p *= exp (-length_to_boundery * my_sum_plus_abs); // Attentuate the beam for the small distance
+                  scattering_event = 0;
+                }
+              } else {
+                // Strong scattering, use exponential description to select scattering position between safetydistance and infinity
+                length_to_scattering = safty_distance - log (1 - rand01 ()) / my_sum_plus_abs;
+                // Scattering happens if the scattering position is before the boundery (and safty distance)
+                if (length_to_scattering < length_to_boundery - safty_distance)
+                  scattering_event = 1;
+                else
+                  scattering_event = 0;
+              }
+            }
 
             if (scattering_event == 1) {
-                // When scattering events occur, place the absoprtion the same place (the total cross section is used to place it)
-                abs_distance = length_to_scattering;
-            } else {
-                // When the ray exits a volume, the absorption position should be exponentially distributed using the total cross section
-                //#FIXME
-		//my_abs = Volumes[current_volume]->p_physics->my_a*(2200/v_length);
-                abs_distance = -log(1.0 - rand0max(1.0 - exp(-my_sum_plus_abs*length_to_boundery)) ) / my_sum_plus_abs;
-            }
+              // Adjust weight for absorption
+              p *= my_sum / my_sum_plus_abs;
+              // Safety feature, alert in case of nonsense my results / negative absorption
+              if (my_sum / my_sum_plus_abs > 1.0)
+                printf ("WARNING: Absorption weight factor above 1! Should not happen! \n");
+              // Select process
+              if (Volumes[current_volume]->p_physics->number_of_processes == 1) { // trivial case
+                // Select the only available process, which will always have index 0
+                selected_process = 0;
+              } else {
+                if (Volumes[current_volume]->p_physics->interact_control == 1) {
+                  // Interact_fraction is used to influence the choice of process in this material
+                  mc_prop = rand01 ();
+                  culmative_probability = 0;
+                  total_process_interact = 1.0;
 
-            t_abs_propagation = abs_distance/M_C;
+                  // If any of the processes have probability 0, they are excluded from the selection
+                  for (iterator = 0; iterator < Volumes[current_volume]->p_physics->number_of_processes; iterator++) {
+                    if (my_trace[iterator] < 1E-18) {
+                      // When this happens, the total force probability is corrected and the probability for this particular instance is set to 0
+                      total_process_interact -= Volumes[current_volume]->p_physics->p_scattering_array[iterator].process_p_interact;
+                      my_trace_fraction_control[iterator] = 0;
+                      // In cases where my_trace is not zero, the forced fraction is still used.
+                    } else
+                      my_trace_fraction_control[iterator] = Volumes[current_volume]->p_physics->p_scattering_array[iterator].process_p_interact;
+                  }
+                  // Randomly select a process using the weights stored in my_trace_fraction_control divided by total_process_interact
+                  for (iterator = 0; iterator < Volumes[current_volume]->p_physics->number_of_processes; iterator++) {
+                    culmative_probability += my_trace_fraction_control[iterator] / total_process_interact;
+                    if (culmative_probability > mc_prop) {
+                      selected_process = iterator;
+                      p *= (my_trace[iterator] / my_sum) * (total_process_interact / my_trace_fraction_control[iterator]);
+                      break;
+                    }
+                  }
 
-            abs_position = coords_set(x + t_abs_propagation*kx, y + t_abs_propagation*ky, z + t_abs_propagation*kz);
+                } else {
+                  // Select a process based on their relative attenuations factors
+                  mc_prop = rand01 ();
+                  culmative_probability = 0;
+                  for (iterator = 0; iterator < Volumes[current_volume]->p_physics->number_of_processes; iterator++) {
+                    culmative_probability += my_trace[iterator] / my_sum;
+                    if (culmative_probability > mc_prop) {
+                      selected_process = iterator;
+                      break;
+                    }
+                  }
+                }
+              }
+            } // end of select process
+          }
+        }
+      } // Done checking for scttering event and in case of scattering selecting a process
 
-            // This info needs to be loaded into the absorption loggers
+      // Record initial weight, absorption weight factor and initial position
 
-            // Need to run through relevant absorption loggers here
-            #ifdef Union_trace_verbal_setting
-            printf("Running abs_logger system for specific volumes \n");
-            #endif
+      initial_weight = p;
+      r_old[0] = r[0];
+      r_old[1] = r[1];
+      r_old[2] = r[2];
+      time_old = t;
+      // Apply absorption
+      p *= abs_weight_factor;
 
-            // Logging for detector components assosiated with this volume
-            for (log_index=0;log_index<Volumes[current_volume]->abs_loggers.num_elements;log_index++) {
-              // Make transformation according to the individual position of the abs_logger? This would require position / rotation for all abs_loggers
-              transformed_abs_position = coords_sub(abs_position, Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->position);
-              transformed_abs_position = rot_apply(Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->rotation, transformed_abs_position);
+      // Create event for absorption loggers
+      // Need to use start position and length travelled to sample that trajectory for absorption event. Could do several, here just one.
 
-                // This function calls a logger function which in turn stores some data among the passed, and possibly performs some basic data analysis
-              Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->function_pointers.active_record_function(&transformed_abs_position, k_new, initial_weight*(1.0-abs_weight_factor), t + t_abs_propagation, scattered_flag[current_volume], number_of_scattering_events, Volumes[current_volume]->abs_loggers.p_abs_logger[log_index], &abs_loggers_with_data_array);
-                // If the logging component have a conditional attatched, the collected data will be written to a temporary place
-                // At the end of the rays life, it will be checked if the condition is met
-                //  if it is met, the temporary data is transfered to permanent, and temp is cleared.
-                //  if it is not met, the temporary data is cleared.
-            }
+      // min length: 0, max length: length_to_scattering if scattering, else length to boundary
 
-            #ifdef Union_trace_verbal_setting
-              printf("Running abs_logger system for all volumes \n");
-            #endif
-            for (log_index=0;log_index<global_all_volume_abs_logger_list_master->num_elements;log_index++) {
-              // As above, but on a global scale, meaning scattering in all volumes are logged
+      // Avoid logging absorption when the ray is in vacuum.
+      if (current_volume != 0 && abs_weight_factor_set == 1) {    // Volume 0 is always vacuum, and if this is the current volume, an event will not occur
+        if (Volumes[current_volume]->p_physics->is_vacuum == 0) { // No absorption in vacuum
 
-              // Problems with VN, PV, as there is no assosiated volume or process. The functions however need to have the same input to make the logger components general.
-              // Could be interesting to have a monitor that just globally measurres the second scattering event in any volume (must be two in the same). Weird but not meaningless.
+          if (scattering_event == 1) {
+            // When scattering events occur, place the absoprtion the same place (the total cross section is used to place it)
+            abs_distance = length_to_scattering;
+          } else {
+            // When the ray exits a volume, the absorption position should be exponentially distributed using the total cross section
+            // #FIXME
+            // my_abs = Volumes[current_volume]->p_physics->my_a*(2200/v_length);
+            abs_distance = -log (1.0 - rand0max (1.0 - exp (-my_sum_plus_abs * length_to_boundery))) / my_sum_plus_abs;
+          }
 
-              // Make transformation according to the individual position of the abs_logger? This would require position / rotation for all abs_loggers
-              transformed_abs_position = coords_sub(abs_position, global_all_volume_abs_logger_list_master->elements[log_index].abs_logger->position);
-              transformed_abs_position = rot_apply(global_all_volume_abs_logger_list_master->elements[log_index].abs_logger->rotation, transformed_abs_position);
+          t_abs_propagation = abs_distance / M_C;
 
-              // Above version includes scattered_flag_VP, but selected_process may be undefined at this point.
-              global_all_volume_abs_logger_list_master->elements[log_index].abs_logger->function_pointers.active_record_function(&transformed_abs_position, k_new, initial_weight*(1.0-abs_weight_factor), t+t_abs_propagation, scattered_flag[current_volume], number_of_scattering_events, global_all_volume_abs_logger_list_master->elements[log_index].abs_logger, &abs_loggers_with_data_array);
-            }
+          abs_position = coords_set (x + t_abs_propagation * kx, y + t_abs_propagation * ky, z + t_abs_propagation * kz);
+
+          // This info needs to be loaded into the absorption loggers
+
+          // Need to run through relevant absorption loggers here
+          #ifdef Union_trace_verbal_setting
+          printf ("Running abs_logger system for specific volumes \n");
+          #endif
+
+          // Logging for detector components assosiated with this volume
+          for (log_index = 0; log_index < Volumes[current_volume]->abs_loggers.num_elements; log_index++) {
+            // Make transformation according to the individual position of the abs_logger? This would require position / rotation for all abs_loggers
+            transformed_abs_position = coords_sub (abs_position, Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->position);
+            transformed_abs_position = rot_apply (Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->rotation, transformed_abs_position);
+
+            // This function calls a logger function which in turn stores some data among the passed, and possibly performs some basic data analysis
+            Volumes[current_volume]->abs_loggers.p_abs_logger[log_index]->function_pointers.active_record_function (
+                &transformed_abs_position, k_new, initial_weight * (1.0 - abs_weight_factor), t + t_abs_propagation, scattered_flag[current_volume],
+                number_of_scattering_events, Volumes[current_volume]->abs_loggers.p_abs_logger[log_index], &abs_loggers_with_data_array);
+            // If the logging component have a conditional attatched, the collected data will be written to a temporary place
+            // At the end of the rays life, it will be checked if the condition is met
+            //  if it is met, the temporary data is transfered to permanent, and temp is cleared.
+            //  if it is not met, the temporary data is cleared.
+          }
+
+          #ifdef Union_trace_verbal_setting
+          printf ("Running abs_logger system for all volumes \n");
+          #endif
+          for (log_index = 0; log_index < global_all_volume_abs_logger_list_master->num_elements; log_index++) {
+            // As above, but on a global scale, meaning scattering in all volumes are logged
+
+            // Problems with VN, PV, as there is no assosiated volume or process. The functions however need to have the same input to make the logger components
+            // general. Could be interesting to have a monitor that just globally measurres the second scattering event in any volume (must be two in the same).
+            // Weird but not meaningless.
+
+            // Make transformation according to the individual position of the abs_logger? This would require position / rotation for all abs_loggers
+            transformed_abs_position = coords_sub (abs_position, global_all_volume_abs_logger_list_master->elements[log_index].abs_logger->position);
+            transformed_abs_position = rot_apply (global_all_volume_abs_logger_list_master->elements[log_index].abs_logger->rotation, transformed_abs_position);
+
+            // Above version includes scattered_flag_VP, but selected_process may be undefined at this point.
+            global_all_volume_abs_logger_list_master->elements[log_index].abs_logger->function_pointers.active_record_function (
+                &transformed_abs_position, k_new, initial_weight * (1.0 - abs_weight_factor), t + t_abs_propagation, scattered_flag[current_volume],
+                number_of_scattering_events, global_all_volume_abs_logger_list_master->elements[log_index].abs_logger, &abs_loggers_with_data_array);
+          }
+        }
+      }
+
+      if (scattering_event == 1) {
+        #ifdef Union_trace_verbal_setting
+        printf ("SCATTERING EVENT \n");
+        printf ("current_volume            = %d \n", current_volume);
+        printf ("r = (%f,%f,%f) k = (%f,%f,%f) \n", r[0], r[1], r[2], k[0], k[1], k[2]);
+        #endif
+
+        // Calculate the time to scattering
+        time_to_scattering = length_to_scattering / M_C;
+
+        #ifdef Union_trace_verbal_setting
+        printf ("length to scattering        = %2.20f \n", length_to_scattering);
+        #endif
+
+        // May be replace by version without gravity
+        // PROP_DT(time_to_scattering);
+
+        // Reduce the double book keeping done here
+        // change time_to_scattering => length_to_scattering
+
+        x += length_to_scattering * kx / k_length;
+        y += length_to_scattering * ky / k_length;
+        z += length_to_scattering * kz / k_length;
+        t += time_to_scattering;
+        r_start[0] = x;
+        r_start[1] = y;
+        r_start[2] = z;
+        r[0] = x;
+        r[1] = y;
+        r[2] = z;
+        ray_position = coords_set (x, y, z);
+        ray_wavevector = coords_set (kx, ky, kz);
+
+        // Safe check that should be unecessary. Used to fine tune how close to the edge of a volume a scattering event is allowed to take place (1E-14 m away
+        // currently).
+        if (r_within_function (ray_position, &Volumes[current_volume]->geometry) == 0) {
+          printf ("\nERROR, propagated out of current volume instead of to a point within!\n");
+          printf ("length_to_scattering_specified = %2.20f\n             length propagated = %2.20f\n            length_to_boundery = %2.20f \n   "
+                  "current_position = (%lf,%lf,%lf) \n",
+                  length_to_scattering,
+                  sqrt (length_to_scattering * length_to_scattering * kx * kx / k_length / k_length
+                        + length_to_scattering * length_to_scattering * ky * ky / k_length / k_length
+                        + length_to_scattering * length_to_scattering * kz * kz / k_length / k_length),
+                  length_to_boundery, x, y, z);
+
+          volume_index = within_which_volume_GPU (ray_position, starting_lists.reduced_start_list, starting_lists.starting_destinations_list, Volumes,
+                                                  &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
+
+          printf ("Debug info: Volumes[current_volume]->name = %s, but now inside volume number %d named %s.\n", Volumes[current_volume]->name, volume_index,
+                  Volumes[volume_index]->name);
+          printf ("Ray absorbed \n");
+          ABSORB;
+        }
+
+        // Save information before scattering event needed in logging section
+        p_old = p;
+        k_old[0] = k[0];
+        k_old[1] = k[1];
+        k_old[2] = k[2];
+
+        // Find correct focus_data_array index for this volume/process
+        focus_data_index = Volumes[current_volume]->geometry.focus_array_indices.elements[selected_process];
+
+        // Rotation to local process coordinate system (for non isotropic processes)
+        if (Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index != -1) {
+          ray_wavevector_rotated = rot_apply (
+              Volumes[current_volume]
+                  ->geometry.process_rot_matrix_array[Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index],
+              ray_wavevector);
+        } else {
+          ray_wavevector_rotated = ray_wavevector;
+        }
+        #ifdef Union_trace_verbal_setting
+        printf ("Kin: %g %g %g, selected_process: %i %i\n", k[0], k[1], k[2], selected_process, current_volume);
+        coords_print (Volumes[current_volume]->geometry.focus_data_array.elements[0].Aim);
+        #endif
+        // test_physics_scattering(double *k_final, double *k_initial, union data_transfer_union data_transfer) {
+        coords_get (ray_wavevector_rotated, &k[0], &k[1], &k[2]);
+
+        // I may replace a intial and final k with one instance that serves as both input and output
+        process = &Volumes[current_volume]->p_physics->p_scattering_array[selected_process]; // CPU Only
+        if (0
+            == physics_scattering (process->eProcess, k_new, k, &p, process->data_transfer, &Volumes[current_volume]->geometry.focus_data_array.elements[0],
+                                   _particle)) {
+          /*
+          // PowderN and Single_crystal requires the option of absorbing the x-ray, which is weird. If there is a scattering probability, there should be a new
+          direction.
+          // It can arise from need to simplify sampling process and end up in cases where weight factor is 0, and the ray should be absorbed in these cases
+          printf("ERROR: Union_master: %s.Absorbed ray because scattering function returned 0 (error/absorb)\n",NAME_CURRENT_COMP);
+          component_error_msg++;
+          if (component_error_msg > 100) {
+            printf("To many errors encountered, exiting. \n");
+            exit(1);
+          }
+          */
+          ABSORB;
+        }
+        #ifdef Union_trace_verbal_setting
+        printf ("Kout: %g %g %g\n", k_new[0], k_new[1], k_new[2]);
+        #endif
+        // Update velocity using k
+        ray_wavevector_rotated = coords_set (k_new[0], k_new[1], k_new[2]);
+
+        // Transformation back to main coordinate system (maybe one should only do this when multiple scattering in that volume was over, especially if there is
+        // only one non isotropic frame)
+        if (Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index != -1) {
+          ray_wavevector_final = rot_apply (
+              Volumes[current_volume]
+                  ->geometry.transpose_process_rot_matrix_array[Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index],
+              ray_wavevector_rotated);
+        } else {
+          ray_wavevector_final = ray_wavevector_rotated;
+        }
+        #ifdef Union_trace_verbal_setting
+        printf ("Final wavevector ");
+        coords_print (ray_wavevector_final);
+        #endif
+        // Write velocity to global variable (temp, only really necessary at final)
+        coords_get (ray_wavevector_final, &kx, &ky, &kz);
+
+        // Write velocity in array format as it is still used by intersect functions (temp, they need to be updated to ray_position / ray_velocity)
+        // change to wavevector
+        k[0] = kx;
+        k[1] = ky;
+        k[2] = kz;
+        k_length = sqrt (kx * kx + ky * ky + kz * kz);
+        k_new[0] = kx;
+        k_new[1] = ky;
+        k_new[2] = kz;
+        // if (verbal) if (k_length < 1) printf("wavevector set to less than 1\n");
+
+        #ifdef Union_trace_verbal_setting
+        printf ("Running logger system for specific volumes \n");
+        #endif
+        // Logging for detector components assosiated with this volume
+        for (log_index = 0; log_index < Volumes[current_volume]->loggers.num_elements; log_index++) {
+          if (Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process] != NULL) {
+            // Technically the scattering function could edit k, the wavevector before the scattering, even though there would be little point to doing that.
+            // Could save a secure copy and pass that instead to be certain that no scattering process accidently tampers with the logging.
+
+            // This function calls a logger function which in turn stores some data among the passed, and possibly performs some basic data analysis
+            Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process]->function_pointers.active_record_function (
+                &ray_position, k_new, k_old, p, p_old, t, scattered_flag[current_volume], scattered_flag_VP[current_volume][selected_process],
+                number_of_scattering_events, Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process],
+                &loggers_with_data_array);
+            // If the logging component have a conditional attatched, the collected data will be written to a temporary place
+            // At the end of the rays life, it will be checked if the condition is met
+            //  if it is met, the temporary data is transfered to permanent, and temp is cleared.
+            //  if it is not met, the temporary data is cleared.
           }
         }
 
-        if (scattering_event == 1) {
-            #ifdef Union_trace_verbal_setting
-              printf("SCATTERING EVENT \n");
-              printf("current_volume            = %d \n",current_volume);
-              printf("r = (%f,%f,%f) k = (%f,%f,%f) \n", r[0], r[1], r[2], k[0], k[1], k[2]);
-            #endif
+        #ifdef Union_trace_verbal_setting
+        printf ("Running logger system for all volumes \n");
+        #endif
+        for (log_index = 0; log_index < global_all_volume_logger_list_master->num_elements; log_index++) {
+          // As above, but on a global scale, meaning scattering in all volumes are logged
 
-            // Calculate the time to scattering
-            time_to_scattering = length_to_scattering/M_C;
+          // Problems with VN, PV, as there is no assosiated volume or process. The functions however need to have the same input to make the logger components
+          // general. Could be interesting to have a monitor that just globally measurres the second scattering event in any volume (must be two in the same).
+          // Weird but not meaningless.
+          global_all_volume_logger_list_master->elements[log_index].logger->function_pointers.active_record_function (
+              &ray_position, k_new, k_old, p, p_old, t, scattered_flag[current_volume], scattered_flag_VP[current_volume][selected_process],
+              number_of_scattering_events, global_all_volume_logger_list_master->elements[log_index].logger, &loggers_with_data_array);
+        }
+        #ifdef Union_trace_verbal_setting
+        printf ("Outgoing event: %g %g %g // %g %g %g\n", x, y, z, kx, ky, kz);
+        #endif
+        SCATTER;
+        ++number_of_scattering_events;
+        ++scattered_flag[current_volume];
+        ++scattered_flag_VP[current_volume][selected_process];
 
-            #ifdef Union_trace_verbal_setting
-              printf("length to scattering        = %2.20f \n",length_to_scattering);
-            #endif
+        // Clear intersection time lists as the direction of the ray has changed
+        clear_intersection_table (&intersection_time_table);
+        time_propagated_without_scattering = 0.0;
+        #ifdef Union_trace_verbal_setting
+        printf ("SCATTERED SUCCESSFULLY \n");
+        printf ("r = (%f,%f,%f) k = (%f,%f,%f) \n", x, y, z, kx, ky, kz);
 
-            // May be replace by version without gravity
-            //PROP_DT(time_to_scattering);
+        if (enable_tagging && stop_tagging_ray == 0)
+          printf ("Before new process node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+        if (enable_tagging && stop_tagging_ray == 0)
+          printf ("Before new process node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
+        #endif
 
-            // Reduce the double book keeping done here
-            // change time_to_scattering => length_to_scattering
+        if (enable_tagging && stop_tagging_ray == 0)
+          current_tagging_node = goto_process_node (current_tagging_node, selected_process, Volumes[current_volume], &stop_tagging_ray, stop_creating_nodes);
 
-            x += length_to_scattering*kx/k_length; y += length_to_scattering*ky/k_length; z += length_to_scattering*kz/k_length; t += time_to_scattering;
-            r_start[0] = x; r_start[1] = y; r_start[2] = z;
-            r[0] = x; r[1] = y; r[2] = z;
-            ray_position = coords_set(x,y,z);
-            ray_wavevector = coords_set(kx,ky,kz);
+        #ifdef Union_trace_verbal_setting
+        if (enable_tagging && stop_tagging_ray == 0)
+          printf ("After new process node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+        if (enable_tagging && stop_tagging_ray == 0)
+          printf ("After new process node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
+        #endif
 
-            // Safe check that should be unecessary. Used to fine tune how close to the edge of a volume a scattering event is allowed to take place (1E-14 m away currently).
-            if (r_within_function(ray_position, &Volumes[current_volume]->geometry) == 0) {
-              printf("\nERROR, propagated out of current volume instead of to a point within!\n");
-              printf("length_to_scattering_specified = %2.20f\n             length propagated = %2.20f\n            length_to_boundery = %2.20f \n   current_position = (%lf,%lf,%lf) \n",length_to_scattering,sqrt(length_to_scattering*length_to_scattering*kx*kx/k_length/k_length+length_to_scattering*length_to_scattering*ky*ky/k_length/k_length+length_to_scattering*length_to_scattering*kz*kz/k_length/k_length),length_to_boundery,x,y,z);
+      } else {
+        #ifdef Union_trace_verbal_setting
+        printf ("Propagate out of volume %d\n", current_volume);
+        printf ("r = (%f,%f,%f) k = (%f,%f,%f) \n", x, y, z, kx, ky, kz);
+        #endif
+        // Propagate x-ray to found minimum time
+        // PROP_DT(length_to_boundery);
+        x += length_to_boundery * kx / k_length;
+        y += length_to_boundery * ky / k_length;
+        z += length_to_boundery * kz / k_length;
+        t += time_to_boundery;
+        r[0] = x;
+        r[1] = y;
+        r[2] = z;
+        ray_position = coords_set (x, y, z);
+        ray_wavevector = coords_set (kx, ky, kz);
 
-              volume_index = within_which_volume_GPU(ray_position,starting_lists.reduced_start_list,starting_lists.starting_destinations_list,Volumes,&mask_status_list,number_of_volumes,pre_allocated1,pre_allocated2,pre_allocated3);
+        time_propagated_without_scattering = min_intersection_time;
+        SCATTER; // For debugging purposes
+                 #ifdef Union_trace_verbal_setting
+        printf ("r = (%f,%f,%f) k = (%f,%f,%f) \n", x, y, z, kx, ky, kz);
+        #endif
+        // Remove this entry from the intersection_time_table
+        intersection_time_table.intersection_times[min_volume][min_solution] = -1;
 
-              printf("Debug info: Volumes[current_volume]->name = %s, but now inside volume number %d named %s.\n",Volumes[current_volume]->name,volume_index,Volumes[volume_index]->name);
-              printf("Ray absorbed \n");
-              ABSORB;
-            }
+        // Use destination list for corresponding intersection entry n,i) to find next volume
+        #ifdef Union_trace_verbal_setting
+        printf ("PROPAGATION FROM VOLUME %d \n", current_volume);
+        #endif
+        if (min_volume == current_volume) {
+          #ifdef Union_trace_verbal_setting
+          printf ("min_volume == current_volume \n");
+          #endif
+          // List approach to finding the next volume.
+          // When the ray intersects the current volume, the next volume must be on the destination list of the current volume
+          // However, the reduced_destination_list can be investigated first, and depending on the results, the
+          //  direct children of the volumes on the reduced destination list are investigated.
+          // In the worst case, all direct children are investigated, which is eqvivalent to the entire destination list.
+          // There is however a certain overhead in the logic needed to set up this tree, avoid duplicates of direct children, and so on.
+          // This method is only faster than just checking the destination list when there are direct children (nested structures),
+          //  but in general the tree method scales better with complexity, and is only slightly slower in simple cases.
 
-            // Save information before scattering event needed in logging section
-            p_old = p;
-            k_old[0] = k[0];k_old[1] = k[1];k_old[2] = k[2];
+          if (Volumes[current_volume]->geometry.destinations_list.num_elements == 1)
+            tree_next_volume = Volumes[current_volume]->geometry.destinations_list.elements[0];
+          else {
+            ray_position = coords_set (x, y, z);
+            ray_wavevector = coords_set (kx, ky, kz);
+            tree_next_volume = within_which_volume (ray_position, Volumes[current_volume]->geometry.reduced_destinations_list,
+                                                    Volumes[current_volume]->geometry.destinations_list, Volumes, &mask_status_list, number_of_volumes,
+                                                    pre_allocated1, pre_allocated2, pre_allocated3);
+          }
 
-            // Find correct focus_data_array index for this volume/process
-            focus_data_index = Volumes[current_volume]->geometry.focus_array_indices.elements[selected_process];
+          #ifdef Union_trace_verbal_setting
+          if (enable_tagging)
+            printf ("tree method moves from %d to %d\n", current_volume, tree_next_volume);
 
-            // Rotation to local process coordinate system (for non isotropic processes)
-            if (Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index != -1) {
-                ray_wavevector_rotated = rot_apply(Volumes[current_volume]->geometry.process_rot_matrix_array[Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index],ray_wavevector);
-            } else {
-                ray_wavevector_rotated = ray_wavevector;
-            }
-	    #ifdef Union_trace_verbal_setting
-            printf("Kin: %g %g %g, selected_process: %i %i\n",k[0],k[1],k[2],selected_process,current_volume);
-	    coords_print(Volumes[current_volume]->geometry.focus_data_array.elements[0].Aim);
-            #endif
-            // test_physics_scattering(double *k_final, double *k_initial, union data_transfer_union data_transfer) {
-            coords_get(ray_wavevector_rotated,&k[0],&k[1],&k[2]);
+          if (enable_tagging && stop_tagging_ray == 0)
+            printf ("Before new tree volume node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+          if (enable_tagging && stop_tagging_ray == 0)
+            printf ("Before new tree volume node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
+          #endif
 
-            // I may replace a intial and final k with one instance that serves as both input and output
-            process = &Volumes[current_volume]->p_physics->p_scattering_array[selected_process]; // CPU Only
-            if (0 == physics_scattering(process->eProcess, k_new, k, &p, process->data_transfer, &Volumes[current_volume]->geometry.focus_data_array.elements[0], _particle)) {
-              /*
-              // PowderN and Single_crystal requires the option of absorbing the x-ray, which is weird. If there is a scattering probability, there should be a new direction.
-              // It can arise from need to simplify sampling process and end up in cases where weight factor is 0, and the ray should be absorbed in these cases
-              printf("ERROR: Union_master: %s.Absorbed ray because scattering function returned 0 (error/absorb)\n",NAME_CURRENT_COMP);
-              component_error_msg++;
-              if (component_error_msg > 100) {
-                printf("To many errors encountered, exiting. \n");
-                exit(1);
-              }
-              */
-              ABSORB;
-            }
-            #ifdef Union_trace_verbal_setting
-            printf("Kout: %g %g %g\n", k_new[0],k_new[1],k_new[2]);
-            #endif
-            // Update velocity using k
-            ray_wavevector_rotated = coords_set(k_new[0],k_new[1],k_new[2]);
+          if (enable_tagging && stop_tagging_ray == 0)
+            current_tagging_node = goto_volume_node (current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
 
-            // Transformation back to main coordinate system (maybe one should only do this when multiple scattering in that volume was over, especially if there is only one non isotropic frame)
-            if (Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index != -1) {
-                ray_wavevector_final = rot_apply(Volumes[current_volume]->geometry.transpose_process_rot_matrix_array[Volumes[current_volume]->p_physics->p_scattering_array[selected_process].non_isotropic_rot_index],ray_wavevector_rotated);
-            } else {
-               ray_wavevector_final = ray_wavevector_rotated;
-            }
-            #ifdef Union_trace_verbal_setting
-	    printf("Final wavevector "); coords_print(ray_wavevector_final);
-	    #endif
-            // Write velocity to global variable (temp, only really necessary at final)
-            coords_get(ray_wavevector_final,&kx,&ky,&kz);
+          #ifdef Union_trace_verbal_setting
+          if (enable_tagging && stop_tagging_ray == 0)
+            printf ("After new tree volume node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+          if (enable_tagging && stop_tagging_ray == 0)
+            printf ("After new tree volume node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
+          #endif
 
-            // Write velocity in array format as it is still used by intersect functions (temp, they need to be updated to ray_position / ray_velocity)
-            // change to wavevector
-            k[0] = kx; k[1] = ky; k[2] = kz;
-            k_length = sqrt(kx*kx+ky*ky+kz*kz);
-            k_new[0] = kx; k_new[1] = ky; k_new[2] = kz;
-            //if (verbal) if (k_length < 1) printf("wavevector set to less than 1\n");
-
-            #ifdef Union_trace_verbal_setting
-              printf("Running logger system for specific volumes \n");
-            #endif
-            // Logging for detector components assosiated with this volume
-            for (log_index=0;log_index<Volumes[current_volume]->loggers.num_elements;log_index++) {
-              if (Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process] != NULL) {
-                // Technically the scattering function could edit k, the wavevector before the scattering, even though there would be little point to doing that.
-                // Could save a secure copy and pass that instead to be certain that no scattering process accidently tampers with the logging.
-
-                // This function calls a logger function which in turn stores some data among the passed, and possibly performs some basic data analysis
-                Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process]->function_pointers.active_record_function(&ray_position, k_new, k_old, p, p_old, t, scattered_flag[current_volume], scattered_flag_VP[current_volume][selected_process], number_of_scattering_events, Volumes[current_volume]->loggers.p_logger_volume[log_index].p_logger_process[selected_process], &loggers_with_data_array);
-                // If the logging component have a conditional attatched, the collected data will be written to a temporary place
-                // At the end of the rays life, it will be checked if the condition is met
-                //  if it is met, the temporary data is transfered to permanent, and temp is cleared.
-                //  if it is not met, the temporary data is cleared.
-              }
-            }
-
-            #ifdef Union_trace_verbal_setting
-              printf("Running logger system for all volumes \n");
-            #endif
-            for (log_index=0;log_index<global_all_volume_logger_list_master->num_elements;log_index++) {
-              // As above, but on a global scale, meaning scattering in all volumes are logged
-
-              // Problems with VN, PV, as there is no assosiated volume or process. The functions however need to have the same input to make the logger components general.
-              // Could be interesting to have a monitor that just globally measurres the second scattering event in any volume (must be two in the same). Weird but not meaningless.
-              global_all_volume_logger_list_master->elements[log_index].logger->function_pointers.active_record_function(&ray_position, k_new, k_old, p, p_old, t, scattered_flag[current_volume], scattered_flag_VP[current_volume][selected_process], number_of_scattering_events, global_all_volume_logger_list_master->elements[log_index].logger, &loggers_with_data_array);
-            }
-            #ifdef Union_trace_verbal_setting
-	    printf("Outgoing event: %g %g %g // %g %g %g\n",x,y,z,kx,ky,kz);
-            #endif
-            SCATTER;
-            ++number_of_scattering_events;
-            ++scattered_flag[current_volume];
-            ++scattered_flag_VP[current_volume][selected_process];
-
-            // Clear intersection time lists as the direction of the ray has changed
-            clear_intersection_table(&intersection_time_table);
-            time_propagated_without_scattering = 0.0;
-            #ifdef Union_trace_verbal_setting
-              printf("SCATTERED SUCCESSFULLY \n");
-              printf("r = (%f,%f,%f) k = (%f,%f,%f) \n",x,y,z,kx,ky,kz);
-
-              if (enable_tagging && stop_tagging_ray == 0) printf("Before new process node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
-              if (enable_tagging && stop_tagging_ray == 0) printf("Before new process node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
-            #endif
-
-              if (enable_tagging && stop_tagging_ray == 0)
-                current_tagging_node = goto_process_node(current_tagging_node, selected_process,Volumes[current_volume], &stop_tagging_ray,stop_creating_nodes);
-
-            #ifdef Union_trace_verbal_setting
-              if (enable_tagging && stop_tagging_ray == 0) printf("After new process node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
-              if (enable_tagging && stop_tagging_ray == 0) printf("After new process node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
-            #endif
+          // Set next volume to the solution found in the tree method
+          current_volume = tree_next_volume;
+          update_current_mask_intersect_status (&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
+          #ifdef Union_trace_verbal_setting
+          print_1d_int_list (current_mask_intersect_list_status, "Updated current_mask_intersect_list_status");
+          #endif
 
         } else {
+          #ifdef Union_trace_verbal_setting
+          if (enable_tagging && stop_tagging_ray == 0)
+            printf ("Before new intersection volume node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+          if (enable_tagging && stop_tagging_ray == 0)
+            printf ("Before new intersection volume node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
+          #endif
+
+          // Mask update: If the min_volume is not a mask, things are simple, current_volume = min_volume.
+          //               however, if it is a mask, the mask status will switch.
+          //               if the mask status becomes one, the masked volumes inside may be the next volume (unless they are children of the mask)
+          //               if the mask status becomes zero (and the current volume is masked by min_volume), the destinations list of the mask is searched
+          //               if the mask status becomes zero (and the current volume is NOT masked by min volume), the current volume doesn't change
+
+          if (Volumes[min_volume]->geometry.is_mask_volume == 0) {
             #ifdef Union_trace_verbal_setting
-              printf("Propagate out of volume %d\n", current_volume);
-              printf("r = (%f,%f,%f) k = (%f,%f,%f) \n",x,y,z,kx,ky,kz);
+            printf ("Min volume is not a mask, next volume = min volume\n");
             #endif
-            // Propagate x-ray to found minimum time
-            // PROP_DT(length_to_boundery);
-            x += length_to_boundery*kx/k_length;
-            y += length_to_boundery*ky/k_length;
-            z += length_to_boundery*kz/k_length;
-            t += time_to_boundery;
-            r[0] = x; r[1] = y; r[2] = z;
-            ray_position = coords_set(x,y,z);
-            ray_wavevector = coords_set(kx,ky,kz);
-
-
-            time_propagated_without_scattering = min_intersection_time;
-            SCATTER; // For debugging purposes
+            if (enable_tagging && stop_tagging_ray == 0) {
+              current_tagging_node = goto_volume_node (current_tagging_node, current_volume, min_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
+            }
+            current_volume = min_volume;
+          } else {
             #ifdef Union_trace_verbal_setting
-              printf("r = (%f,%f,%f) k = (%f,%f,%f) \n",x,y,z,kx,ky,kz);
+            printf ("Current volume is not a mask, complex decision tree\n");
             #endif
-            // Remove this entry from the intersection_time_table
-            intersection_time_table.intersection_times[min_volume][min_solution] = -1;
-
-            // Use destination list for corresponding intersection entry n,i) to find next volume
-            #ifdef Union_trace_verbal_setting
-              printf("PROPAGATION FROM VOLUME %d \n",current_volume);
-            #endif
-            if (min_volume == current_volume) {
+            if (mask_status_list.elements[Volumes[min_volume]->geometry.mask_index] == 1) {
+              // We are leaving the mask, change the status
+              #ifdef Union_trace_verbal_setting
+              printf ("mask status changed from 1 to 0 as a mask is left\n");
+              #endif
+              mask_status_list.elements[Volumes[min_volume]->geometry.mask_index] = 0;
+              // If the current volume is masked by this mask, run within_which_volume using the masks destination list, otherwise keep the current volume
+              if (on_int_list (Volumes[current_volume]->geometry.masked_by_list, min_volume) == 1) {
                 #ifdef Union_trace_verbal_setting
-                  printf("min_volume == current_volume \n");
+                printf ("The current volume was masked by this mask, and my need updating\n");
                 #endif
-                // List approach to finding the next volume.
-                // When the ray intersects the current volume, the next volume must be on the destination list of the current volume
-                // However, the reduced_destination_list can be investigated first, and depending on the results, the
-                //  direct children of the volumes on the reduced destination list are investigated.
-                // In the worst case, all direct children are investigated, which is eqvivalent to the entire destination list.
-                // There is however a certain overhead in the logic needed to set up this tree, avoid duplicates of direct children, and so on.
-                // This method is only faster than just checking the destination list when there are direct children (nested structures),
-                //  but in general the tree method scales better with complexity, and is only slightly slower in simple cases.
-
-                if (Volumes[current_volume]->geometry.destinations_list.num_elements == 1)
-                    tree_next_volume = Volumes[current_volume]->geometry.destinations_list.elements[0];
-                else {
-                    ray_position = coords_set(x,y,z);
-                    ray_wavevector = coords_set(kx,ky,kz);
-                    tree_next_volume = within_which_volume(ray_position,Volumes[current_volume]->geometry.reduced_destinations_list,Volumes[current_volume]->geometry.destinations_list,Volumes,&mask_status_list,number_of_volumes,pre_allocated1,pre_allocated2,pre_allocated3);
-                }
-
-                #ifdef Union_trace_verbal_setting
-                  if (enable_tagging) printf("tree method moves from %d to %d\n",current_volume,tree_next_volume);
-
-                  if (enable_tagging && stop_tagging_ray == 0) printf("Before new tree volume node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-                  if (enable_tagging && stop_tagging_ray == 0) printf("Before new tree volume node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
-                #endif
-
-                if (enable_tagging && stop_tagging_ray == 0)
-                    current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
-
-                #ifdef Union_trace_verbal_setting
-                  if (enable_tagging && stop_tagging_ray == 0) printf("After new tree volume node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-                  if (enable_tagging && stop_tagging_ray == 0) printf("After new tree volume node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
-                #endif
-
-                // Set next volume to the solution found in the tree method
-                current_volume = tree_next_volume;
-                update_current_mask_intersect_status(&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
-                #ifdef Union_trace_verbal_setting
-                  print_1d_int_list(current_mask_intersect_list_status,"Updated current_mask_intersect_list_status");
-                #endif
-
-            } else {
-                #ifdef Union_trace_verbal_setting
-                  if (enable_tagging && stop_tagging_ray == 0) printf("Before new intersection volume node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-                  if (enable_tagging && stop_tagging_ray == 0) printf("Before new intersection volume node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
-                #endif
-
-                // Mask update: If the min_volume is not a mask, things are simple, current_volume = min_volume.
-                //               however, if it is a mask, the mask status will switch.
-                //               if the mask status becomes one, the masked volumes inside may be the next volume (unless they are children of the mask)
-                //               if the mask status becomes zero (and the current volume is masked by min_volume), the destinations list of the mask is searched
-                //               if the mask status becomes zero (and the current volume is NOT masked by min volume), the current volume doesn't change
-
-                if (Volumes[min_volume]->geometry.is_mask_volume == 0) {
-                  #ifdef Union_trace_verbal_setting
-                    printf("Min volume is not a mask, next volume = min volume\n");
-                  #endif
-                  if (enable_tagging && stop_tagging_ray == 0) {
-                    current_tagging_node = goto_volume_node(current_tagging_node, current_volume, min_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
+                // In case of ANY mode, need to see if another mask on the masked_by list of the current volume is active, and if so, nothing happens
+                need_to_run_within_which_volume = 1;
+                if (Volumes[current_volume]->geometry.mask_mode == 2) {
+                  for (mask_start = mask_check = Volumes[current_volume]->geometry.masked_by_mask_index_list.elements;
+                       mask_check - mask_start < Volumes[current_volume]->geometry.masked_by_mask_index_list.num_elements; mask_check++) {
+                    if (mask_status_list.elements[*mask_check] == 1) {
+                      // Nothing needs to be done, the effective mask status of the current volume is still 1
+                      need_to_run_within_which_volume = 0;
+                      break;
+                    }
                   }
-                  current_volume = min_volume;
-                } else {
+                }
+                if (need_to_run_within_which_volume == 1) {
                   #ifdef Union_trace_verbal_setting
-                    printf("Current volume is not a mask, complex decision tree\n");
+                  printf ("The current volume was masked by this mask, and does need updating\n");
                   #endif
-                  if (mask_status_list.elements[Volumes[min_volume]->geometry.mask_index] == 1) {
-                    // We are leaving the mask, change the status
+                  if (Volumes[min_volume]->geometry.destinations_list.num_elements == 1) {
                     #ifdef Union_trace_verbal_setting
-                      printf("mask status changed from 1 to 0 as a mask is left\n");
+                    printf ("Only one element in the destination tree of the mask\n");
                     #endif
-                    mask_status_list.elements[Volumes[min_volume]->geometry.mask_index] = 0;
-                    // If the current volume is masked by this mask, run within_which_volume using the masks destination list, otherwise keep the current volume
-                    if (on_int_list(Volumes[current_volume]->geometry.masked_by_list,min_volume) == 1) {
+                    // If there is only one element on the destinations list (quite common) there is no reason to run within_which_volume
+                    // Instead the mask status is calculated here
+                    if (Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.is_masked_volume == 1) {
                       #ifdef Union_trace_verbal_setting
-                        printf("The current volume was masked by this mask, and my need updating\n");
+                      printf ("The one element is however masked, so the mask status need to be calculated\n");
                       #endif
-                      // In case of ANY mode, need to see if another mask on the masked_by list of the current volume is active, and if so, nothing happens
-                      need_to_run_within_which_volume = 1;
-                      if (Volumes[current_volume]->geometry.mask_mode == 2) {
-                        for (mask_start=mask_check=Volumes[current_volume]->geometry.masked_by_mask_index_list.elements; mask_check-mask_start<Volumes[current_volume]->geometry.masked_by_mask_index_list.num_elements; mask_check++) {
+                      // figure out the effective mask status of this volume
+                      if (Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.mask_mode == 2) { // ANY mask mode
+                        tree_next_volume = 0;
+                        for (mask_start = mask_check
+                             = Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.elements;
+                             mask_check - mask_start
+                             < Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.num_elements;
+                             mask_check++) {
                           if (mask_status_list.elements[*mask_check] == 1) {
-                            // Nothing needs to be done, the effective mask status of the current volume is still 1
-                            need_to_run_within_which_volume = 0;
+                            tree_next_volume = Volumes[min_volume]->geometry.destinations_list.elements[0];
+                            break;
+                          }
+                        }
+                      } else { // ALL mask mode
+                        tree_next_volume = Volumes[min_volume]->geometry.destinations_list.elements[0];
+                        for (mask_start = mask_check
+                             = Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.elements;
+                             mask_check - mask_start
+                             < Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.num_elements;
+                             mask_check++) {
+                          if (mask_status_list.elements[*mask_check] == 0) {
+                            tree_next_volume = 0;
                             break;
                           }
                         }
                       }
-                      if (need_to_run_within_which_volume == 1) {
-                        #ifdef Union_trace_verbal_setting
-                          printf("The current volume was masked by this mask, and does need updating\n");
-                        #endif
-                        if (Volumes[min_volume]->geometry.destinations_list.num_elements == 1) {
-                          #ifdef Union_trace_verbal_setting
-                            printf("Only one element in the destination tree of the mask\n");
-                          #endif
-                          // If there is only one element on the destinations list (quite common) there is no reason to run within_which_volume
-                          // Instead the mask status is calculated here
-                          if (Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.is_masked_volume == 1) {
-                            #ifdef Union_trace_verbal_setting
-                              printf("The one element is however masked, so the mask status need to be calculated\n");
-                            #endif
-                            // figure out the effective mask status of this volume
-                            if (Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.mask_mode == 2) { // ANY mask mode
-                              tree_next_volume = 0;
-                              for (mask_start=mask_check=Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.elements; mask_check-mask_start<Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.num_elements; mask_check++) {
-                                if (mask_status_list.elements[*mask_check] == 1) {
-                                  tree_next_volume = Volumes[min_volume]->geometry.destinations_list.elements[0];
-                                  break;
-                                }
-                              }
-                            } else { // ALL mask mode
-                              tree_next_volume = Volumes[min_volume]->geometry.destinations_list.elements[0];
-                              for (mask_start=mask_check=Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.elements;mask_check-mask_start<Volumes[Volumes[min_volume]->geometry.destinations_list.elements[0]]->geometry.masked_by_mask_index_list.num_elements;mask_check++) {
-                                if (mask_status_list.elements[*mask_check] == 0) {
-                                  tree_next_volume = 0;
-                                  break;
-                                }
-                              }
-                            }
-                          } else tree_next_volume = Volumes[min_volume]->geometry.destinations_list.elements[0];
-                          #ifdef Union_trace_verbal_setting
-                            printf("The method found the next tree volume to be %d\n",tree_next_volume);
-                          #endif
-                          if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
-                          current_volume = tree_next_volume;
-                        } else {
-                          #ifdef Union_trace_verbal_setting
-                            printf("Many elements in destinations list, use within_which_volume\n");
-                          #endif
-                          ray_position = coords_set(x,y,z);
-                          ray_wavevector = coords_set(kx,ky,kz);
-                          tree_next_volume = within_which_volume_GPU(ray_position, Volumes[min_volume]->geometry.reduced_destinations_list, Volumes[min_volume]->geometry.destinations_list, Volumes, &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
-
-                          if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes,&stop_tagging_ray,stop_creating_nodes);
-                          current_volume = tree_next_volume;
-                          #ifdef Union_trace_verbal_setting
-                            printf("Set new new volume to %d\n",tree_next_volume);
-                          #endif
-                        }
-                      } else {
-                        #ifdef Union_trace_verbal_setting
-                          printf("Did not need updating, as another mask was covering the volume\n");
-                        #endif
-                      }
-                    }
-
+                    } else
+                      tree_next_volume = Volumes[min_volume]->geometry.destinations_list.elements[0];
+                    #ifdef Union_trace_verbal_setting
+                    printf ("The method found the next tree volume to be %d\n", tree_next_volume);
+                    #endif
+                    if (enable_tagging && stop_tagging_ray == 0)
+                      current_tagging_node
+                          = goto_volume_node (current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
+                    current_volume = tree_next_volume;
                   } else {
-                    // Here beccause the mask status of the mask that is intersected was 0, and it is thus switched to 1
-                    mask_status_list.elements[Volumes[min_volume]->geometry.mask_index] = 1;
-                    // When entering a mask, the new highest priority volume may be one of the masked volumes, if not we keep the current volume
-                    ray_position = coords_set(x,y,z);
-                    ray_wavevector = coords_set(kx,ky,kz);
-                    // Bug found on the 2/9 2016, the destinations_list of a mask does not contain the volumes inside it. Could make an additional list for this.
-                    // The temporary fix will be to use the mask list for both reduced destinations list and destinations list.
-                    tree_next_volume = within_which_volume_GPU(ray_position, Volumes[min_volume]->geometry.mask_list, Volumes[min_volume]->geometry.mask_list, Volumes, &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
-                    // if within_which_volume returns 0, no result was found (volume 0 can not be masked, so it could not be on the mask list)
-                    if (tree_next_volume != 0) {
-                      if (Volumes[tree_next_volume]->geometry.priority_value > Volumes[current_volume]->geometry.priority_value) {
-                        // In case the current volume has a higher priority, nothing happens, otherwise change current volume
-                        if (enable_tagging && stop_tagging_ray == 0) current_tagging_node = goto_volume_node(current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
-                        current_volume = tree_next_volume;
-                      }
-                    }
+                    #ifdef Union_trace_verbal_setting
+                    printf ("Many elements in destinations list, use within_which_volume\n");
+                    #endif
+                    ray_position = coords_set (x, y, z);
+                    ray_wavevector = coords_set (kx, ky, kz);
+                    tree_next_volume = within_which_volume_GPU (ray_position, Volumes[min_volume]->geometry.reduced_destinations_list,
+                                                                Volumes[min_volume]->geometry.destinations_list, Volumes, &mask_status_list, number_of_volumes,
+                                                                pre_allocated1, pre_allocated2, pre_allocated3);
+
+                    if (enable_tagging && stop_tagging_ray == 0)
+                      current_tagging_node
+                          = goto_volume_node (current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
+                    current_volume = tree_next_volume;
+                    #ifdef Union_trace_verbal_setting
+                    printf ("Set new new volume to %d\n", tree_next_volume);
+                    #endif
                   }
+                } else {
+                  #ifdef Union_trace_verbal_setting
+                  printf ("Did not need updating, as another mask was covering the volume\n");
+                  #endif
                 }
-
-                // Regardless of the outcome of the above code, either the mask status or current volume have changed, and thus a effective mask update is needed.
-                update_current_mask_intersect_status(&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
-                #ifdef Union_trace_verbal_setting
-                  print_1d_int_list(mask_status_list,"Updated mask status list");
-                  print_1d_int_list(current_mask_intersect_list_status,"Updated current_mask_intersect_list_status");
-                  if (enable_tagging) printf("After new intersection volume node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-                  if (enable_tagging) printf("After new intersection volume node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
-                #endif
-
-            }
-            if (Volumes[current_volume]->geometry.is_exit_volume==1) {
-                    done = 1; // Exit volumes allow the ray to escape the component
-                    ray_sucseeded = 1; // Allows the ray to
-            }
-            #ifdef Union_trace_verbal_setting
-              printf(" TO VOLUME %d \n",current_volume);
-            #endif
-        }
-    } else { // Here because a shortest time is not found
-        if (current_volume == 0) {
-            done = 1;
-            ray_sucseeded = 1;
-
-        } else { // Check for errors (debugging phase)
-            if (error_msg == 0) {
-              component_error_msg++;
-              ray_sucseeded = 0;
-              done = 1; // stop the loop
-              printf("\n----------------------------------------------------------------------------------------------------\n");
-              printf("Union_master %s: Somehow reached a situation with no intersection time found, but still inside volume %d instead of 0\n",NAME_CURRENT_COMP,current_volume);
-              for (volume_index = 1; volume_index < number_of_volumes; volume_index++) {
-                if (r_within_function(ray_position,&Volumes[volume_index]->geometry) == 1)
-                    printf("The ray is in volume       %d\n",volume_index);
               }
 
-              print_1d_int_list(mask_status_list,"mask status list");
-              for (iterator=0;iterator<number_of_volumes;iterator++)
-                 printf("%d:%d - ",iterator,scattered_flag[iterator]);
-              printf("\n");
-              printf("r = (%f,%f,%f) k = (%f,%f,%f) \n",x,y,z,kx,ky,kz);
-
-              printf("Trace error number (%d/100) \n",component_error_msg);
+            } else {
+              // Here beccause the mask status of the mask that is intersected was 0, and it is thus switched to 1
+              mask_status_list.elements[Volumes[min_volume]->geometry.mask_index] = 1;
+              // When entering a mask, the new highest priority volume may be one of the masked volumes, if not we keep the current volume
+              ray_position = coords_set (x, y, z);
+              ray_wavevector = coords_set (kx, ky, kz);
+              // Bug found on the 2/9 2016, the destinations_list of a mask does not contain the volumes inside it. Could make an additional list for this.
+              // The temporary fix will be to use the mask list for both reduced destinations list and destinations list.
+              tree_next_volume = within_which_volume_GPU (ray_position, Volumes[min_volume]->geometry.mask_list, Volumes[min_volume]->geometry.mask_list, Volumes,
+                                                          &mask_status_list, number_of_volumes, pre_allocated1, pre_allocated2, pre_allocated3);
+              // if within_which_volume returns 0, no result was found (volume 0 can not be masked, so it could not be on the mask list)
+              if (tree_next_volume != 0) {
+                if (Volumes[tree_next_volume]->geometry.priority_value > Volumes[current_volume]->geometry.priority_value) {
+                  // In case the current volume has a higher priority, nothing happens, otherwise change current volume
+                  if (enable_tagging && stop_tagging_ray == 0)
+                    current_tagging_node
+                        = goto_volume_node (current_tagging_node, current_volume, tree_next_volume, Volumes, &stop_tagging_ray, stop_creating_nodes);
+                  current_volume = tree_next_volume;
+                }
+              }
             }
-            error_msg++;
+          }
 
-            if (component_error_msg > 100) {
-                printf("To many errors encountered, exiting. \n");
-                // need ERROR FLAG to be read in finally which can warn the user of problems!
-                exit(1);
-            }
+          // Regardless of the outcome of the above code, either the mask status or current volume have changed, and thus a effective mask update is needed.
+          update_current_mask_intersect_status (&current_mask_intersect_list_status, &mask_status_list, Volumes, &current_volume);
+          #ifdef Union_trace_verbal_setting
+          print_1d_int_list (mask_status_list, "Updated mask status list");
+          print_1d_int_list (current_mask_intersect_list_status, "Updated current_mask_intersect_list_status");
+          if (enable_tagging)
+            printf ("After new intersection volume node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+          if (enable_tagging)
+            printf ("After new intersection volume node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
+          #endif
         }
+        if (Volumes[current_volume]->geometry.is_exit_volume == 1) {
+          done = 1;          // Exit volumes allow the ray to escape the component
+          ray_sucseeded = 1; // Allows the ray to
+        }
+        #ifdef Union_trace_verbal_setting
+        printf (" TO VOLUME %d \n", current_volume);
+        #endif
+      }
+    } else { // Here because a shortest time is not found
+      if (current_volume == 0) {
+        done = 1;
+        ray_sucseeded = 1;
+
+      } else { // Check for errors (debugging phase)
+        if (error_msg == 0) {
+          component_error_msg++;
+          ray_sucseeded = 0;
+          done = 1; // stop the loop
+          printf ("\n----------------------------------------------------------------------------------------------------\n");
+          printf ("Union_master %s: Somehow reached a situation with no intersection time found, but still inside volume %d instead of 0\n", NAME_CURRENT_COMP,
+                  current_volume);
+          for (volume_index = 1; volume_index < number_of_volumes; volume_index++) {
+            if (r_within_function (ray_position, &Volumes[volume_index]->geometry) == 1)
+              printf ("The ray is in volume       %d\n", volume_index);
+          }
+
+          print_1d_int_list (mask_status_list, "mask status list");
+          for (iterator = 0; iterator < number_of_volumes; iterator++)
+            printf ("%d:%d - ", iterator, scattered_flag[iterator]);
+          printf ("\n");
+          printf ("r = (%f,%f,%f) k = (%f,%f,%f) \n", x, y, z, kx, ky, kz);
+
+          printf ("Trace error number (%d/100) \n", component_error_msg);
+        }
+        error_msg++;
+
+        if (component_error_msg > 100) {
+          printf ("To many errors encountered, exiting. \n");
+          // need ERROR FLAG to be read in finally which can warn the user of problems!
+          exit (1);
+        }
+      }
     }
 
-    if (limit == 0) {done = 1; ray_sucseeded = 0; printf("Reached limit on number of interactions, and discarded the x-ray, was in volume %d\n", current_volume); ABSORB;}
+    if (limit == 0) {
+      done = 1;
+      ray_sucseeded = 0;
+      printf ("Reached limit on number of interactions, and discarded the x-ray, was in volume %d\n", current_volume);
+      ABSORB;
+    }
     #ifdef Union_trace_verbal_setting
-      printf("----------- END OF WHILE LOOP --------------------------------------\n");
+    printf ("----------- END OF WHILE LOOP --------------------------------------\n");
     #endif
-
   }
   // Could move all add_statistics and similar to this point, but need to filter for failed rays
   if (ray_sucseeded == 1) {
 
     // Ray succeeded, need to check status of conditionals
     #ifdef Union_trace_verbal_setting
-      printf("----------- logger loop --------------------------------------\n");
+    printf ("----------- logger loop --------------------------------------\n");
     #endif
     // Loggers attatched to specific volumes need to be handled with care to avoid looping over all loggers for every ray
     if (enable_conditionals == 1) {
-      for (log_index=loggers_with_data_array.used_elements-1; log_index>-1; log_index--) {
+      for (log_index = loggers_with_data_array.used_elements - 1; log_index > -1; log_index--) {
         // Check all conditionals attatched to the current logger
         this_logger = loggers_with_data_array.logger_pointers[log_index];
         conditional_status = 1;
-        for (iterator=0;iterator<loggers_with_data_array.logger_pointers[log_index]->conditional_list.num_elements;iterator++) {
+        for (iterator = 0; iterator < loggers_with_data_array.logger_pointers[log_index]->conditional_list.num_elements; iterator++) {
           // Call this particular conditional. If it fails, report the status and break
           #ifdef Union_trace_verbal_setting
-            printf("Checking conditional number %d for logger named %s \n",iterator,loggers_with_data_array.logger_pointers[log_index]->name);
+          printf ("Checking conditional number %d for logger named %s \n", iterator, loggers_with_data_array.logger_pointers[log_index]->name);
           #endif
-          if (0 == this_logger->conditional_list.conditional_functions[iterator](
-                         this_logger->conditional_list.p_data_unions[iterator],
-                         &ray_position,&ray_wavevector, &p, &t, &current_volume,
-                         &number_of_scattering_events, scattered_flag,scattered_flag_VP)) {
+          if (0
+              == this_logger->conditional_list.conditional_functions[iterator](this_logger->conditional_list.p_data_unions[iterator], &ray_position,
+                                                                               &ray_wavevector, &p, &t, &current_volume, &number_of_scattering_events,
+                                                                               scattered_flag, scattered_flag_VP)) {
             conditional_status = 0;
             break;
           }
         }
         if (conditional_status == 1) {
-          // If a logger does not have a conditional, it will write directly to perm, and not even add it to the loggers_with_data_array, thus we know the temp_to_perm function needs to be called
-          // The input for the temp_to_perm function is a pointer to the logger_data_union for the appropriate logger
+          // If a logger does not have a conditional, it will write directly to perm, and not even add it to the loggers_with_data_array, thus we know the
+          // temp_to_perm function needs to be called The input for the temp_to_perm function is a pointer to the logger_data_union for the appropriate logger
 
           if (loggers_with_data_array.logger_pointers[log_index]->function_pointers.select_t_to_p == 1) {
-            loggers_with_data_array.logger_pointers[log_index]->function_pointers.temp_to_perm(&loggers_with_data_array.logger_pointers[log_index]->data_union);
-          }
-          else if (loggers_with_data_array.logger_pointers[log_index]->function_pointers.select_t_to_p == 2) {
-            loggers_with_data_array.logger_pointers[log_index]->function_pointers.temp_to_perm_final_p(&loggers_with_data_array.logger_pointers[log_index]->data_union,p);
+            loggers_with_data_array.logger_pointers[log_index]->function_pointers.temp_to_perm (&loggers_with_data_array.logger_pointers[log_index]->data_union);
+          } else if (loggers_with_data_array.logger_pointers[log_index]->function_pointers.select_t_to_p == 2) {
+            loggers_with_data_array.logger_pointers[log_index]->function_pointers.temp_to_perm_final_p (
+                &loggers_with_data_array.logger_pointers[log_index]->data_union, p);
           }
 
           // The user can set a condtional_extend_index, so that the evaluation of this specific conditional can be taken easily from extend
           if (loggers_with_data_array.logger_pointers[log_index]->logger_extend_index != -1) {
             #ifdef Union_trace_verbal_setting
-              printf("Updating logger_conditional_extend_array[%d] to 1 (max length = %d)\n", loggers_with_data_array.logger_pointers[log_index]->logger_extend_index, max_conditional_extend_index);
+            printf ("Updating logger_conditional_extend_array[%d] to 1 (max length = %d)\n",
+                    loggers_with_data_array.logger_pointers[log_index]->logger_extend_index, max_conditional_extend_index);
             #endif
             logger_conditional_extend_array[loggers_with_data_array.logger_pointers[log_index]->logger_extend_index] = 1; // Can be reached from EXTEND
-            // Are all reset to 0 for each new ray
+                                                                                                                          // Are all reset to 0 for each new ray
             #ifdef Union_trace_verbal_setting
-              printf("Updated extend index sucessfully\n");
+            printf ("Updated extend index sucessfully\n");
             #endif
           }
 
           // Need to remove the current element from logger_with_data as it has been cleared and written to disk
           // The remaining elements is passed on to the next Union_master as it may fulfill the conditional after that master
-          if (global_master_list_master->elements[global_master_list_master->num_elements-1].component_index != INDEX_CURRENT_COMP) {
+          if (global_master_list_master->elements[global_master_list_master->num_elements - 1].component_index != INDEX_CURRENT_COMP) {
             // Move current logger pointer in logger_with_data to end position
-            loggers_with_data_array.logger_pointers[log_index] = loggers_with_data_array.logger_pointers[loggers_with_data_array.used_elements-1];
+            loggers_with_data_array.logger_pointers[log_index] = loggers_with_data_array.logger_pointers[loggers_with_data_array.used_elements - 1];
             // Decrease logger_with_data.used_elements with 1
             loggers_with_data_array.used_elements--;
           }
@@ -2022,65 +2222,67 @@ TRACE
       }
 
       // Perform the same loop with abs_loggers and their conditionals
-      for (log_index=abs_loggers_with_data_array.used_elements-1; log_index>-1; log_index--) {
+      for (log_index = abs_loggers_with_data_array.used_elements - 1; log_index > -1; log_index--) {
         // Check all conditionals attatched to the current logger
         this_abs_logger = abs_loggers_with_data_array.abs_logger_pointers[log_index];
         conditional_status = 1;
-        for (iterator=0;iterator<abs_loggers_with_data_array.abs_logger_pointers[log_index]->conditional_list.num_elements;iterator++) {
+        for (iterator = 0; iterator < abs_loggers_with_data_array.abs_logger_pointers[log_index]->conditional_list.num_elements; iterator++) {
           // Call this particular conditional. If it fails, report the status and break
           #ifdef Union_trace_verbal_setting
-            printf("Checking conditional number %d for abs logger named %s \n",iterator, abs_loggers_with_data_array.abs_logger_pointers[log_index]->name);
+          printf ("Checking conditional number %d for abs logger named %s \n", iterator, abs_loggers_with_data_array.abs_logger_pointers[log_index]->name);
           #endif
-          if (0 == this_abs_logger->conditional_list.conditional_functions[iterator](
-                         this_abs_logger->conditional_list.p_data_unions[iterator],
-                         &ray_position, &ray_wavevector, &p, &t, &current_volume,
-                         &number_of_scattering_events, scattered_flag, scattered_flag_VP)) {
+          if (0
+              == this_abs_logger->conditional_list.conditional_functions[iterator](this_abs_logger->conditional_list.p_data_unions[iterator], &ray_position,
+                                                                                   &ray_wavevector, &p, &t, &current_volume, &number_of_scattering_events,
+                                                                                   scattered_flag, scattered_flag_VP)) {
             conditional_status = 0;
             break;
           }
         }
         if (conditional_status == 1) {
-          // If a logger does not have a conditional, it will write directly to perm, and not even add it to the loggers_with_data_array, thus we know the temp_to_perm function needs to be called
-          // The input for the temp_to_perm function is a pointer to the logger_data_union for the appropriate logger
-          abs_loggers_with_data_array.abs_logger_pointers[log_index]->function_pointers.temp_to_perm(&abs_loggers_with_data_array.abs_logger_pointers[log_index]->data_union);
+          // If a logger does not have a conditional, it will write directly to perm, and not even add it to the loggers_with_data_array, thus we know the
+          // temp_to_perm function needs to be called The input for the temp_to_perm function is a pointer to the logger_data_union for the appropriate logger
+          abs_loggers_with_data_array.abs_logger_pointers[log_index]->function_pointers.temp_to_perm (
+              &abs_loggers_with_data_array.abs_logger_pointers[log_index]->data_union);
 
           // The user can set a condtional_extend_index, so that the evaluation of this specific conditional can be taken easily from extend
           if (abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index != -1) {
             #ifdef Union_trace_verbal_setting
-              printf("Updating logger_conditional_extend_array[%d] to 1 (max length = %d)\n",abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index,max_conditional_extend_index);
+            printf ("Updating logger_conditional_extend_array[%d] to 1 (max length = %d)\n",
+                    abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index, max_conditional_extend_index);
             #endif
-            abs_logger_conditional_extend_array[abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index] = 1; // Can be reached from EXTEND
-            // Are all reset to 0 for each new ray
-            #ifdef Union_trace_verbal_setting
-              printf("Updated extend index sucessfully\n");
+            abs_logger_conditional_extend_array[abs_loggers_with_data_array.abs_logger_pointers[log_index]->abs_logger_extend_index]
+                = 1; // Can be reached from EXTEND
+                     // Are all reset to 0 for each new ray
+                     #ifdef Union_trace_verbal_setting
+            printf ("Updated extend index sucessfully\n");
             #endif
           }
 
           // Need to remove the current element from logger_with_data as it has been cleared and written to disk
           // The remaining elements is passed on to the next Union_master as it may fulfill the conditional after that master
-          if (global_master_list_master->elements[global_master_list_master->num_elements-1].component_index != INDEX_CURRENT_COMP) {
+          if (global_master_list_master->elements[global_master_list_master->num_elements - 1].component_index != INDEX_CURRENT_COMP) {
             // Move current logger pointer in logger_with_data to end position
-            abs_loggers_with_data_array.abs_logger_pointers[log_index] = abs_loggers_with_data_array.abs_logger_pointers[abs_loggers_with_data_array.used_elements-1];
+            abs_loggers_with_data_array.abs_logger_pointers[log_index]
+                = abs_loggers_with_data_array.abs_logger_pointers[abs_loggers_with_data_array.used_elements - 1];
             // Decrease logger_with_data.used_elements with 1
             abs_loggers_with_data_array.used_elements--;
           }
-
         }
       }
     }
 
     if (enable_tagging && stop_tagging_ray == 0) {
       conditional_status = 1;
-      for (iterator=0; iterator<tagging_conditional_list->num_elements; iterator++) {
+      for (iterator = 0; iterator < tagging_conditional_list->num_elements; iterator++) {
         // Call this particular conditional. If it fails, report the status and break
         // Since a conditional can work for a logger and master_tagging at the same time, it may be evaluated twice
         #ifdef Union_trace_verbal_setting
-          printf("Checking tagging conditional number %d\n",iterator);
+        printf ("Checking tagging conditional number %d\n", iterator);
         #endif
-        if (0 == tagging_conditional_list->conditional_functions[iterator](
-                         tagging_conditional_list->p_data_unions[iterator],
-                         &ray_position, &ray_wavevector,&p, &t, &current_volume,
-                         &number_of_scattering_events, scattered_flag,scattered_flag_VP)) {
+        if (0
+            == tagging_conditional_list->conditional_functions[iterator](tagging_conditional_list->p_data_unions[iterator], &ray_position, &ray_wavevector, &p,
+                                                                         &t, &current_volume, &number_of_scattering_events, scattered_flag, scattered_flag_VP)) {
           conditional_status = 0;
           break;
         }
@@ -2088,21 +2290,24 @@ TRACE
       if (conditional_status == 1) {
         tagging_conditional_extend = 1;
         #ifdef Union_trace_verbal_setting
-          printf("Before adding statistics to node: current_tagging_nodbe->intensity = %f\n",current_tagging_node->intensity);
-          printf("Before adding statistics to node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
+        printf ("Before adding statistics to node: current_tagging_nodbe->intensity = %f\n", current_tagging_node->intensity);
+        printf ("Before adding statistics to node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
         #endif
 
-          add_statistics_to_node(current_tagging_node,&ray_position, &ray_wavevector, &p, &tagging_leaf_counter);
+        add_statistics_to_node (current_tagging_node, &ray_position, &ray_wavevector, &p, &tagging_leaf_counter);
 
         #ifdef Union_trace_verbal_setting
-          printf("After adding statistics to node: current_tagging_node->intensity = %f\n",current_tagging_node->intensity);
-          printf("After adding statistics to node: current_tagging_node->number_of_rays = %d\n",current_tagging_node->number_of_rays);
+        printf ("After adding statistics to node: current_tagging_node->intensity = %f\n", current_tagging_node->intensity);
+        printf ("After adding statistics to node: current_tagging_node->number_of_rays = %d\n", current_tagging_node->number_of_rays);
         #endif
       }
     }
 
     // Move the rays a picometer away from the surface it left, in case activation counter > 1, this will prevent the ray from starting on a volume boundery
-    x += kx*1E-12/k_length; y += ky*1E-12/k_length; z += kz*1E-12/k_length; t += 1E-12/M_C;
+    x += kx * 1E-12 / k_length;
+    y += ky * 1E-12 / k_length;
+    z += kz * 1E-12 / k_length;
+    t += 1E-12 / M_C;
 
   } else {
     ABSORB; // Absorb rays that didn't exit correctly for whatever reason
@@ -2111,7 +2316,6 @@ TRACE
 
   // Stores nubmer of scattering events in global master list so that another master with inherit_number_of_scattering_events can continue
   global_master_list_master->elements[this_global_master_index].stored_number_of_scattering_events = number_of_scattering_events;
-
 %}
 
 
@@ -2122,194 +2326,246 @@ SAVE
 
 FINALLY
 %{
-// write out histories from tagging system if enabled
-if (enable_tagging) {
-    if (finally_verbal) printf("Writing tagging tree to disk \n");
-    if (finally_verbal) printf("Number of leafs = %d \n",tagging_leaf_counter);
+  // write out histories from tagging system if enabled
+  if (enable_tagging) {
+    if (finally_verbal)
+      printf ("Writing tagging tree to disk \n");
+    if (finally_verbal)
+      printf ("Number of leafs = %d \n", tagging_leaf_counter);
     // While writing the tagging tree to disk, all the leafs are deallocated
-    write_tagging_tree(&master_tagging_node_list, Volumes, tagging_leaf_counter, number_of_volumes);
-}
-if (master_tagging_node_list.num_elements > 0) free(master_tagging_node_list.elements);
+    write_tagging_tree (&master_tagging_node_list, Volumes, tagging_leaf_counter, number_of_volumes);
+  }
+  if (master_tagging_node_list.num_elements > 0)
+    free (master_tagging_node_list.elements);
 
+  if (finally_verbal)
+    printf ("Freeing variables which are always allocated \n");
+  // free allocated arrays specific to this master union component
+  free (scattered_flag);
+  free (my_trace);
+  free (pre_allocated1);
+  free (pre_allocated2);
+  free (pre_allocated3);
+  free (number_of_processes_array);
+  free (Geometries);
 
-if (finally_verbal) printf("Freeing variables which are always allocated \n");
-// free allocated arrays specific to this master union component
-free(scattered_flag);
-free(my_trace);
-free(pre_allocated1);
-free(pre_allocated2);
-free(pre_allocated3);
-free(number_of_processes_array);
-free(Geometries);
-
-if (finally_verbal) printf("Freeing intersection_time_table \n");
-for (iterator = 1;iterator < intersection_time_table.num_volumes;iterator++){
-    free(intersection_time_table.intersection_times[iterator]);
-}
-
-free(intersection_time_table.n_elements);
-free(intersection_time_table.calculated);
-free(intersection_time_table.intersection_times);
-
-if (free_tagging_conditional_list == 1) free(tagging_conditional_list);
-
-if (finally_verbal) printf("Freeing lists for individual volumes \n");
-for (volume_index=0;volume_index<number_of_volumes;volume_index++) {
-
-  if (Volumes[volume_index]->geometry.intersect_check_list.num_elements > 0) free(Volumes[volume_index]->geometry.intersect_check_list.elements);
-  if (Volumes[volume_index]->geometry.destinations_list.num_elements > 0) free(Volumes[volume_index]->geometry.destinations_list.elements);
-  if (Volumes[volume_index]->geometry.reduced_destinations_list.num_elements > 0) free(Volumes[volume_index]->geometry.reduced_destinations_list.elements);
-  if (Volumes[volume_index]->geometry.children.num_elements > 0) free(Volumes[volume_index]->geometry.children.elements);
-  if (Volumes[volume_index]->geometry.direct_children.num_elements > 0) free(Volumes[volume_index]->geometry.direct_children.elements);
-  if (Volumes[volume_index]->geometry.masked_by_list.num_elements > 0) free(Volumes[volume_index]->geometry.masked_by_list.elements);
-  if (Volumes[volume_index]->geometry.masked_by_mask_index_list.num_elements > 0) free(Volumes[volume_index]->geometry.masked_by_mask_index_list.elements);
-  if (Volumes[volume_index]->geometry.mask_list.num_elements > 0) free(Volumes[volume_index]->geometry.mask_list.elements);
-  if (Volumes[volume_index]->geometry.mask_intersect_list.num_elements > 0) free(Volumes[volume_index]->geometry.mask_intersect_list.elements);
-  if (Volumes[volume_index]->geometry.next_volume_list.num_elements > 0) free(Volumes[volume_index]->geometry.next_volume_list.elements);
-
-  if (finally_verbal) printf("  Freeing physics\n");
-  if (volume_index > 0) { // Volume 0 does not have physical properties allocated
-    free(scattered_flag_VP[volume_index]);
-    if (Volumes[volume_index]->geometry.process_rot_allocated == 1) {
-          free(Volumes[volume_index]->geometry.process_rot_matrix_array);
-          free(Volumes[volume_index]->geometry.transpose_process_rot_matrix_array);
-          Volumes[volume_index]->geometry.process_rot_allocated = 0;
-    }
-    if (on_int_list(Volume_copies_allocated,volume_index)) {
-      // This is a local copy of a volume, deallocate that local copy (all the allocated memory attachted to it was just deallocated, so this should not leave any leaks)
-      free(Volumes[volume_index]);
-    } else {
-      // Only free p_physics for vacuum volumes for the original at the end (there is a p_physics allocated for each vacuum volume)
-      if (Volumes[volume_index]->p_physics->is_vacuum == 1 ) free(Volumes[volume_index]->p_physics);
-    }
+  if (finally_verbal)
+    printf ("Freeing intersection_time_table \n");
+  for (iterator = 1; iterator < intersection_time_table.num_volumes; iterator++) {
+    free (intersection_time_table.intersection_times[iterator]);
   }
 
-  if (finally_verbal) printf("  Freeing loggers\n");
-  if (Volumes[volume_index]->loggers.num_elements >0) {
-    for (iterator=0;iterator<Volumes[volume_index]->loggers.num_elements;iterator++) {
-      free(Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process);
+  free (intersection_time_table.n_elements);
+  free (intersection_time_table.calculated);
+  free (intersection_time_table.intersection_times);
+
+  if (free_tagging_conditional_list == 1)
+    free (tagging_conditional_list);
+
+  if (finally_verbal)
+    printf ("Freeing lists for individual volumes \n");
+  for (volume_index = 0; volume_index < number_of_volumes; volume_index++) {
+
+    if (Volumes[volume_index]->geometry.intersect_check_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.intersect_check_list.elements);
+    if (Volumes[volume_index]->geometry.destinations_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.destinations_list.elements);
+    if (Volumes[volume_index]->geometry.reduced_destinations_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.reduced_destinations_list.elements);
+    if (Volumes[volume_index]->geometry.children.num_elements > 0)
+      free (Volumes[volume_index]->geometry.children.elements);
+    if (Volumes[volume_index]->geometry.direct_children.num_elements > 0)
+      free (Volumes[volume_index]->geometry.direct_children.elements);
+    if (Volumes[volume_index]->geometry.masked_by_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.masked_by_list.elements);
+    if (Volumes[volume_index]->geometry.masked_by_mask_index_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.masked_by_mask_index_list.elements);
+    if (Volumes[volume_index]->geometry.mask_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.mask_list.elements);
+    if (Volumes[volume_index]->geometry.mask_intersect_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.mask_intersect_list.elements);
+    if (Volumes[volume_index]->geometry.next_volume_list.num_elements > 0)
+      free (Volumes[volume_index]->geometry.next_volume_list.elements);
+
+    if (finally_verbal)
+      printf ("  Freeing physics\n");
+    if (volume_index > 0) { // Volume 0 does not have physical properties allocated
+      free (scattered_flag_VP[volume_index]);
+      if (Volumes[volume_index]->geometry.process_rot_allocated == 1) {
+        free (Volumes[volume_index]->geometry.process_rot_matrix_array);
+        free (Volumes[volume_index]->geometry.transpose_process_rot_matrix_array);
+        Volumes[volume_index]->geometry.process_rot_allocated = 0;
+      }
+      if (on_int_list (Volume_copies_allocated, volume_index)) {
+        // This is a local copy of a volume, deallocate that local copy (all the allocated memory attachted to it was just deallocated, so this should not leave
+        // any leaks)
+        free (Volumes[volume_index]);
+      } else {
+        // Only free p_physics for vacuum volumes for the original at the end (there is a p_physics allocated for each vacuum volume)
+        if (Volumes[volume_index]->p_physics->is_vacuum == 1)
+          free (Volumes[volume_index]->p_physics);
+      }
     }
-    free(Volumes[volume_index]->loggers.p_logger_volume);
+
+    if (finally_verbal)
+      printf ("  Freeing loggers\n");
+    if (Volumes[volume_index]->loggers.num_elements > 0) {
+      for (iterator = 0; iterator < Volumes[volume_index]->loggers.num_elements; iterator++) {
+        free (Volumes[volume_index]->loggers.p_logger_volume[iterator].p_logger_process);
+      }
+      free (Volumes[volume_index]->loggers.p_logger_volume);
+    }
+
+    if (finally_verbal)
+      printf ("  Freeing abs_loggers\n");
+    if (Volumes[volume_index]->abs_loggers.num_elements > 0) {
+      free (Volumes[volume_index]->abs_loggers.p_abs_logger);
+    }
+    if (finally_verbal)
+      printf ("  Freeing Volumes[index]\n");
+    // free(Volumes[volume_index]); // Not able to free
+    // if (finally_verbal) printf("  Managed to free Volumes[index]\n");
   }
 
-  if (finally_verbal) printf("  Freeing abs_loggers\n");
-  if (Volumes[volume_index]->abs_loggers.num_elements > 0) {
-    free(Volumes[volume_index]->abs_loggers.p_abs_logger);
-  }
-  if (finally_verbal) printf("  Freeing Volumes[index]\n");
-  //free(Volumes[volume_index]); // Not able to free
-  //if (finally_verbal) printf("  Managed to free Volumes[index]\n");
-}
+  free (scattered_flag_VP);
 
-free(scattered_flag_VP);
+  if (finally_verbal)
+    printf ("Freeing starting lists \n");
+  if (starting_lists.allowed_starting_volume_logic_list.num_elements > 0)
+    free (starting_lists.allowed_starting_volume_logic_list.elements);
+  if (starting_lists.reduced_start_list.num_elements > 0)
+    free (starting_lists.reduced_start_list.elements);
+  if (starting_lists.start_logic_list.num_elements > 0)
+    free (starting_lists.start_logic_list.elements);
 
-if (finally_verbal) printf("Freeing starting lists \n");
-if (starting_lists.allowed_starting_volume_logic_list.num_elements > 0) free(starting_lists.allowed_starting_volume_logic_list.elements);
-if (starting_lists.reduced_start_list.num_elements > 0) free(starting_lists.reduced_start_list.elements);
-if (starting_lists.start_logic_list.num_elements > 0) free(starting_lists.start_logic_list.elements);
+  if (finally_verbal)
+    printf ("Freeing mask lists \n");
+  if (mask_status_list.num_elements > 0)
+    free (mask_status_list.elements);
+  if (current_mask_intersect_list_status.num_elements > 0)
+    free (current_mask_intersect_list_status.elements);
+  if (mask_volume_index_list.num_elements > 0)
+    free (mask_volume_index_list.elements);
 
-if (finally_verbal) printf("Freeing mask lists \n");
-if (mask_status_list.num_elements>0) free(mask_status_list.elements);
-if (current_mask_intersect_list_status.num_elements>0) free(current_mask_intersect_list_status.elements);
-if (mask_volume_index_list.num_elements>0) free(mask_volume_index_list.elements);
+  if (finally_verbal)
+    printf ("Freeing component index list \n");
+  if (geometry_component_index_list.num_elements > 0)
+    free (geometry_component_index_list.elements);
 
-if (finally_verbal) printf("Freeing component index list \n");
-if (geometry_component_index_list.num_elements>0) free(geometry_component_index_list.elements);
+  if (finally_verbal)
+    printf ("Freeing Volumes \n");
+  free (Volumes);
 
+  // Free global allocated arrays if this is the last master union component in the instrument file
 
-if (finally_verbal) printf("Freeing Volumes \n");
-free(Volumes);
-
-// Free global allocated arrays if this is the last master union component in the instrument file
-
-if (global_master_list_master->elements[global_master_list_master->num_elements-1].component_index == INDEX_CURRENT_COMP) {
-    if (finally_verbal) printf("Freeing global arrays because this is the last Union master component\n");
+  if (global_master_list_master->elements[global_master_list_master->num_elements - 1].component_index == INDEX_CURRENT_COMP) {
+    if (finally_verbal)
+      printf ("Freeing global arrays because this is the last Union master component\n");
 
     // Freeing lists allocated in Union_initialization
 
-    if (finally_verbal) printf("Freeing global process list \n");
-    if (global_process_list_master->num_elements > 0) free(global_process_list_master->elements);
+    if (finally_verbal)
+      printf ("Freeing global process list \n");
+    if (global_process_list_master->num_elements > 0)
+      free (global_process_list_master->elements);
 
-    if (finally_verbal) printf("Freeing global material list \n");
-    if (global_material_list_master->num_elements > 0) free(global_material_list_master->elements);
+    if (finally_verbal)
+      printf ("Freeing global material list \n");
+    if (global_material_list_master->num_elements > 0)
+      free (global_material_list_master->elements);
 
-    if (finally_verbal) printf("Freeing global geometry list \n");
-    if (global_geometry_list_master->num_elements > 0) free(global_geometry_list_master->elements);
+    if (finally_verbal)
+      printf ("Freeing global geometry list \n");
+    if (global_geometry_list_master->num_elements > 0)
+      free (global_geometry_list_master->elements);
 
-    if (finally_verbal) printf("Freeing global master list \n");
-    if (global_master_list_master->num_elements > 0) free(global_master_list_master->elements);
+    if (finally_verbal)
+      printf ("Freeing global master list \n");
+    if (global_master_list_master->num_elements > 0)
+      free (global_master_list_master->elements);
 
-    if (finally_verbal) printf("Freeing global logger lists \n");
-    for (iterator=0;iterator<global_all_volume_logger_list_master->num_elements;iterator++) {
+    if (finally_verbal)
+      printf ("Freeing global logger lists \n");
+    for (iterator = 0; iterator < global_all_volume_logger_list_master->num_elements; iterator++) {
       if (global_all_volume_logger_list_master->elements[iterator].logger->conditional_list.num_elements > 0) {
-        free(global_all_volume_logger_list_master->elements[iterator].logger->conditional_list.conditional_functions);
-        free(global_all_volume_logger_list_master->elements[iterator].logger->conditional_list.p_data_unions);
+        free (global_all_volume_logger_list_master->elements[iterator].logger->conditional_list.conditional_functions);
+        free (global_all_volume_logger_list_master->elements[iterator].logger->conditional_list.p_data_unions);
       }
     }
-    if (global_all_volume_logger_list_master->num_elements > 0) free(global_all_volume_logger_list_master->elements);
+    if (global_all_volume_logger_list_master->num_elements > 0)
+      free (global_all_volume_logger_list_master->elements);
 
-    for (iterator=0;iterator<global_specific_volumes_logger_list_master->num_elements;iterator++) {
+    for (iterator = 0; iterator < global_specific_volumes_logger_list_master->num_elements; iterator++) {
       if (global_specific_volumes_logger_list_master->elements[iterator].logger->conditional_list.num_elements > 0) {
-        free(global_specific_volumes_logger_list_master->elements[iterator].logger->conditional_list.conditional_functions);
-        free(global_specific_volumes_logger_list_master->elements[iterator].logger->conditional_list.p_data_unions);
+        free (global_specific_volumes_logger_list_master->elements[iterator].logger->conditional_list.conditional_functions);
+        free (global_specific_volumes_logger_list_master->elements[iterator].logger->conditional_list.p_data_unions);
       }
     }
-    if (global_specific_volumes_logger_list_master->num_elements > 0) free(global_specific_volumes_logger_list_master->elements);
+    if (global_specific_volumes_logger_list_master->num_elements > 0)
+      free (global_specific_volumes_logger_list_master->elements);
 
-    if (finally_verbal) printf("Freeing global abs logger lists \n");
-    for (iterator=0;iterator<global_all_volume_abs_logger_list_master->num_elements;iterator++) {
+    if (finally_verbal)
+      printf ("Freeing global abs logger lists \n");
+    for (iterator = 0; iterator < global_all_volume_abs_logger_list_master->num_elements; iterator++) {
       if (global_all_volume_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.num_elements > 0) {
-        free(global_all_volume_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.conditional_functions);
-        free(global_all_volume_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.p_data_unions);
+        free (global_all_volume_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.conditional_functions);
+        free (global_all_volume_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.p_data_unions);
       }
     }
-    if (global_all_volume_abs_logger_list_master->num_elements > 0) free(global_all_volume_abs_logger_list_master->elements);
+    if (global_all_volume_abs_logger_list_master->num_elements > 0)
+      free (global_all_volume_abs_logger_list_master->elements);
 
-    for (iterator=0;iterator<global_specific_volumes_abs_logger_list_master->num_elements;iterator++) {
+    for (iterator = 0; iterator < global_specific_volumes_abs_logger_list_master->num_elements; iterator++) {
       if (global_specific_volumes_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.num_elements > 0) {
-        free(global_specific_volumes_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.conditional_functions);
-        free(global_specific_volumes_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.p_data_unions);
+        free (global_specific_volumes_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.conditional_functions);
+        free (global_specific_volumes_abs_logger_list_master->elements[iterator].abs_logger->conditional_list.p_data_unions);
       }
     }
-    if (global_specific_volumes_abs_logger_list_master->num_elements > 0) free(global_specific_volumes_abs_logger_list_master->elements);
+    if (global_specific_volumes_abs_logger_list_master->num_elements > 0)
+      free (global_specific_volumes_abs_logger_list_master->elements);
 
-    if (finally_verbal) printf("Freeing global tagging conditional lists \n");
-    for (iterator=0;iterator<global_tagging_conditional_list_master->num_elements;iterator++) {
+    if (finally_verbal)
+      printf ("Freeing global tagging conditional lists \n");
+    for (iterator = 0; iterator < global_tagging_conditional_list_master->num_elements; iterator++) {
       if (global_tagging_conditional_list_master->elements[iterator].conditional_list.num_elements > 0) {
-        free(global_tagging_conditional_list_master->elements[iterator].conditional_list.conditional_functions);
-        free(global_tagging_conditional_list_master->elements[iterator].conditional_list.p_data_unions);
+        free (global_tagging_conditional_list_master->elements[iterator].conditional_list.conditional_functions);
+        free (global_tagging_conditional_list_master->elements[iterator].conditional_list.p_data_unions);
       }
     }
-    if (global_tagging_conditional_list_master->num_elements>0) free(global_tagging_conditional_list_master->elements);
-}
-
+    if (global_tagging_conditional_list_master->num_elements > 0)
+      free (global_tagging_conditional_list_master->elements);
+  }
 %}
 
 
 MCDISPLAY
 %{
-  // mcdisplay is handled in the component files for each geometry and called here. The line function is only available in this section, and not through functions,
+  // mcdisplay is handled in the component files for each geometry and called here. The line function is only available in this section, and not through
+  // functions,
   //   so all the lines to be drawn for each volume are collected in a structure that is then drawn here.
-  magnify("xyz");
+  magnify ("xyz");
   struct lines_to_draw lines_to_draw_master;
-  for (volume_index=1; volume_index<number_of_volumes; volume_index++) {
-        if (Volumes[volume_index]->geometry.visualization_on == 1) {
-            lines_to_draw_master.number_of_lines = 0;
+  for (volume_index = 1; volume_index < number_of_volumes; volume_index++) {
+    if (Volumes[volume_index]->geometry.visualization_on == 1) {
+      lines_to_draw_master.number_of_lines = 0;
 
-            Volumes[volume_index]->geometry.mcdisplay_function(&lines_to_draw_master,volume_index,Geometries,number_of_volumes);
+      Volumes[volume_index]->geometry.mcdisplay_function (&lines_to_draw_master, volume_index, Geometries, number_of_volumes);
 
-            for (iterator = 0;iterator<lines_to_draw_master.number_of_lines;iterator++) {
-               if (lines_to_draw_master.lines[iterator].number_of_dashes == 1) {
-                 line(lines_to_draw_master.lines[iterator].point1.x, lines_to_draw_master.lines[iterator].point1.y, lines_to_draw_master.lines[iterator].point1.z, lines_to_draw_master.lines[iterator].point2.x, lines_to_draw_master.lines[iterator].point2.y, lines_to_draw_master.lines[iterator].point2.z);
-               }
-               else {
-                 dashed_line(lines_to_draw_master.lines[iterator].point1.x, lines_to_draw_master.lines[iterator].point1.y, lines_to_draw_master.lines[iterator].point1.z, lines_to_draw_master.lines[iterator].point2.x, lines_to_draw_master.lines[iterator].point2.y, lines_to_draw_master.lines[iterator].point2.z, lines_to_draw_master.lines[iterator].number_of_dashes);
-               }
-            }
-            if (lines_to_draw_master.number_of_lines>0) free(lines_to_draw_master.lines);
+      for (iterator = 0; iterator < lines_to_draw_master.number_of_lines; iterator++) {
+        if (lines_to_draw_master.lines[iterator].number_of_dashes == 1) {
+          line (lines_to_draw_master.lines[iterator].point1.x, lines_to_draw_master.lines[iterator].point1.y, lines_to_draw_master.lines[iterator].point1.z,
+                lines_to_draw_master.lines[iterator].point2.x, lines_to_draw_master.lines[iterator].point2.y, lines_to_draw_master.lines[iterator].point2.z);
+        } else {
+          dashed_line (lines_to_draw_master.lines[iterator].point1.x, lines_to_draw_master.lines[iterator].point1.y,
+                       lines_to_draw_master.lines[iterator].point1.z, lines_to_draw_master.lines[iterator].point2.x,
+                       lines_to_draw_master.lines[iterator].point2.y, lines_to_draw_master.lines[iterator].point2.z,
+                       lines_to_draw_master.lines[iterator].number_of_dashes);
         }
-   }
-
+      }
+      if (lines_to_draw_master.number_of_lines > 0)
+        free (lines_to_draw_master.lines);
+    }
+  }
 %}
 
 END

--- a/mcxtrace-comps/union/Union_master.comp
+++ b/mcxtrace-comps/union/Union_master.comp
@@ -69,7 +69,7 @@ SHARE
   %include "read_table-lib"
 
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_master requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Union_sphere.comp
+++ b/mcxtrace-comps/union/Union_sphere.comp
@@ -72,8 +72,6 @@ SHARE
 #define Union $Revision: 0.8 $
 
 
-%include "union-init.c"
-
 #endif
 
 
@@ -188,13 +186,8 @@ if (radius <= 0) {
   exit(1);
 }
 
-if (_getcomp_index(init) < 0) {
-fprintf(stderr,"Union_sphere:%s: Error identifying Union_init component, %s is not a known component name.\n",
-NAME_CURRENT_COMP, init);
-exit(-1);
-}
 // Get global variable from init component
-struct pointer_to_global_material_list *global_material_list = COMP_GETPAR3(Union_init, init, global_material_list);
+struct pointer_to_global_material_list *global_material_list = &g_material_list;
 // Use sanitation
 #ifdef MATERIAL_DETECTOR
 if (global_material_list->num_elements == 0) {
@@ -213,7 +206,7 @@ this_sphere_volume.geometry.is_masked_volume = 0;
 this_sphere_volume.geometry.is_exit_volume = 0;
 this_sphere_volume.geometry.is_mask_volume = 0;
 
-struct pointer_to_global_geometry_list *global_geometry_list = COMP_GETPAR3(Union_init, init, global_geometry_list);
+struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
 // Read the material input, or if it lacks, use automatic linking.
 if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.

--- a/mcxtrace-comps/union/Union_sphere.comp
+++ b/mcxtrace-comps/union/Union_sphere.comp
@@ -50,7 +50,6 @@
 * focus_xw:   [m]   horiz. dimension of a rectangular area
 * focus_xh:   [m]   vert. dimension of a rectangular area
 * focus_r:    [m]   focusing on circle with this radius
-* init:       [str]   Name of Union inititaliser component
 *
 * OUTPUT PARAMETERS:
 *
@@ -61,20 +60,20 @@
 
 DEFINE COMPONENT Union_sphere
 DEFINITION PARAMETERS ()
-SETTING PARAMETERS(string material_string=0, priority, radius, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1, string init="init")
+SETTING PARAMETERS(string material_string=0, priority, radius, visualize=1, int target_index=0, target_x=0, target_y=0, target_z=0, focus_aw=0, focus_ah=0, focus_xw=0, focus_xh=0, focus_r=0, p_interact=0, string mask_string=0, string mask_setting=0,number_of_activations=1)
 OUTPUT PARAMETERS ()
 
 /* X-ray parameters: (x,y,z,kx,ky,kz ,phi, t, Ex,Ey,Ez,p) */
 
 SHARE
 %{
-#ifndef Union
-#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #ifndef Union
+  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
-#endif
+  #endif
 
-
-void mcdisplay_sphere_function(struct lines_to_draw *lines_to_draw_output,int index, struct geometry_struct **Geometries,int number_of_volumes) {
+  void
+  mcdisplay_sphere_function (struct lines_to_draw* lines_to_draw_output, int index, struct geometry_struct** Geometries, int number_of_volumes) {
     // Function to call in mcdisplay section of the sample component for this volume
     // One can assume that Geometries[index] refers to a geometry as described in this file
     // The 4 lines describing the sphere are aligned to the local frame of the sphere,
@@ -85,26 +84,25 @@ void mcdisplay_sphere_function(struct lines_to_draw *lines_to_draw_output,int in
     double radius = Geometries[index]->geometry_parameters.p_sphere_storage->sph_radius;
     Coords center = Geometries[index]->center;
 
-    Coords direction1 = coords_set(0,0,1.0);
-    Coords direction2 = coords_set(0,1.0,0);
-    Coords direction3 = coords_set(1.0,0,0);
+    Coords direction1 = coords_set (0, 0, 1.0);
+    Coords direction2 = coords_set (0, 1.0, 0);
+    Coords direction3 = coords_set (1.0, 0, 0);
 
     struct lines_to_draw lines_to_draw_temp;
     lines_to_draw_temp.number_of_lines = 0;
 
+    lines_to_draw_temp = draw_circle_with_highest_priority (center, direction1, radius, index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    lines_to_draw_temp = draw_circle_with_highest_priority(center,direction1,radius,index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_circle_with_highest_priority (center, direction2, radius, index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
 
-    lines_to_draw_temp = draw_circle_with_highest_priority(center,direction2,radius,index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
+    lines_to_draw_temp = draw_circle_with_highest_priority (center, direction3, radius, index, Geometries, number_of_volumes, 2);
+    merge_lines_to_draw (lines_to_draw_output, &lines_to_draw_temp);
+  };
 
-    lines_to_draw_temp = draw_circle_with_highest_priority(center,direction3,radius,index,Geometries,number_of_volumes,2);
-    merge_lines_to_draw(lines_to_draw_output,&lines_to_draw_temp);
-
-};
-
-void initialize_sphere_geometry_from_main_component(struct geometry_struct *sphere) {
+  void
+  initialize_sphere_geometry_from_main_component (struct geometry_struct* sphere) {
     // Function to be called in initialize of the main component
     // This is done as the rotation matrix needs to be relative to the main component instead of global
     // Everything done in initialize in this component file has the rotation matrix relative to global
@@ -112,225 +110,228 @@ void initialize_sphere_geometry_from_main_component(struct geometry_struct *sphe
     // Nothing needs to be done for the sphere
     // If an empty function provides difficulties for some compilers, a dummy operation can be added
     int dummy;
+  };
 
-};
+  struct pointer_to_1d_coords_list
+  sphere_shell_points (struct geometry_struct* geometry, int max_number_of_points) {
+    // Function that returns a number (less than max) of points on the geometry surface
+    // If used, remember to free the space allocated.
 
-struct pointer_to_1d_coords_list sphere_shell_points(struct geometry_struct *geometry,int max_number_of_points) {
-  // Function that returns a number (less than max) of points on the geometry surface
-  // If used, remember to free the space allocated.
+    int points_per_circle = floor (sqrt (max_number_of_points));
+    int number_of_circles = points_per_circle;
 
-  int points_per_circle = floor(sqrt(max_number_of_points));
-  int number_of_circles = points_per_circle;
+    struct pointer_to_1d_coords_list sphere_shell_array;
+    sphere_shell_array.elements = malloc (points_per_circle * number_of_circles * sizeof (Coords));
+    sphere_shell_array.num_elements = points_per_circle * number_of_circles;
 
-  struct pointer_to_1d_coords_list sphere_shell_array;
-  sphere_shell_array.elements = malloc(points_per_circle*number_of_circles*sizeof(Coords));
-  sphere_shell_array.num_elements = points_per_circle*number_of_circles;
+    Coords center = geometry->center;
+    double radius = geometry->geometry_parameters.p_sphere_storage->sph_radius;
 
-  Coords center = geometry->center;
-  double radius = geometry->geometry_parameters.p_sphere_storage->sph_radius;
+    Coords direction = coords_set (0, 0, 1.0);
 
-  Coords direction = coords_set(0,0,1.0);
+    Rotation rot_matrix;
+    rot_set_rotation (rot_matrix, (double)PI / number_of_circles, 0, 0);
 
-  Rotation rot_matrix;
-  rot_set_rotation(rot_matrix,(double) PI/number_of_circles,0,0);
+    // print_rotation(rot_matrix,"rot matrix");
 
-  //print_rotation(rot_matrix,"rot matrix");
+    // Do the first iteration before the loop to avoid one unecessary matrix operation
+    points_on_circle (sphere_shell_array.elements, center, direction, radius, points_per_circle);
 
-  // Do the first iteration before the loop to avoid one unecessary matrix operation
-  points_on_circle(sphere_shell_array.elements,center,direction,radius,points_per_circle);
+    int iterate;
+    for (iterate = 1; iterate < number_of_circles; iterate++) {
+      direction = rot_apply (rot_matrix, direction);
+      points_on_circle (sphere_shell_array.elements + points_per_circle * iterate, center, direction, radius, points_per_circle);
+    }
+    // Other parts of the program change behavior when I use the above code, may be writing to unwanted parts of memory!
 
-  int iterate;
-  for (iterate=1;iterate<number_of_circles;iterate++) {
-    direction = rot_apply(rot_matrix,direction);
-    points_on_circle(sphere_shell_array.elements+points_per_circle*iterate,center,direction,radius,points_per_circle);
+    /*
+    // Debug
+    for (iterate=0;iterate<sphere_shell_array.num_elements;iterate++) {
+      //print_position(sphere_shell_array.elements[iterate],"Sphere shell points");
+      //printf("\n%f,%f,%f",sphere_shell_array.elements[iterate].x,sphere_shell_array.elements[iterate].y,sphere_shell_array.elements[iterate].z);
+    }
+    */
+
+    return sphere_shell_array;
   }
-  // Other parts of the program change behavior when I use the above code, may be writing to unwanted parts of memory!
 
-  /*
-  // Debug
-  for (iterate=0;iterate<sphere_shell_array.num_elements;iterate++) {
-    //print_position(sphere_shell_array.elements[iterate],"Sphere shell points");
-    //printf("\n%f,%f,%f",sphere_shell_array.elements[iterate].x,sphere_shell_array.elements[iterate].y,sphere_shell_array.elements[iterate].z);
-  }
-  */
-
-  return sphere_shell_array;
-}
-
-#ifndef ANY_GEOMETRY_DETECTOR_DECLARE
-    #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
-    //struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
-#endif
+  #ifndef ANY_GEOMETRY_DETECTOR_DECLARE
+  #define ANY_GEOMETRY_DETECTOR_DECLARE dummy
+  // struct pointer_to_global_geometry_list global_geometry_list = {0,NULL};
+  #endif
 %}
 
 DECLARE
 %{
-// Needed for transport to the main component
-struct global_geometry_element_struct global_geometry_element;
+  // Needed for transport to the main component
+  struct global_geometry_element_struct global_geometry_element;
 
-int loop_index;
+  int loop_index;
 
-struct Volume_struct this_sphere_volume;
-struct sphere_storage this_sphere_storage;
+  struct Volume_struct this_sphere_volume;
+  struct sphere_storage this_sphere_storage;
 %}
 
 INITIALIZE
 %{
-// Initializes the focusing system for this volume including input sanitation.
-focus_initialize(&this_sphere_volume.geometry, POS_A_COMP_INDEX(INDEX_CURRENT_COMP+target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index, target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
+  // Initializes the focusing system for this volume including input sanitation.
+  focus_initialize (&this_sphere_volume.geometry, POS_A_COMP_INDEX (INDEX_CURRENT_COMP + target_index), POS_A_CURRENT_COMP, ROT_A_CURRENT_COMP, target_index,
+                    target_x, target_y, target_z, focus_aw, focus_ah, focus_xw, focus_xh, focus_r, NAME_CURRENT_COMP);
 
-// Input sanitation for this geometry
-if (radius <= 0) {
-  printf("\nERROR in Union_sphere named %s, the radius is <= 0. \n",NAME_CURRENT_COMP);
-  exit(1);
-}
+  // Input sanitation for this geometry
+  if (radius <= 0) {
+    printf ("\nERROR in Union_sphere named %s, the radius is <= 0. \n", NAME_CURRENT_COMP);
+    exit (1);
+  }
 
-// Get global variable from init component
-struct pointer_to_global_material_list *global_material_list = &g_material_list;
-// Use sanitation
-#ifdef MATERIAL_DETECTOR
-if (global_material_list->num_elements == 0) {
-  // Here if the user have defined a material, but only after this material
-  printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
-  printf("       %s was defined before first use of Union_make_material.\n",NAME_CURRENT_COMP);
-  exit(1);
-}
-#endif
-#ifndef MATERIAL_DETECTOR
-  printf("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
-  exit(1);
-#endif
+  // Get global variable from the auto-injected Union state
+  struct pointer_to_global_material_list* global_material_list = &g_material_list;
+  // Use sanitation
+  #ifdef MATERIAL_DETECTOR
+  if (global_material_list->num_elements == 0) {
+    // Here if the user have defined a material, but only after this material
+    printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
+    printf ("       %s was defined before first use of Union_make_material.\n", NAME_CURRENT_COMP);
+    exit (1);
+  }
+  #endif
+  #ifndef MATERIAL_DETECTOR
+  printf ("\nERROR: Need to define a material using Union_make_material before using a Union geometry component. \n");
+  exit (1);
+  #endif
 
-this_sphere_volume.geometry.is_masked_volume = 0;
-this_sphere_volume.geometry.is_exit_volume = 0;
-this_sphere_volume.geometry.is_mask_volume = 0;
+  this_sphere_volume.geometry.is_masked_volume = 0;
+  this_sphere_volume.geometry.is_exit_volume = 0;
+  this_sphere_volume.geometry.is_mask_volume = 0;
 
-struct pointer_to_global_geometry_list *global_geometry_list = &g_geometry_list;
-// Read the material input, or if it lacks, use automatic linking.
-if (mask_string && strlen(mask_string) && strcmp(mask_string, "NULL") && strcmp(mask_string, "0")) {
+  struct pointer_to_global_geometry_list* global_geometry_list = &g_geometry_list;
+  // Read the material input, or if it lacks, use automatic linking.
+  if (mask_string && strlen (mask_string) && strcmp (mask_string, "NULL") && strcmp (mask_string, "0")) {
     // A mask volume is used to limit the extend of other volumes, called the masked volumes. These are specified in the mask_string.
     // In order for a ray to enter a masked volume, it needs to be both in the region covered by that volume AND the mask volume.
     // When more than
     this_sphere_volume.geometry.mask_mode = 1; // Default is mask mode is ALL
-    if (mask_setting && strlen(mask_setting) && strcmp(mask_setting, "NULL") && strcmp(mask_setting, "0")) {
-        if (strcmp(mask_setting,"ALL") == 0 || strcmp(mask_setting,"All") == 0) this_sphere_volume.geometry.mask_mode = 1;
-        else if (strcmp(mask_setting,"ANY") == 0 || strcmp(mask_setting,"Any") == 0) this_sphere_volume.geometry.mask_mode = 2;
-        else {
-            printf("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n",NAME_CURRENT_COMP,mask_setting);
-            exit(1);
-        }
+    if (mask_setting && strlen (mask_setting) && strcmp (mask_setting, "NULL") && strcmp (mask_setting, "0")) {
+      if (strcmp (mask_setting, "ALL") == 0 || strcmp (mask_setting, "All") == 0)
+        this_sphere_volume.geometry.mask_mode = 1;
+      else if (strcmp (mask_setting, "ANY") == 0 || strcmp (mask_setting, "Any") == 0)
+        this_sphere_volume.geometry.mask_mode = 2;
+      else {
+        printf ("The mask_mode of component %s is set to %s, but must be either ALL or ANY.\n", NAME_CURRENT_COMP, mask_setting);
+        exit (1);
+      }
     }
 
     int found_geometries = 0;
-    for (loop_index=0;loop_index<global_geometry_list->num_elements;loop_index++) {
-        // Add mask list
-        if (1 == manual_linking_function(global_geometry_list->elements[loop_index].name,mask_string)) {
-            add_element_to_int_list(&this_sphere_volume.geometry.mask_list,global_geometry_list->elements[loop_index].component_index);
-            add_element_to_int_list(&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list,INDEX_CURRENT_COMP);
-            global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
-            if (this_sphere_volume.geometry.mask_mode == 2)
-                global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
-            if (this_sphere_volume.geometry.mask_mode == 1) {
-                if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1 && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
-                    // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
-                    global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
-            }
-
-            found_geometries = 1;
+    for (loop_index = 0; loop_index < global_geometry_list->num_elements; loop_index++) {
+      // Add mask list
+      if (1 == manual_linking_function (global_geometry_list->elements[loop_index].name, mask_string)) {
+        add_element_to_int_list (&this_sphere_volume.geometry.mask_list, global_geometry_list->elements[loop_index].component_index);
+        add_element_to_int_list (&global_geometry_list->elements[loop_index].Volume->geometry.masked_by_list, INDEX_CURRENT_COMP);
+        global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume = 1;
+        if (this_sphere_volume.geometry.mask_mode == 2)
+          global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 2;
+        if (this_sphere_volume.geometry.mask_mode == 1) {
+          if (global_geometry_list->elements[loop_index].Volume->geometry.is_masked_volume == 1
+              && global_geometry_list->elements[loop_index].Volume->geometry.mask_mode != 2)
+            // If more than one mask is added to one volume, the ANY mode overwrites the (default) ALL mode.
+            global_geometry_list->elements[loop_index].Volume->geometry.mask_mode = 1;
         }
+
+        found_geometries = 1;
+      }
     }
     if (found_geometries == 0) {
-        printf("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n",NAME_CURRENT_COMP,mask_string);
-        exit(1);
+      printf ("The mask_string in geometry: %s did not find any of the specified volumes in the mask_string %s \n", NAME_CURRENT_COMP, mask_string);
+      exit (1);
     }
-    this_sphere_volume.p_physics = malloc(sizeof(struct physics_struct));
-    this_sphere_volume.p_physics->is_vacuum = 0; // Makes this volume a vacuum
-    this_sphere_volume.p_physics->number_of_processes = (int) 0; // Should not be used.
-    this_sphere_volume.p_physics->my_a = 0; // Should not be used.
-    sprintf(this_sphere_volume.p_physics->name,"Mask");
+    this_sphere_volume.p_physics = malloc (sizeof (struct physics_struct));
+    this_sphere_volume.p_physics->is_vacuum = 0;                // Makes this volume a vacuum
+    this_sphere_volume.p_physics->number_of_processes = (int)0; // Should not be used.
+    this_sphere_volume.p_physics->my_a = 0;                     // Should not be used.
+    sprintf (this_sphere_volume.p_physics->name, "Mask");
     this_sphere_volume.geometry.is_mask_volume = 1;
 
-
-// Read the material input, or if it lacks, use automatic linking.
-} else if (material_string && strlen(material_string) && strcmp(material_string, "NULL") && strcmp(material_string, "0")) {
+    // Read the material input, or if it lacks, use automatic linking.
+  } else if (material_string && strlen (material_string) && strcmp (material_string, "NULL") && strcmp (material_string, "0")) {
     // A geometry string was given, use it to determine which material
-    if (0 == strcmp(material_string,"vacuum") || 0 == strcmp(material_string,"Vacuum")) {
-        // One could have a global physics struct for vacuum instead of creating one for each
-        this_sphere_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_sphere_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_sphere_volume.p_physics->number_of_processes = (int) 0;
-        this_sphere_volume.p_physics->my_a = 0; // Should not be used.
-        sprintf(this_sphere_volume.p_physics->name,"Vacuum");
-    } else if (0 == strcmp(material_string,"exit") || 0 == strcmp(material_string,"Exit")) {
-        // One could have a global physics struct for vacuum instead of creating one for each
-        this_sphere_volume.p_physics = malloc(sizeof(struct physics_struct));
-        this_sphere_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
-        this_sphere_volume.p_physics->number_of_processes = (int) 0;
-        this_sphere_volume.p_physics->my_a = 0; // Should not be used.
-        this_sphere_volume.geometry.is_exit_volume = 1;
-        sprintf(this_sphere_volume.p_physics->name,"Exit");
+    if (0 == strcmp (material_string, "vacuum") || 0 == strcmp (material_string, "Vacuum")) {
+      // One could have a global physics struct for vacuum instead of creating one for each
+      this_sphere_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_sphere_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_sphere_volume.p_physics->number_of_processes = (int)0;
+      this_sphere_volume.p_physics->my_a = 0; // Should not be used.
+      sprintf (this_sphere_volume.p_physics->name, "Vacuum");
+    } else if (0 == strcmp (material_string, "exit") || 0 == strcmp (material_string, "Exit")) {
+      // One could have a global physics struct for vacuum instead of creating one for each
+      this_sphere_volume.p_physics = malloc (sizeof (struct physics_struct));
+      this_sphere_volume.p_physics->is_vacuum = 1; // Makes this volume a vacuum
+      this_sphere_volume.p_physics->number_of_processes = (int)0;
+      this_sphere_volume.p_physics->my_a = 0; // Should not be used.
+      this_sphere_volume.geometry.is_exit_volume = 1;
+      sprintf (this_sphere_volume.p_physics->name, "Exit");
     } else {
-        for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++) {
-          if (0 == strcmp(material_string,global_material_list->elements[loop_index].name)) {
-            this_sphere_volume.p_physics = global_material_list->elements[loop_index].physics;
-            break;
-          }
-          if (loop_index == global_material_list->num_elements-1) {
-            printf("\n");
-            printf("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n",material_string,NAME_CURRENT_COMP);
-            printf("       The materials available at this point (need to be defined before the geometry): \n");
-            for (loop_index=0;loop_index<global_material_list->num_elements;loop_index++)
-              printf("         %s\n",global_material_list->elements[loop_index].name);
-            printf("\n");
-            printf("       It is also possible to use one of the defualt materials avaiable: \n");
-            printf("           Vacuum (for a Volume without scattering or absorption)\n");
-            printf("           Exit (for a Volume where the ray exits the component if it enters)\n");
-            printf("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
-            exit(1);
-          }
+      for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++) {
+        if (0 == strcmp (material_string, global_material_list->elements[loop_index].name)) {
+          this_sphere_volume.p_physics = global_material_list->elements[loop_index].physics;
+          break;
         }
+        if (loop_index == global_material_list->num_elements - 1) {
+          printf ("\n");
+          printf ("ERROR: The material string \"%s\" in Union geometry \"%s\" did not match a specified material. \n", material_string, NAME_CURRENT_COMP);
+          printf ("       The materials available at this point (need to be defined before the geometry): \n");
+          for (loop_index = 0; loop_index < global_material_list->num_elements; loop_index++)
+            printf ("         %s\n", global_material_list->elements[loop_index].name);
+          printf ("\n");
+          printf ("       It is also possible to use one of the defualt materials avaiable: \n");
+          printf ("           Vacuum (for a Volume without scattering or absorption)\n");
+          printf ("           Exit (for a Volume where the ray exits the component if it enters)\n");
+          printf ("           Mask (for a Volume that masks existing volumes specified in the mask_string\n");
+          exit (1);
+        }
+      }
     }
-} else {
+  } else {
     // Automatic linking, simply using the last defined material.
     #ifndef MATERIAL_DETECTOR
-        printf("Need to define a material before the geometry to use automatic linking %s.\n",NAME_CURRENT_COMP);
-        exit(1);
+    printf ("Need to define a material before the geometry to use automatic linking %s.\n", NAME_CURRENT_COMP);
+    exit (1);
     #endif
-    this_sphere_volume.p_physics = global_material_list->elements[global_material_list->num_elements-1].physics;
-}
+    this_sphere_volume.p_physics = global_material_list->elements[global_material_list->num_elements - 1].physics;
+  }
 
-sprintf(this_sphere_volume.name,NAME_CURRENT_COMP);
-sprintf(this_sphere_volume.geometry.shape,"sphere");
-this_sphere_volume.geometry.eShape = sphere;
-this_sphere_volume.geometry.priority_value = priority;
-// Currently the coordinates will be in absolute space.
-this_sphere_volume.geometry.center = POS_A_CURRENT_COMP;
+  sprintf (this_sphere_volume.name, NAME_CURRENT_COMP);
+  sprintf (this_sphere_volume.geometry.shape, "sphere");
+  this_sphere_volume.geometry.eShape = sphere;
+  this_sphere_volume.geometry.priority_value = priority;
+  // Currently the coordinates will be in absolute space.
+  this_sphere_volume.geometry.center = POS_A_CURRENT_COMP;
 
-this_sphere_volume.geometry.geometry_p_interact = p_interact;
-this_sphere_storage.sph_radius = radius;
-this_sphere_volume.geometry.visualization_on = visualize;
-this_sphere_volume.geometry.geometry_parameters.p_sphere_storage = &this_sphere_storage;
-this_sphere_volume.geometry.within_function = &r_within_sphere;
-this_sphere_volume.geometry.intersect_function = &sample_sphere_intersect;
-this_sphere_volume.geometry.mcdisplay_function = &mcdisplay_sphere_function;
-this_sphere_volume.geometry.initialize_from_main_function = &initialize_sphere_geometry_from_main_component;
-this_sphere_volume.geometry.shell_points = &sphere_shell_points;
-this_sphere_volume.geometry.process_rot_allocated = 0;
-this_sphere_volume.geometry.copy_geometry_parameters = &allocate_sphere_storage_copy;
+  this_sphere_volume.geometry.geometry_p_interact = p_interact;
+  this_sphere_storage.sph_radius = radius;
+  this_sphere_volume.geometry.visualization_on = visualize;
+  this_sphere_volume.geometry.geometry_parameters.p_sphere_storage = &this_sphere_storage;
+  this_sphere_volume.geometry.within_function = &r_within_sphere;
+  this_sphere_volume.geometry.intersect_function = &sample_sphere_intersect;
+  this_sphere_volume.geometry.mcdisplay_function = &mcdisplay_sphere_function;
+  this_sphere_volume.geometry.initialize_from_main_function = &initialize_sphere_geometry_from_main_component;
+  this_sphere_volume.geometry.shell_points = &sphere_shell_points;
+  this_sphere_volume.geometry.process_rot_allocated = 0;
+  this_sphere_volume.geometry.copy_geometry_parameters = &allocate_sphere_storage_copy;
 
-rot_copy(this_sphere_volume.geometry.rotation_matrix,ROT_A_CURRENT_COMP);
-rot_transpose(ROT_A_CURRENT_COMP,this_sphere_volume.geometry.transpose_rotation_matrix);
+  rot_copy (this_sphere_volume.geometry.rotation_matrix, ROT_A_CURRENT_COMP);
+  rot_transpose (ROT_A_CURRENT_COMP, this_sphere_volume.geometry.transpose_rotation_matrix);
 
-// Initialize loggers
-this_sphere_volume.loggers.num_elements = 0;
-this_sphere_volume.abs_loggers.num_elements = 0;
+  // Initialize loggers
+  this_sphere_volume.loggers.num_elements = 0;
+  this_sphere_volume.abs_loggers.num_elements = 0;
 
-// packing the information into the global_geometry_element, which is then included in the global_geometry_list.
-sprintf(global_geometry_element.name,NAME_CURRENT_COMP);
-global_geometry_element.activation_counter = number_of_activations;
-global_geometry_element.component_index = INDEX_CURRENT_COMP;
-global_geometry_element.Volume = &this_sphere_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
-add_element_to_geometry_list(global_geometry_list,global_geometry_element);
+  // packing the information into the global_geometry_element, which is then included in the global_geometry_list.
+  sprintf (global_geometry_element.name, NAME_CURRENT_COMP);
+  global_geometry_element.activation_counter = number_of_activations;
+  global_geometry_element.component_index = INDEX_CURRENT_COMP;
+  global_geometry_element.Volume = &this_sphere_volume; // Would be nicer if this m was a pointer, now we have the (small) data two places
+  add_element_to_geometry_list (global_geometry_list, global_geometry_element);
 %}
 
 TRACE

--- a/mcxtrace-comps/union/Union_sphere.comp
+++ b/mcxtrace-comps/union/Union_sphere.comp
@@ -68,7 +68,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
   #ifndef Union
-  #error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
+  #error "ERROR: Union_sphere requires the Union library. Add a Union_master component to load the libraries."
 
   #endif
 

--- a/mcxtrace-comps/union/Union_sphere.comp
+++ b/mcxtrace-comps/union/Union_sphere.comp
@@ -69,8 +69,7 @@ OUTPUT PARAMETERS ()
 SHARE
 %{
 #ifndef Union
-#define Union $Revision: 0.8 $
-
+#error "Union library not loaded: the instrument has no Union_master. Add a Union_master (or Union_master_GPU) so the code generator loads it."
 
 #endif
 

--- a/mcxtrace-comps/union/Union_stop.comp
+++ b/mcxtrace-comps/union/Union_stop.comp
@@ -6,39 +6,36 @@
 * %I
 * Written by: Mads Bertelsen and Erik B Knudsen
 * Date: 20.08.15
+* Version: $Revision: 0.1 $
 * Origin: ESS DMSC & DTU Physics
 *
-* Stop component that must be placed after all Union components for instrument to compile correctly
+* Deprecated no-op placeholder, kept for backward compatibility.
 *
 * %D
 * Part of the Union components, a set of components that work together and thus
 *  separates geometry and physics within McXtrace.
-* The use of this component requires other components to be used.
 *
-* 1) One specifies a number of processes using process components
-* 2) These are gathered into material definitions using Union_make_material
-* 3) Geometries are placed using Union_box/cylinder/sphere, assigned a material
-* 4) A Union_master component placed after all of the above
+* This component used to be required as the LAST component. It pulled in the
+*  dispatch switch (union-suffix.c) so it would be compiled after all the
+*  process components had defined their PROCESS DETECTOR macros.
 *
-* Only in step 4 will any simulation happen, and per default all geometries
-*  defined before this master, but after the previous will be simulated here.
+* That is no longer needed: the code generator now detects that the instrument
+*  uses Union (by the presence of a Union_master) and auto-injects the dispatch
+*  switch after all the component SHARE sections. The Union_init and
+*  Union_stop components are therefore optional.
 *
-* There is a dedicated manual available for the Union components
-*
-* Algorithm:
-* Described elsewhere
+* This definition is kept only so that existing instruments that still place a
+*  Union_stop component continue to compile. It has no effect.
 *
 * %P
 * INPUT PARAMETERS:
 *
 * OUTPUT PARAMETERS:
 *
-* GLOBAL PARAMETERS:
-*
 * %L
 *
 * %E
-******************************************************************************/
+ ******************************************************************************/
 
 DEFINE COMPONENT Union_stop
 DEFINITION PARAMETERS ()
@@ -49,15 +46,6 @@ OUTPUT PARAMETERS ()
 
 SHARE
 %{
-#ifndef Union
-#define Union $Revision: 0.8 $
-
-
-%include "union-init.c"
-
-#endif
-
-%include "union-suffix.c"
 %}
 
 DECLARE

--- a/mcxtrace-comps/union/Union_stop.comp
+++ b/mcxtrace-comps/union/Union_stop.comp
@@ -46,6 +46,10 @@ OUTPUT PARAMETERS ()
 
 SHARE
 %{
+#ifndef UNION_SUFFIX_C
+/* Compatibility path for code generators without Union auto-injection. */
+%include "union-suffix.c"
+#endif
 %}
 
 DECLARE

--- a/mcxtrace-comps/union/Union_stop.comp
+++ b/mcxtrace-comps/union/Union_stop.comp
@@ -25,7 +25,8 @@
 *  Union_stop components are therefore optional.
 *
 * This definition is kept only so that existing instruments that still place a
-*  Union_stop component continue to compile. It has no effect.
+*  Union_stop component continue to compile. It emits a deprecation warning
+*  and has no effect.
 *
 * %P
 * INPUT PARAMETERS:
@@ -44,20 +45,9 @@ OUTPUT PARAMETERS ()
 
 /* X-ray parameters: (x,y,z,kx,ky,kz ,phi, t, Ex,Ey,Ez,p) */
 
-SHARE
-%{
-  #ifndef UNION_SUFFIX_C
-  /* Compatibility path for code generators without Union auto-injection. */
-  %include "union-suffix.c"
-  #endif
-%}
-
-DECLARE
-%{
-%}
-
 INITIALIZE
 %{
+  MPI_MASTER (printf ("WARNING: Union_stop is deprecated; Union components finalize automatically.\n"););
 %}
 
 END

--- a/mcxtrace-comps/union/Union_stop.comp
+++ b/mcxtrace-comps/union/Union_stop.comp
@@ -46,10 +46,10 @@ OUTPUT PARAMETERS ()
 
 SHARE
 %{
-#ifndef UNION_SUFFIX_C
-/* Compatibility path for code generators without Union auto-injection. */
-%include "union-suffix.c"
-#endif
+  #ifndef UNION_SUFFIX_C
+  /* Compatibility path for code generators without Union auto-injection. */
+  %include "union-suffix.c"
+  #endif
 %}
 
 DECLARE


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

This is a suggestion on how to avoid the need for the Union_init and Union_stop components. Today they serve
two functions:

- Add the .c code files at start and end so the preprocessor can limit what code is actually compiled
- Provide "global" variables in the init, other Union components communicated through GETPAR things

This branch simply does these things in the cogen by checking if a Union_master or Union_master_GPU is in the instrument. This is to avoid more invasive things like tagging all the Union components, but other suggestions for detecting when to trigger including union globals and libraries.

Instruments with Union_init and Union_stop will continue to work, just show deprecation warnings. Instruments that use the init parameter on Union components explicitly will break as that parameter is not available anymore (mcstas-pygen generated instruments might be extra susceptible to this, as all parameters are always specified).

--------------
### Declaration of use of AI-tools
* [X] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution includes patches to an **existing component** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [X] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [X] I have used the `mctest` utility to **test** one or more instruments making use of the component (please attach `mcviewtest` report as screenshot in comments)
  * [X] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes patches to an **existing** instrument file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have used the `mctest` utility to **test** the instrument (please attach `mcviewtest` report as screenshot in comments)
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
* ### My contribution includes a **new component** file
  * [ ] I have ensured that naming of parameters are in the style of existing components. (Please check the [McStas](https://github.com/mccode-dev/McCode/blob/main/mcstas-comps/NOMENCLATURE.md) or [McXtrace](https://github.com/mccode-dev/McCode/blob/main/mcxtrace-comps/NOMENCLATURE) NOMENCLATURE docs.)
  * [ ] I have ensured that component parameters are in the usually units of McStas or McXtrace (SI + neutron/x-ray 'usual' units)
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the component (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the component is OK (e.g. an instrument using it compiles?)
  * [ ] I have included a corresponding **example** instrument and will fill in the **new instrument** section below
  * [ ] I have used the `mccode-clangformat` tool to apply the standard McCode component indentation scheme
  * [ ] My new component is added within the `contrib` component category
* ### My contribution includes a **new instrument** file
  * [ ] I have used the `mcdoc` utility and **rendered** a reasonable documentation page for the instrument (please attach as screenshot in comments!)
  * [ ] I have ensured that basic use of the instrument is OK (e.g. it compiles?)
  * [ ] ... and provided reasonable default parameters in that instrument that produce reasonable output
  * [ ] ... and maybe even added a `%Example:` line to describe expected behaviour
  * [ ] I have used the `mcrun --c-lint` "linter" and followed advice to remove most / all warnings that are raised
  * [ ] My new instrument is added within the `examples` hierarchy in a folder in the style of `examples/ESS/New_stuff/New_stuff.instr`
  * [ ] My new instrument has a new, unique filename, not clashing with existing example instruments
  * [ ] My new instrument requires a data/input file. If the datafile is _specific_ for my instrument I have left it in the same `example` folder, but if general use I have placed it in the global `data` folder.
* ### My work touches the code-generator in mccode/src
  * [X] I have added reasoning and documentation for the change through an ADR record in our [GRAMMAR](https://github.com/mccode-dev/McCode/tree/main/docs/GRAMMAR) section
  * [ ] I am attaching test output in the comments
* ### My work touches / adds to the runtime lib code (.c,.h etc in multiple locations
  * [X] I am have added reasoning and documentation for the change below
  * [ ] I am attaching test output in the comments
* ### My PR is meant to fix a specific, existing issue
  * [ ] I have indicated the issue number here:
  * [ ] I have added documentation for the fix and possible side effects
* ### My contribution contains something else
  * [ ] Explanation is added in free form text above or below the checklist

--------------



