### PR TITLE
mccoplot: legend / title suppression

### DIFF
--- a/tools/Python/mcplot/html/mccoplot.py
+++ b/tools/Python/mcplot/html/mccoplot.py
@@ -29,6 +29,7 @@ template_1d_coplot.html.
 import argparse
 import logging
 import os
+import re
 import sys
 import json
 import subprocess
@@ -130,7 +131,13 @@ def _legend_rows_html(letters, colours, dat_links):
 def get_html(params_list_json, legend_rows_html):
     text = open(os.path.join(os.path.dirname(__file__), 'template_1d_coplot.html')).read()
     text = text.replace("@PARAMS_LIST@", params_list_json)
-    text = text.replace("@LEGEND_ROWS@", legend_rows_html)
+    if legend_rows_html:
+        text = text.replace("@LEGEND_ROWS@", legend_rows_html)
+    else:
+        # --no-legends: drop the whole legend <div> (not just its rows) -
+        # otherwise its background/border styling would still render as
+        # an empty box in the corner of the plot.
+        text = re.sub(r'<div class="coplot-legend">\s*@LEGEND_ROWS@\s*</div>\n?', '', text)
     logscalestr = "true" if logscale else "false"
     text = text.replace("@LOGSCALE@", logscalestr)
     text = text.replace("@LIBPATH@", libpath)
@@ -181,7 +188,8 @@ def browse(html_filepath):
 # per-monitor plot writer
 # ---------------------------------------------------------------------------
 
-def coplot_single(key, datas, outdir, use_logscale, colours, dat_links, identities):
+def coplot_single(key, datas, outdir, use_logscale, colours, dat_links, identities,
+                   no_legends=False, no_titles=False):
     """ Writes one co-plot (overlaid N-dataset) monitor page to outdir.
         Returns the file path written. """
     global logscale
@@ -195,14 +203,21 @@ def coplot_single(key, datas, outdir, use_logscale, colours, dat_links, identiti
         os.remove(f)
 
     letters = _legend_letters(len(datas))
-    title_0 = _title_for(datas, identities)
+    # Empty string, not just omitted: _draw_labels() in plotfuncs.js
+    # measures the title text's own actual rendered height (getBBox()) to
+    # size the plot area, so an empty title genuinely gives the plot more
+    # vertical room rather than just leaving blank space where the title
+    # used to be - useful with many co-plotted datasets, where the
+    # verbose title (one "letter=label: I=... Err=... N=..." line per
+    # dataset) can end up taller than the plot itself.
+    title_0 = '' if no_titles else _title_for(datas, identities)
 
     params_list = [get_params_json(datas[0], colours[0], title_0)]
     for data, colour in zip(datas[1:], colours[1:]):
         params_list.append(get_params_json(data, colour, ""))  # only dataset 0's title is used (see template)
     params_list_json = '[\n' + ',\n'.join(params_list) + '\n]'
 
-    legend_rows_html = _legend_rows_html(letters, colours, dat_links)
+    legend_rows_html = '' if no_legends else _legend_rows_html(letters, colours, dat_links)
 
     text = get_html(params_list_json, legend_rows_html)
 
@@ -435,15 +450,18 @@ def main(args):
             lin, log = find_original_plot(d, data.filename)
             dat_links.append(_relhref(lin, outdir))
 
-        f = coplot_single(key, datas, outdir, False, colours, dat_links, identities)
+        f = coplot_single(key, datas, outdir, False, colours, dat_links, identities,
+                           no_legends=args.no_legends, no_titles=args.no_titles)
         f_log = None
         if single_input:
             if args.log:
-                f_log = coplot_single(key, datas, outdir, True, colours, dat_links, identities)
+                f_log = coplot_single(key, datas, outdir, True, colours, dat_links, identities,
+                                       no_legends=args.no_legends, no_titles=args.no_titles)
         else:
             # folder mode: always produce both linear and log variants,
             # exactly like mcplotdiff.py does for multi-monitor overviews
-            f_log = coplot_single(key, datas, outdir, True, colours, dat_links, identities)
+            f_log = coplot_single(key, datas, outdir, True, colours, dat_links, identities,
+                                   no_legends=args.no_legends, no_titles=args.no_titles)
 
         entries.append({'coplot': f, 'coplot_log': f_log})
         print("Generated: %s" % f)
@@ -484,6 +502,15 @@ if __name__ == '__main__':
                               'default: %s' % ', '.join(DEFAULT_PALETTE))
     parser.add_argument('-W', '--width', nargs=1, help='width of iframes')
     parser.add_argument('-H', '--height', nargs=1, help='height of iframes')
+    parser.add_argument('--no-legends', action='store_true', default=False,
+                         help='do not draw the on-plot legend box (the compact A/B/C/... letters, '
+                              'plus "view original plot" links) - useful with many co-plotted '
+                              'datasets, where the legend box itself can grow tall enough to cover '
+                              'a large part of the plot')
+    parser.add_argument('--no-titles', action='store_true', default=False,
+                         help='do not draw the in-plot title or the "A=.../B=..." dataset identity '
+                              'block - useful with many co-plotted datasets, where the verbose title '
+                              '(one line per dataset) can end up taller than the plot itself')
     args = parser.parse_args()
 
     main(args)

--- a/tools/Python/mcplot/matplotlib/mccoplot.py
+++ b/tools/Python/mcplot/matplotlib/mccoplot.py
@@ -64,6 +64,27 @@ def _legend_letters(n):
     return ['S%d' % i for i in range(n)]
 
 
+def _build_verbose_title_lines(datas, labels):
+    ''' The per-line breakdown of a single-monitor co-plot's verbose title:
+        component/filename, the monitor's own title, then one
+        "letter=label: I=... Err=... N=...; statistics" line per
+        co-plotted dataset. Shared between _plot_coplot_panel()'s in-plot
+        title and McCoplotPlotter._render()'s separate title side-window
+        (see show_text_window() in plotfuncs.py), so a long dataset list's
+        title text can be moved out of the main plot entirely (via
+        --no-titles) without the information simply being lost. '''
+    d0 = datas[0]
+    try:
+        letters = _legend_letters(len(datas))
+        lines = ['%s [%s]' % (d0.component, d0.filename), d0.title]
+        for data, letter, label in zip(datas, letters, labels):
+            lines.append('%s=%s: I=%s Err=%s N=%s; %s' % (
+                letter, label, data.values[0], data.values[1], data.values[2], data.statistics))
+        return lines
+    except Exception:
+        return ['%s [%s]' % (d0.component, d0.filename)]
+
+
 def _plot_coplot_panel(datas, labels, colours, i, n, log, no_legends=False, no_titles=False):
     ''' plot one overlaid N-dataset group into subplot i of n '''
     dims = plotfuncs._calc_panel_size(n)
@@ -114,15 +135,7 @@ def _plot_coplot_panel(datas, labels, colours, i, n, log, no_legends=False, no_t
     # plot itself.
     if not no_titles:
         if verbose:
-            try:
-                letters = _legend_letters(len(datas))
-                lines = ['%s [%s]' % (d0.component, d0.filename), d0.title]
-                for data, letter, label in zip(datas, letters, labels):
-                    lines.append('%s=%s: I=%s Err=%s N=%s; %s' % (
-                        letter, label, data.values[0], data.values[1], data.values[2], data.statistics))
-                title = '\n'.join(lines)
-            except Exception:
-                title = '%s [%s]' % (d0.component, d0.filename)
+            title = '\n'.join(_build_verbose_title_lines(datas, labels))
         else:
             title = '%s [%s]' % (d0.component, d0.filename)
         title = plotfuncs._wrap_title(title, plotfuncs._title_wrap_width(n, title_fontsize))
@@ -165,6 +178,15 @@ class McCoplotPlotter():
         self.no_titles = no_titles
         self.current = None  # None = overview grid; else index into self.pairs
         self.event_dc_cid = None
+        # Separate side windows (see _render()) shown only for the
+        # single-monitor drill-down (n==1) view, when --no-titles/
+        # --no-legends have freed up the main plot but the information
+        # itself shouldn't just disappear. Tracked explicitly (rather than
+        # relying on matplotlib's own "current figure") so they can be
+        # closed by reference on every re-render, including when
+        # navigating away from the single-monitor view entirely.
+        self.title_window = None
+        self.legend_window = None
 
     def _flip_log(self):
         self.log = not self.log
@@ -193,7 +215,24 @@ class McCoplotPlotter():
         plotfuncs.keypress(event, back_cb=self._show_overview, replot_cb=self._replot,
                             togglelog_cb=self._flip_log)
 
-    def _render(self):
+    def _close_side_windows(self):
+        ''' Closes any previously-open title/legend side windows by direct
+            reference (see __init__'s note on why not via matplotlib's own
+            "current figure") - called at the start of every _render(), so
+            a stale side window from a previous single-monitor view never
+            lingers after navigating to a different monitor or back to the
+            overview grid. '''
+        for attr in ('title_window', 'legend_window'):
+            fig = getattr(self, attr)
+            if fig is not None:
+                try:
+                    plotfuncs.pylab.close(fig)
+                except Exception:
+                    pass
+                setattr(self, attr, None)
+
+    def _render(self, side_windows=True):
+        self._close_side_windows()
         visible = self._visible_pairs()
         n = len(visible)
         fig_w, fig_h = plotfuncs._figure_size(n)
@@ -268,6 +307,34 @@ class McCoplotPlotter():
         else:
             self.click_cbs = []
 
+        # Single-monitor view only ("not an overview-plot", per the actual
+        # request this responds to): when --no-titles/--no-legends have
+        # freed up the main plot, open a separate, full-screen-height,
+        # narrow side window for each piece of information that was
+        # removed, rather than losing it outright. side_windows=False (see
+        # html()) skips this entirely for the non-interactive mpld3 export
+        # path, where a GUI side window would serve no purpose and could
+        # even fail outright in a headless export context.
+        if side_windows and n == 1:
+            datas = visible[0][1]
+            if self.no_titles:
+                lines = [(line, None) for line in _build_verbose_title_lines(datas, self.labels)]
+                self.title_window = plotfuncs.show_text_window(lines, 'mccoplot: title')
+            if self.no_legends:
+                letters = _legend_letters(len(datas))
+                legend_lines = [('%s = %s' % (letter, label), colour)
+                                 for letter, label, colour in zip(letters, self.labels, self.colours)]
+                self.legend_window = plotfuncs.show_text_window(legend_lines, 'mccoplot: legend')
+            # Side windows created above (via plotfuncs.pylab.figure())
+            # become matplotlib's new "current figure" - restore the main
+            # plot figure as current before returning, since _replot()'s
+            # own pylab.close() (no arguments - see its docstring) closes
+            # whatever figure is current at the time, and needs that to
+            # still be THIS figure on the next call, not a leftover side
+            # window.
+            if self.title_window is not None or self.legend_window is not None:
+                plotfuncs.pylab.figure(fig.number)
+
         return fig
 
     def _replot(self):
@@ -300,7 +367,7 @@ class McCoplotPlotter():
         ''' render and save to html using mpld3 '''
         import mpld3
         plotfuncs.pylab.close()
-        self._render()
+        self._render(side_windows=False)
         mpld3.save_html(plotfuncs.pylab.gcf(), fileobj)
 
 

--- a/tools/Python/mcplot/matplotlib/mccoplot.py
+++ b/tools/Python/mcplot/matplotlib/mccoplot.py
@@ -64,7 +64,7 @@ def _legend_letters(n):
     return ['S%d' % i for i in range(n)]
 
 
-def _plot_coplot_panel(datas, labels, colours, i, n, log):
+def _plot_coplot_panel(datas, labels, colours, i, n, log, no_legends=False, no_titles=False):
     ''' plot one overlaid N-dataset group into subplot i of n '''
     dims = plotfuncs._calc_panel_size(n)
     subplt = plotfuncs.pylab.subplot(dims[1], dims[0], i + 1)
@@ -107,24 +107,36 @@ def _plot_coplot_panel(datas, labels, colours, i, n, log):
     # every dataset's identity/I/statistics) once drilled down to a single
     # panel - the same "verbose only at n==1" convention
     # plotfuncs.plot_single_data uses for ordinary (non-coplot) monitors.
-    if verbose:
-        try:
-            letters = _legend_letters(len(datas))
-            lines = ['%s [%s]' % (d0.component, d0.filename), d0.title]
-            for data, letter, label in zip(datas, letters, labels):
-                lines.append('%s=%s: I=%s Err=%s N=%s; %s' % (
-                    letter, label, data.values[0], data.values[1], data.values[2], data.statistics))
-            title = '\n'.join(lines)
-        except Exception:
+    # Skipped entirely (no pylab.title() call at all, not just an empty
+    # one) when no_titles is set - for a long list of co-plotted datasets
+    # the verbose form in particular grows by one line per dataset, and at
+    # 20+ datasets can end up taking more vertical space than the actual
+    # plot itself.
+    if not no_titles:
+        if verbose:
+            try:
+                letters = _legend_letters(len(datas))
+                lines = ['%s [%s]' % (d0.component, d0.filename), d0.title]
+                for data, letter, label in zip(datas, letters, labels):
+                    lines.append('%s=%s: I=%s Err=%s N=%s; %s' % (
+                        letter, label, data.values[0], data.values[1], data.values[2], data.statistics))
+                title = '\n'.join(lines)
+            except Exception:
+                title = '%s [%s]' % (d0.component, d0.filename)
+        else:
             title = '%s [%s]' % (d0.component, d0.filename)
-    else:
-        title = '%s [%s]' % (d0.component, d0.filename)
-    title = plotfuncs._wrap_title(title, plotfuncs._title_wrap_width(n, title_fontsize))
-    plotfuncs.pylab.title(title, fontsize=title_fontsize, fontweight='bold')
+        title = plotfuncs._wrap_title(title, plotfuncs._title_wrap_width(n, title_fontsize))
+        plotfuncs.pylab.title(title, fontsize=title_fontsize, fontweight='bold')
 
-    leg = plotfuncs.pylab.legend(loc='upper left', fontsize=title_fontsize, framealpha=0.85,
-                                  handlelength=1.2, handletextpad=0.5, borderpad=0.4)
-    leg.set_draggable(True)
+    # Legend similarly skipped entirely (not just made invisible) when
+    # no_legends is set - with many co-plotted datasets the legend box
+    # itself (one row per dataset) can grow tall enough to cover a large
+    # fraction of the panel, which is exactly the "can't see the actual
+    # plots" problem this option exists to avoid.
+    if not no_legends:
+        leg = plotfuncs.pylab.legend(loc='upper left', fontsize=title_fontsize, framealpha=0.85,
+                                      handlelength=1.2, handletextpad=0.5, borderpad=0.4)
+        leg.set_draggable(True)
 
     return subplt
 
@@ -143,12 +155,14 @@ class McCoplotPlotter():
         primaries/secondaries to sweep through), click_cbs is simply empty
         once drilled down - only the back-navigation remains active. '''
 
-    def __init__(self, pairs, labels, colours, log, identity_note=None):
+    def __init__(self, pairs, labels, colours, log, identity_note=None, no_legends=False, no_titles=False):
         self.pairs = pairs  # [(key, [data_0, ..., data_N-1]), ...]
         self.labels = labels
         self.colours = colours
         self.log = log
         self.identity_note = identity_note
+        self.no_legends = no_legends
+        self.no_titles = no_titles
         self.current = None  # None = overview grid; else index into self.pairs
         self.event_dc_cid = None
 
@@ -186,30 +200,42 @@ class McCoplotPlotter():
         fig = plotfuncs.pylab.figure(figsize=(fig_w, fig_h))
 
         self.subplts = [
-            _plot_coplot_panel(datas, self.labels, self.colours, i, n, self.log)
+            _plot_coplot_panel(datas, self.labels, self.colours, i, n, self.log,
+                                no_legends=self.no_legends, no_titles=self.no_titles)
             for i, (key, datas) in enumerate(visible)
         ]
 
         if n == 1:
-            # Single-panel drill-down: the verbose title now includes one
-            # letter=label identity line per dataset (in addition to the
-            # existing component/filename/monitor-title/stats lines), so
-            # its height grows with how many datasets are co-plotted - a
-            # fixed top margin tuned for the old, shorter title clipped the
-            # top lines off the figure entirely once there were more than
-            # a couple of datasets. Scale the margin down (more headroom)
-            # as N grows; this is a rough heuristic; matches the
-            # established style of _title_wrap_width()'s own "good enough"
-            # character-width estimate rather than exact text measurement.
-            n_datasets = len(visible[0][1])
-            top = max(0.45, 0.95 - 0.045 * n_datasets)
+            if self.no_titles:
+                # No title text is drawn at all in this case (see
+                # _plot_coplot_panel()), so there's nothing to reserve
+                # extra vertical space for - use the same generous margin
+                # as the overview grid case below, rather than the
+                # dataset-count-scaled one a few lines down (which exists
+                # specifically to make room for the verbose title that
+                # isn't being drawn here).
+                top = 0.97
+            else:
+                # Single-panel drill-down: the verbose title now includes
+                # one letter=label identity line per dataset (in addition
+                # to the existing component/filename/monitor-title/stats
+                # lines), so its height grows with how many datasets are
+                # co-plotted - a fixed top margin tuned for the old,
+                # shorter title clipped the top lines off the figure
+                # entirely once there were more than a couple of datasets.
+                # Scale the margin down (more headroom) as N grows; this is
+                # a rough heuristic, matching the established style of
+                # _title_wrap_width()'s own "good enough" character-width
+                # estimate rather than exact text measurement.
+                n_datasets = len(visible[0][1])
+                top = max(0.45, 0.95 - 0.045 * n_datasets)
             fig.subplots_adjust(left=0.06, right=0.98, top=top, bottom=0.06,
                                  wspace=0.3, hspace=0.35)
         else:
             fig.subplots_adjust(left=0.06, right=0.98, top=0.97, bottom=0.06,
                                  wspace=0.3, hspace=0.35)
 
-        if self.identity_note and n > 1:
+        if self.identity_note and n > 1 and not self.no_titles:
             # The legend now always uses compact positional letters
             # (_legend_letters()), never the real labels directly (which
             # may now be a full input path - see resolve_labels()) - shown
@@ -359,7 +385,8 @@ def main(args):
         # use running many comparisons out of one working directory.
         plotfuncs.filenamebase = "coplot_" + "_vs_".join(diffloader.dirsafe_name(p) for p in paths)
 
-        plotter = McCoplotPlotter(pairs, labels, colours, log=args.log, identity_note=identity_note)
+        plotter = McCoplotPlotter(pairs, labels, colours, log=args.log, identity_note=identity_note,
+                                   no_legends=args.no_legends, no_titles=args.no_titles)
 
         if (sys.platform == "linux" or sys.platform == "linux2") and args.html:
             # save to html and exit
@@ -401,6 +428,14 @@ if __name__ == '__main__':
                               '(e.g. pdf/png/eps/svg) can be specified in the file name or --format')
     parser.add_argument('--log', action='store_true', help='initiate plot(s) with log of signal')
     parser.add_argument('--backend', dest='backend', help='use non-default backend for matplotlib plot')
+    parser.add_argument('--no-legends', action='store_true', default=False,
+                         help='do not draw the per-panel legend (the compact A/B/C/... letters) - '
+                              'useful with many co-plotted datasets, where the legend box itself can '
+                              'grow tall enough to cover a large part of the panel')
+    parser.add_argument('--no-titles', action='store_true', default=False,
+                         help='do not draw panel titles or the figure-level dataset identity note - '
+                              'useful with many co-plotted datasets, where the verbose single-panel '
+                              'title (one line per dataset) can end up taller than the plot itself')
 
     args = parser.parse_args()
 

--- a/tools/Python/mcplot/matplotlib/plotfuncs.py
+++ b/tools/Python/mcplot/matplotlib/plotfuncs.py
@@ -11,6 +11,7 @@ simulation's plot graph.
 import os
 import sys
 import math
+import subprocess
 import textwrap
 import numpy as np
 
@@ -131,6 +132,84 @@ def _wrap_title(title, width):
         textwrap.fill(line, width=width) if line else line
         for line in title.split('\n')
     )
+
+
+def _screen_size_inches():
+    ''' Best-effort (width, height) of the primary screen, in inches - used
+        to size a side window to the full available screen height (see
+        show_text_window()).
+
+        Queried via a throwaway tkinter root window, but critically NOT in
+        this process directly: on at least one real-world macOS/Tcl-Tk/
+        Python combination, merely initialising a Tk root window crashed
+        with a native NSInvalidArgumentException
+        ('-[NSApplication macOSVersion]: unrecognized selector') that
+        aborted the WHOLE process via SIGABRT. That is a native Objective-C
+        /Tcl-level crash, not a Python exception - no try/except in this
+        process can catch or survive it, so the try/except below is only
+        useful against ordinary Python-level failures (tkinter missing,
+        no display, etc), not this one. Running the actual query in a
+        short-lived subprocess instead means that if IT crashes, only that
+        throwaway subprocess dies - this process (and any plot window(s)
+        it's already showing) are completely unaffected, and this just
+        falls back to the generic default below exactly as if tkinter or a
+        display simply weren't available at all. '''
+    try:
+        result = subprocess.run(
+            [sys.executable, '-c',
+             'import tkinter\n'
+             'r = tkinter.Tk()\n'
+             'r.withdraw()\n'
+             'print(r.winfo_screenwidth(), r.winfo_screenheight(), r.winfo_fpixels("1i"))\n'
+             'r.destroy()\n'],
+            capture_output=True, text=True, timeout=5)
+        if result.returncode == 0 and result.stdout.strip():
+            px_w, px_h, dpi = (float(v) for v in result.stdout.split())
+            if px_w > 0 and px_h > 0 and dpi > 0:
+                return px_w / dpi, px_h / dpi
+    except Exception:
+        pass
+    return (14.0, 8.0)  # roughly a 1920x1080-at-96dpi display, in inches
+
+
+def show_text_window(lines, window_title, width_in=4.5):
+    ''' Opens a separate, tall (full screen height), narrow matplotlib
+        figure with `lines` (a list of (text, colour) tuples, one per row -
+        colour=None for the default black) placed top-to-bottom, font size
+        scaled down as needed so all of them fit within the window's
+        height. Used for mccoplot-matplotlib's "single monitor" title/
+        legend side windows (see McCoplotPlotter._render() in mccoplot.py):
+        with many co-plotted datasets, a long title/legend no longer has
+        to compete with the main plot for space (that's what --no-titles/
+        --no-legends already achieve), but the information isn't simply
+        lost either - it moves to its own appropriately-sized window
+        instead. Returns the new Figure, so the caller can track and
+        explicitly close it later (it deliberately does NOT rely on
+        matplotlib's own "current figure" bookkeeping for that, since a
+        side window shouldn't become "current" out from under the main
+        plot window's own close/redraw cycle). '''
+    screen_w_in, screen_h_in = _screen_size_inches()
+    width_in = min(width_in, screen_w_in * 0.3)
+    fig = pylab.figure(figsize=(width_in, screen_h_in))
+    try:
+        fig.canvas.manager.set_window_title(window_title)
+    except Exception:
+        pass  # not every backend supports a custom window title
+
+    n_lines = max(1, len(lines))
+    top_margin = 0.02
+    usable_h_in = screen_h_in * (1.0 - 2 * top_margin)
+    # 1.5x line spacing, clamped to a sane readable range regardless of how
+    # few or many lines there are.
+    fontsize = min(16, max(6, (usable_h_in * 72) / (n_lines * 1.5)))
+    line_height = (1.0 - 2 * top_margin) / n_lines
+
+    for i, (text, colour) in enumerate(lines):
+        y = 1.0 - top_margin - i * line_height
+        fig.text(0.04, y, text, fontsize=fontsize, va='top', ha='left',
+                  color=colour or 'black', family='monospace')
+
+    return fig
 
 
 def plot_single_data(node, i, n, log):

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -132,7 +132,7 @@ def _legend_fontsize(n_datasets, base_fontsize):
         return max(6, base_fontsize - 4)
 
 
-def plot_coplot_1D(datas, plt, labels, colours, log=False, legend=True, fontsize=10, verbose=False):
+def plot_coplot_1D(datas, plt, labels, colours, log=False, legend=True, fontsize=10, verbose=False, show_title=True):
     ''' overlay N Data1D objects (datas) into the pyqtgraph PlotItem plt '''
     d0 = datas[0]
     series = []  # (x, y, e) per dataset
@@ -161,13 +161,21 @@ def plot_coplot_1D(datas, plt, labels, colours, log=False, legend=True, fontsize
     xmax = max(np.max(x) for x, y, e in series)
     plt.setXRange(xmin, xmax, padding=0)
 
-    try:
-        header = '%s [%s]' % (d0.component, d0.filename)
-        if verbose:
-            header = '%s [%s]<br>%s' % (d0.component, d0.filename, d0.title)
-    except Exception:
-        header = '%s' % d0.component
-    plt.setTitle(header)
+    # Title skipped entirely (not just set to an empty string) when
+    # show_title is False - for a long list of co-plotted datasets the
+    # verbose header in particular grows with the number of datasets, and
+    # PlotItem's title row doesn't reliably auto-grow to fit it (see
+    # McCoplotPlotter._render()'s own note on this same limitation for the
+    # identity_note header), so at high N it can end up clipping into or
+    # crowding out the actual plot area.
+    if show_title:
+        try:
+            header = '%s [%s]' % (d0.component, d0.filename)
+            if verbose:
+                header = '%s [%s]<br>%s' % (d0.component, d0.filename, d0.title)
+        except Exception:
+            header = '%s' % d0.component
+        plt.setTitle(header)
     plt.getAxis('bottom').setLabel(d0.xlabel)
     plt.getAxis('left').setLabel(d0.ylabel)
 
@@ -214,12 +222,14 @@ class McCoplotPlotter():
         is live there. '''
 
     def __init__(self, pairs, labels, colours, invcanvas=False, title=None,
-                 identity_note=None, filenamebase=None):
+                 identity_note=None, filenamebase=None, no_legends=False, no_titles=False):
         self.pairs = pairs  # [(key, [data_0, ..., data_N-1]), ...]
         self.labels = labels
         self.colours = colours
         self.log = False
         self.identity_note = identity_note
+        self.no_legends = no_legends
+        self.no_titles = no_titles
         self.current = None  # None = overview grid; else index into self.pairs
         self.viewbox_list = []
         self.title = title if title is not None else ('coplot: %s' % ' vs '.join(labels))
@@ -315,7 +325,7 @@ class McCoplotPlotter():
         rowlen = max(1, int(math.sqrt(n * 1.61803398875)))
 
         row_offset = 0
-        if self.identity_note:
+        if self.identity_note and not self.no_titles:
             # The legend now always uses compact positional letters
             # (_legend_letters()), never the real labels directly - this
             # header row is what maps each letter back to its actual
@@ -359,7 +369,8 @@ class McCoplotPlotter():
         for i, (key, datas) in enumerate(visible):
             plt = pg.PlotItem()
             vb = plot_coplot_1D(datas, plt, self.labels, self.colours,
-                                 log=self.log, fontsize=fontsize, verbose=verbose)
+                                 log=self.log, fontsize=fontsize, verbose=verbose,
+                                 legend=not self.no_legends, show_title=not self.no_titles)
             self.viewbox_list.append(vb)
             self.plot_layout.addItem(plt, row_offset + i // rowlen, i % rowlen)
 
@@ -497,7 +508,8 @@ def main(args):
 
         plotter = McCoplotPlotter(pairs, labels, colours,
                                    invcanvas=args.invcanvas, title=title, identity_note=identity_note,
-                                   filenamebase="coplot_" + "_vs_".join(diffloader.dirsafe_name(p) for p in paths))
+                                   filenamebase="coplot_" + "_vs_".join(diffloader.dirsafe_name(p) for p in paths),
+                                   no_legends=args.no_legends, no_titles=args.no_titles)
         print(get_help_string())
         plotter.run()
 
@@ -521,6 +533,14 @@ if __name__ == '__main__':
                               'default: %s' % ', '.join(diffloader.DEFAULT_PALETTE))
     parser.add_argument('-t', '--test', action='store_true', default=False, help='print the matched monitor groups before plotting')
     parser.add_argument('--invcanvas', action='store_true', help='invert canvas background from black to white')
+    parser.add_argument('--no-legends', action='store_true', default=False,
+                         help='do not draw the per-panel legend (the compact A/B/C/... letters) - '
+                              'useful with many co-plotted datasets, where the legend box itself can '
+                              'grow tall enough to cover a large part of the panel')
+    parser.add_argument('--no-titles', action='store_true', default=False,
+                         help='do not draw panel titles or the on-canvas dataset identity header - '
+                              'useful with many co-plotted datasets, where the verbose single-panel '
+                              'title (one line per dataset) can end up taller than the plot itself')
     args = parser.parse_args()
 
     mccode_config.load_config("user")

--- a/tools/Python/mcplot/pyqtgraph/mccoplot.py
+++ b/tools/Python/mcplot/pyqtgraph/mccoplot.py
@@ -112,6 +112,27 @@ def _legend_letters(n):
     return ['S%d' % i for i in range(n)]
 
 
+def _build_verbose_title_lines(datas, labels):
+    ''' The per-line breakdown of a single-monitor co-plot's identity/
+        statistics: component/filename, the monitor's own title, then one
+        "letter=label: I=... Err=... N=...; statistics" line per
+        co-plotted dataset - the same level of detail the matplotlib
+        co-plot variant's own _build_verbose_title_lines() shows, used
+        here for the title side-window (see McCoplotPlotter._render() and
+        plotfuncs.show_text_window()) when --no-titles is set for a
+        single-monitor view. '''
+    d0 = datas[0]
+    try:
+        letters = _legend_letters(len(datas))
+        lines = ['%s [%s]' % (d0.component, d0.filename), d0.title]
+        for data, letter, label in zip(datas, letters, labels):
+            lines.append('%s=%s: I=%s Err=%s N=%s; %s' % (
+                letter, label, data.values[0], data.values[1], data.values[2], data.statistics))
+        return lines
+    except Exception:
+        return ['%s [%s]' % (d0.component, d0.filename)]
+
+
 def _legend_fontsize(n_datasets, base_fontsize):
     """ Legend text size, shrinking as the number of co-plotted datasets
         (not the number of panels/monitors in the grid - a separate
@@ -232,6 +253,15 @@ class McCoplotPlotter():
         self.no_titles = no_titles
         self.current = None  # None = overview grid; else index into self.pairs
         self.viewbox_list = []
+        # Separate side windows (see _render()) shown only for the
+        # single-monitor drill-down (n==1) view, when --no-titles/
+        # --no-legends have freed up the main plot but the information
+        # itself shouldn't just disappear. Unlike the matplotlib variant,
+        # Qt windows are independent objects with no "current window"
+        # concept to worry about disturbing - closing/replacing these by
+        # direct reference is all that's needed.
+        self.title_window = None
+        self.legend_window = None
         self.title = title if title is not None else ('coplot: %s' % ' vs '.join(labels))
         # deliberately NOT derived from labels here: those may legitimately
         # collapse to bare letters when their basenames collide (see
@@ -302,7 +332,23 @@ class McCoplotPlotter():
         self.current = idx
         self._replot()
 
+    def _close_side_windows(self):
+        ''' Closes any previously-open title/legend side windows by direct
+            reference - called at the start of every _render(), so a stale
+            side window from a previous single-monitor view never lingers
+            after navigating to a different monitor or back to the
+            overview grid. '''
+        for attr in ('title_window', 'legend_window'):
+            window = getattr(self, attr)
+            if window is not None:
+                try:
+                    window.close()
+                except Exception:
+                    pass
+                setattr(self, attr, None)
+
     def _render(self):
+        self._close_side_windows()
         # Rebuilt from scratch each time, rather than clear()-ing and
         # reusing the same GraphicsLayout: pg.GraphicsLayout.clear() proved
         # unreliable specifically when the grid shape changes between
@@ -373,6 +419,21 @@ class McCoplotPlotter():
                                  legend=not self.no_legends, show_title=not self.no_titles)
             self.viewbox_list.append(vb)
             self.plot_layout.addItem(plt, row_offset + i // rowlen, i % rowlen)
+
+        # Single-monitor view only ("not an overview-plot"): when
+        # --no-titles/--no-legends have freed up the main plot, open a
+        # separate, full-screen-height, narrow side window for each piece
+        # of information that was removed, rather than losing it outright.
+        if n == 1:
+            datas = visible[0][1]
+            if self.no_titles:
+                lines = [(line, None) for line in _build_verbose_title_lines(datas, self.labels)]
+                self.title_window = plotfuncs.show_text_window(lines, 'mccoplot: title')
+            if self.no_legends:
+                letters = _legend_letters(len(datas))
+                legend_lines = [('%s = %s' % (letter, label), colour)
+                                 for letter, label, colour in zip(letters, self.labels, self.colours)]
+                self.legend_window = plotfuncs.show_text_window(legend_lines, 'mccoplot: legend')
 
     def _get_plot_index(self, pos):
         ''' Index of the viewbox containing scene-position pos, or -1.

--- a/tools/Python/mcplot/pyqtgraph/plotfuncs.py
+++ b/tools/Python/mcplot/pyqtgraph/plotfuncs.py
@@ -5,7 +5,7 @@ import os
 import sys
 import numpy as np
 import pyqtgraph as pg
-from pyqtgraph.Qt import QtGui
+from pyqtgraph.Qt import QtGui, QtWidgets, QtCore
 
 from pyqtgraph.graphicsItems.LegendItem import LegendItem, ItemSample
 
@@ -94,6 +94,74 @@ class ModLegend(pg.LegendItem):
         # the legend text itself readable against busy plots.
         p.setBrush(pg.functions.mkBrush(255,255,255,200))
         p.drawRect(self.boundingRect())
+
+
+def _screen_size_px():
+    ''' (width, height) in pixels of the primary screen, via Qt itself -
+        used to size a side window to the full available screen height
+        (see show_text_window()). Qt is already the active GUI toolkit
+        here (unlike the matplotlib co-plot variant, which needs a
+        throwaway tkinter window purely to query this). '''
+    screen = QtWidgets.QApplication.primaryScreen()
+    if screen is not None:
+        size = screen.size()
+        return size.width(), size.height()
+    # very old Qt5 fallback, matching mccoplot.py's own _create_window()
+    rect = QtWidgets.QApplication.desktop().screenGeometry()
+    return rect.width(), rect.height()
+
+
+def show_text_window(lines, window_title, width_px=380):
+    ''' Opens a separate, tall (full screen height), narrow Qt window with
+        `lines` (a list of (text, colour) tuples, one per row - colour=None
+        for the default) shown top-to-bottom in a single rich-text label,
+        font size scaled down as needed so all lines fit within the
+        window's height. Used for mccoplot-pyqtgraph's "single monitor"
+        title/legend side windows (see McCoplotPlotter._render() in
+        mccoplot.py): with many co-plotted datasets, a long title/legend
+        no longer has to compete with the main plot for space (that's what
+        --no-titles/--no-legends already achieve), but the information
+        isn't simply lost either - it moves to its own appropriately-sized
+        window instead. Returns the new QMainWindow, so the caller can
+        track and explicitly close it later (Qt windows are independent
+        objects with no "current window" concept to worry about disturbing,
+        unlike matplotlib's figure-close bookkeeping - see the matplotlib
+        variant's own show_text_window() for the contrast). '''
+    screen_w_px, screen_h_px = _screen_size_px()
+    width_px = min(width_px, int(screen_w_px * 0.3))
+
+    window = QtWidgets.QMainWindow()
+    window.setWindowTitle(window_title)
+    window.resize(width_px, screen_h_px)
+
+    n_lines = max(1, len(lines))
+    usable_h_px = screen_h_px * 0.94
+    # 1.6x line spacing, clamped to a sane readable range regardless of how
+    # few or many lines there are.
+    fontsize_px = min(20, max(8, int(usable_h_px / (n_lines * 1.6))))
+
+    html_lines = []
+    for text, colour in lines:
+        colour_attr = ' style="color:%s;"' % colour if colour else ''
+        html_lines.append('<div%s>%s</div>' % (colour_attr, text))
+
+    label = QtWidgets.QLabel('\n'.join(html_lines))
+    label.setTextFormat(QtCore.Qt.RichText)
+    label.setWordWrap(True)
+    label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
+    label.setContentsMargins(8, 8, 8, 8)
+    font = label.font()
+    font.setFamily('monospace')
+    font.setPixelSize(fontsize_px)
+    label.setFont(font)
+
+    scroll = QtWidgets.QScrollArea()
+    scroll.setWidget(label)
+    scroll.setWidgetResizable(True)
+    window.setCentralWidget(scroll)
+
+    window.show()
+    return window
 
 
 def plot_Data0D(data, plt, log=False, legend=True, icolormap=0, verbose=True, fontsize=10):


### PR DESCRIPTION
### Free-form text area
_Please describe what your PR is adding in terms of features or bugfixes:_

Co-plots with many datasets lead to legends/titles completely dominating the plot window.

This PR 
* adds `--no-legends` and `--no-title` to suppress these strings from the plot view
* For a single-view coplot 
  * adds the legends/titles on separate windows in the case of pyqtgraph / matplotlib

--------------
### Declaration of use of AI-tools
* [x] Please add a checkmark here if you used AI-tools during the work for this contribution
* Furter, please describe how / where and for what the tools were used:

Re-used the same AI context that assisted in creating the tools

--------------
### Development OS / boundary conditions
_Please describe what OS you developed and tested your additions on, and if any special dependencies are required:_


--------------
# PR Checklist for contributing to McStas/McXtrace
## For a coherent and useful contribution to McStas/McXtrace, please fill in _relevant parts_ of the checklist:
* ### My contribution contains something else
  * [x] Explanation is added in free form text above or below the checklist

--------------



