### PR TITLE
If ${SDKROOT} is set - use it instead of calling xcrun

### DIFF
--- a/devel/bin/mccode-build-conda
+++ b/devel/bin/mccode-build-conda
@@ -43,7 +43,7 @@ def detect_condaprefix():
 
 def mccode_build_conda ( cfg ):
 
-    if ( cfg.is_mac ):
+    if ( cfg.is_mac and not os.environ["SDKROOT"]):
         os.environ["SDKROOT"] = runcmd(['xcrun','--sdk','macosx',
                                         '--show-sdk-path'],
                                        capture_output = True).strip()

--- a/devel/bin/mccode-build-conda
+++ b/devel/bin/mccode-build-conda
@@ -43,10 +43,11 @@ def detect_condaprefix():
 
 def mccode_build_conda ( cfg ):
 
-    if ( cfg.is_mac and not os.environ["SDKROOT"]):
-        os.environ["SDKROOT"] = runcmd(['xcrun','--sdk','macosx',
-                                        '--show-sdk-path'],
-                                       capture_output = True).strip()
+    if ( cfg.is_mac ):
+        if not "SDKROOT" in os.environ:
+            os.environ["SDKROOT"] = runcmd(['xcrun','--sdk','macosx',
+                                            '--show-sdk-path'],
+                                        capture_output = True).strip()
 
     conda_prefix = detect_condaprefix()
 


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

**Compilation issues on macOS:**
* After my mac upgraded to a new version of command-line tools for Xcode, the `xcrun` resolved to
```
xcrun --sdk macosx --show-sdk-path
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
```
... which broke my compilation completely - see below.

* This seems to new for current `conda-forge` builds... The workaround is to set:
```
export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX26.5.sdk/
```

This PR provides a workaround by allowing the `devel` tool allows to use an existing `SDKROOT` if already set.


_______________
Compile log before the PR changes

```
ld: warning: ignoring file /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd, malformed file
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd:4:20: error: unknown architecture
                   arm64e.x1-macos, arm64e.x1-maccatalyst ]
                   ^~~~~~~~~~~~~~~

ld: warning: ignoring file /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libm.tbd, malformed file
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libm.tbd:4:20: error: unknown architecture
                   arm64e.x1-macos, arm64e.x1-maccatalyst ]
                   ^~~~~~~~~~~~~~~

Undefined symbols for architecture arm64:
  "___error", referenced from:
      _main in cc-370876.o
      ....```
```




--------------
### Declaration of use of AI-tools
* [ ] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



